### PR TITLE
parse dayOfMonth and month to int to validate dayOfMonth correctly

### DIFF
--- a/src/LocalDate.js
+++ b/src/LocalDate.js
@@ -303,15 +303,10 @@ export class LocalDate extends ChronoLocalDate{
         ChronoField.MONTH_OF_YEAR.checkValidValue(month);
         ChronoField.DAY_OF_MONTH.checkValidValue(dayOfMonth);
         
-        if(typeof month === 'string'){
-            month = parseInt(month);
-        }
-        
-        if(typeof dayOfMonth === 'string'){
-            dayOfMonth = parseInt(dayOfMonth);
-        }
-        
         if (dayOfMonth > 28) {
+            if(typeof month === 'string'){
+                month = parseInt(month);
+            }
             dom = 31;
             switch (month) {
                 case 2:

--- a/src/LocalDate.js
+++ b/src/LocalDate.js
@@ -302,6 +302,15 @@ export class LocalDate extends ChronoLocalDate{
         ChronoField.YEAR.checkValidValue(year);
         ChronoField.MONTH_OF_YEAR.checkValidValue(month);
         ChronoField.DAY_OF_MONTH.checkValidValue(dayOfMonth);
+        
+        if(typeof month === 'string'){
+            month = parseInt(month);
+        }
+        
+        if(typeof dayOfMonth === 'string'){
+            dayOfMonth = parseInt(dayOfMonth);
+        }
+        
         if (dayOfMonth > 28) {
             dom = 31;
             switch (month) {

--- a/test/LocalDateTest.js
+++ b/test/LocalDateTest.js
@@ -26,6 +26,7 @@ describe('Creating a LocalDate instance', () => {
         expect(() => {new LocalDate(1970, 2, 29);}).to.throw(Error);
         expect(() => {new LocalDate(1970, 2, 30);}).to.throw(Error);
         expect(() => {new LocalDate(1970, 4, 31);}).to.throw(Error);
+        expect(() => {new LocalDate('1970', '4', '31');}).to.throw(Error);
     });
 
 });

--- a/test/LocalDateTest.js
+++ b/test/LocalDateTest.js
@@ -19,6 +19,7 @@ describe('Creating a LocalDate instance', () => {
         expect(new LocalDate(1970, 1, 1)).to.be.an.instanceOf(LocalDate);
         expect(new LocalDate(2016, 2, 29)).to.be.an.instanceOf(LocalDate);
     });
+    
 
     it('should fail with an AssertionError for invalid dates', () => {
         expect(() => {new LocalDate(1970, 1, -1);}).to.throw(Error);
@@ -26,10 +27,26 @@ describe('Creating a LocalDate instance', () => {
         expect(() => {new LocalDate(1970, 2, 29);}).to.throw(Error);
         expect(() => {new LocalDate(1970, 2, 30);}).to.throw(Error);
         expect(() => {new LocalDate(1970, 4, 31);}).to.throw(Error);
-        expect(() => {new LocalDate('1970', '4', '31');}).to.throw(Error);
     });
 
+    describe('from strings', () => {
+        it('should create a LocalDate instance equal to one from numbers for a valid date', () => {
+            expect(new LocalDate('1970', '1', '1')).to.deep.equal(new LocalDate(1970, 1, 1));
+            expect(new LocalDate('2016', '2', '29')).to.deep.equal(new LocalDate(2016, 2, 29));
+        });
+        
+        it('should fail with an AssertionError for unparseable dates', () => {
+            expect(() => {new LocalDate('xxxx', '4', '31');}).to.throw(Error);
+            expect(() => {new LocalDate('1970', 'x', '30');}).to.throw(Error);
+            expect(() => {new LocalDate('1970', '4', 'xx');}).to.throw(Error);
+        });
+        
+        it('should fail with an AssertionError for invalid dates', () => {
+            expect(() => {new LocalDate('1970', '4', '31');}).to.throw(Error);
+        });
+    });
 });
+
 
 describe('Using a LocalDate instance', () => {
 


### PR DESCRIPTION
LocalDate accepts strings as parameters, but circumvents validation because the parameters are simply compared to numbers, which leads to '32' > 31 = false.

I added a test to the non-reference tests, because this is really a type safety issue, which is not an issue in threeten.