### PR TITLE
Make `LocalTime.now()` return `LocalTime`

### DIFF
--- a/dist/js-joda.d.ts
+++ b/dist/js-joda.d.ts
@@ -357,7 +357,7 @@ declare namespace JSJoda {
 
         static from(temporal: TemporalAccessor): LocalTime
 
-        static now(clockOrZone?: Clock | ZoneId): LocalDateTime
+        static now(clockOrZone?: Clock | ZoneId): LocalTime
 
         static of(hour?: number, minute?: number, second?: number, nanoOfSecond?: number): LocalTime
 

--- a/src/LocalTime.js
+++ b/src/LocalTime.js
@@ -120,7 +120,7 @@ export class LocalTime extends Temporal /** implements Temporal, TemporalAdjuste
      * The alternate clock may be introduced using dependency injection.
      *
      * @param {Clock|ZoneId} clockOrZone - the zone ID or clock to use, if null Clock.systemDefaultZone() is used.
-     * @return {LocalDateTime} the current time using the system clock, not null
+     * @return {LocalTime} the current time using the system clock, not null
      */
     static now(clockOrZone) {
         if (clockOrZone == null){


### PR DESCRIPTION
It was declared as returning `LocalDateTime`. I’m not sure if you want an issue creating to go with this PR or of it can be considered to fall under js-joda#23 ?