### PR TITLE
check for argument type in LocalDateTime.ofInstant 

### DIFF
--- a/src/LocalDateTime.js
+++ b/src/LocalDateTime.js
@@ -9,6 +9,7 @@ import {assert, requireNonNull, requireInstance} from './assert';
 import {DateTimeException, UnsupportedTemporalTypeException, IllegalArgumentException} from './errors';
 
 import {Clock} from './Clock';
+import {Instant} from './Instant';
 import {LocalDate} from './LocalDate';
 import {LocalTime} from './LocalTime';
 import {ZonedDateTime} from './ZonedDateTime';
@@ -207,6 +208,7 @@ implements Temporal, TemporalAdjuster, Serializable */ {
      */
     static ofInstant(instant, zone=ZoneId.systemDefault()) {
         requireNonNull(instant, 'instant');
+        requireInstance(instant, Instant, 'instant');
         requireNonNull(zone, 'zone');
         var rules = zone.rules();
         var offset = rules.offset(instant);

--- a/test/reference/LocalDateTimeTest.js
+++ b/test/reference/LocalDateTimeTest.js
@@ -714,13 +714,20 @@ describe('org.threeten.bp.TestLocalDateTime', () => {
             var test = LocalDateTime.ofInstant(Instant.ofEpochSecond(-86400 + 4, 500), OFFSET_PTWO);
             assertEquals(test, LocalDateTime.of(1969, 12, 31, 2, 0, 4, 500));
         });
+
+        // TODO tests are missing in threeten bp
+        it('factory_ofInstant_invalidType', () => {
+            expect(() => {
+                LocalDateTime.ofInstant(0);
+            }).to.throw(IllegalArgumentException);
+        });
     
         it('factory_ofInstant_instantTooBig', () => {
             expect(() => {
                 LocalDateTime.ofInstant(Instant.ofEpochSecond(MathUtil.MAX_SAFE_INTEGER), OFFSET_PONE);
             }).to.throw(DateTimeException);
         });
-    
+
         it('factory_ofInstant_instantTooSmall', () => {
             expect(() => {
                 LocalDateTime.ofInstant(Instant.ofEpochSecond(MathUtil.MIN_SAFE_INTEGER), OFFSET_PONE);


### PR DESCRIPTION
and add Test add Test  with wrong argument type

Now if you try something like `LocalDatetime.ofInstant(0)` an IllegalArgumentExcpetion is thrown with message that the parameter must be an instance of `Instant` 

closes #50