### PR TITLE
typescript definition: Fix addTo/subtractFrom

### DIFF
--- a/dist/js-joda.d.ts
+++ b/dist/js-joda.d.ts
@@ -65,13 +65,13 @@ declare namespace JSJoda {
         value(): number
     }
     class TemporalAmount {
-        addTo(temporal: Temporal): Temporal
+        addTo<T extends Temporal>(temporal: T): T
 
         get(unit: TemporalUnit): number
 
         units(): TemporalUnit[]
 
-        subtractFrom(temporal: Temporal): Temporal
+        subtractFrom<T extends Temporal>(temporal: T): T
     }
     class Duration extends TemporalAmount {
         static ZERO: Duration
@@ -98,7 +98,7 @@ declare namespace JSJoda {
 
         abs(): Duration
 
-        addTo(temporal: Temporal): Temporal
+        addTo<T extends Temporal>(temporal: T): T
 
         compareTo(otherDuration: Duration): number
 
@@ -158,7 +158,7 @@ declare namespace JSJoda {
 
         seconds(): number
 
-        subtractFrom(temporal: Temporal): Temporal
+        subtractFrom<T extends Temporal>(temporal: T): T
 
         toDays(): number
 
@@ -646,7 +646,7 @@ declare namespace JSJoda {
         toString(): string
     }
     class TemporalUnit {
-        addTo(temporal: Temporal, amount: number): Temporal
+        addTo<T extends Temporal>(temporal: T, amount: number): T
 
         between(temporal1: Temporal, temporal2: Temporal): number
 
@@ -677,7 +677,7 @@ declare namespace JSJoda {
         static ERAS: ChronoUnit
         static FOREVER: ChronoUnit
 
-        addTo(temporal: Temporal, amount: number): Temporal
+        addTo<T extends Temporal>(temporal: T, amount: number): T
 
         between(temporal1: Temporal, temporal2: Temporal): number
 
@@ -1002,7 +1002,7 @@ declare namespace JSJoda {
 
         static parse(text: string): Period
 
-        addTo(temporal: Temporal): Temporal
+        addTo<T extends Temporal>(temporal: T): T
 
         chronology(): IsoChronology
 
@@ -1042,7 +1042,7 @@ declare namespace JSJoda {
 
         plusYears(yearsToAdd: number): Period
 
-        subtractFrom(temporal: Temporal): Temporal
+        subtractFrom<T extends Temporal>(temporal: T): T
 
         toJSON(): string
 


### PR DESCRIPTION
This changes the `addTo` and `subtractTo` functions, so that whatever type of Temporal object you pass in, you get the same type returned.

This is needed so that when you write something like:

```typescript
var in_a_minute = Duration.ofSeconds(60).addTo(Instant.now());
```

then the variable `in_a_minute` is of type "Instant", with all of the Instant goodness available, rather than the current behavior where `in_a_minute` ends up as the (useless) type "Temporal".

I believe that there are other usages of Temporal where the types can be tightened up, but this pull request is at least a start. (another candidate for improvement are the `between` functions.. for example, is the following sensible? or must both arguments be of the same type of Temporal?)

```typescript
Duration.between(Instant.now(), LocalTime.now())
```
