### PR TITLE
Fix LocalTime.parse

### DIFF
--- a/dist/js-joda.d.ts
+++ b/dist/js-joda.d.ts
@@ -393,7 +393,7 @@ declare namespace JSJoda {
 
         static ofSecondOfDay(secondOfDay?: number, nanoOfSecond?: number): LocalTime
 
-        static parse(text: String, formatter?: String): LocalTime
+        static parse(text: String, formatter?: DateTimeFormatter): LocalTime
 
         constructor(hour?: number, minute?: number, second?: number, nanoOfSecond?: number)
 

--- a/src/LocalTime.js
+++ b/src/LocalTime.js
@@ -254,7 +254,8 @@ export class LocalTime extends Temporal /** implements Temporal, TemporalAdjuste
      * The text is parsed using the formatter, returning a time.
      *
      * @param {!String} text - the text to parse, not null
-     * @param {!String} formatter - the formatter to use, not null
+     * @param {DateTimeFormatter} [formatter=DateTimeFormatter.ISO_LOCAL_TIME] - the formatter to use, default is
+     * {@link DateTimeFormatter.ISO_LOCAL_TIME}
      * @return {LocalTime} the parsed local time, not null
      * @throws {DateTimeParseException} if the text cannot be parsed
      */


### PR DESCRIPTION
Seconds argument of `LocalTime.parse` is a `DateTimeFormatter`, not a string.