### PR TITLE
Changed types of unit multipliers to number

### DIFF
--- a/dist/js-joda.d.ts
+++ b/dist/js-joda.d.ts
@@ -342,18 +342,19 @@ declare namespace JSJoda {
         static MAX: LocalTime
         static MIDNIGHT: LocalTime
         static NOON: LocalTime
-        static HOURS_PER_DAY: LocalTime
-        static MINUTES_PER_HOUR: LocalTime
-        static MINUTES_PER_DAY: LocalTime
-        static SECONDS_PER_MINUTE: LocalTime
-        static SECONDS_PER_HOUR: LocalTime
-        static SECONDS_PER_DAY: LocalTime
-        static MILLIS_PER_DAY: LocalTime
-        static MICROS_PER_DAY: LocalTime
-        static NANOS_PER_SECOND: LocalTime
-        static NANOS_PER_MINUTE: LocalTime
-        static NANOS_PER_HOUR: LocalTime
-        static NANOS_PER_DAY: LocalTime
+        
+        static HOURS_PER_DAY: number
+        static MINUTES_PER_HOUR: number
+        static MINUTES_PER_DAY: number
+        static SECONDS_PER_MINUTE: number
+        static SECONDS_PER_HOUR: number
+        static SECONDS_PER_DAY: number
+        static MILLIS_PER_DAY: number
+        static MICROS_PER_DAY: number
+        static NANOS_PER_SECOND: number
+        static NANOS_PER_MINUTE: number
+        static NANOS_PER_HOUR: number
+        static NANOS_PER_DAY: number
 
         static from(temporal: TemporalAccessor): LocalTime
 


### PR DESCRIPTION
The constant `HOURS_PER_DAY`, `MINUTES_PER_DAY`, `SECONDS_PER_MINUTE`, `SECONDS_PER_DAY`, `MILLIS_PER_DAY`, `NANOS_PER_SECOND`, `NANOS_PER_MINUTE`, `NANOS_PER_HOUR`, `NANOS_PER_DAY` had wrong typings (i.e. `LocalTime` instead of `number`)