### PR TITLE
Add missing TypeScript definitions for YearMonth class

### DIFF
--- a/dist/js-joda.d.ts
+++ b/dist/js-joda.d.ts
@@ -1163,18 +1163,73 @@ declare namespace JSJoda {
         static from(temporal: TemporalAccessor): YearMonth
 
         static now(zoneIdOrClock?: ZoneId|Clock): YearMonth
+        static now0(): YearMonth
+        static nowZoneId(zone: ZoneId): YearMonth
+        static nowClock(clock: Clock): YearMonth
 
         static of(year: number, monthOrNumber: Month|number): YearMonth
+        static ofNumberMonth(year: number, month: Month): YearMonth
+        static ofNumberNumber(year: number, month: number): YearMonth
 
         static parse(text: string, formatter?: DateTimeFormatter): YearMonth
+        static parseString(text: string): YearMonth
+        static parseStringFormatter(text: string, formatter: DateTimeFormatter): YearMonth
 
-        minus(amountOrNumber: TemporalAmount|number, unit?: TemporalUnit): YearMonth
+        constructor(year: number, month: number)
 
-        plus(amountOrNumber: TemporalAmount|number, unit?: TemporalUnit): YearMonth
+        minus(amount: TemporalAmount): YearMonth
+        minus(amountToSubtract: number, unit: TemporalUnit): YearMonth
+        minusAmount(amount: TemporalAmount): YearMonth
+        minusAmountUnit(amountToSubtract: number, unit: TemporalUnit): YearMonth
+        minusYears(yearsToSubtract: number): YearMonth
+        minusMonths(monthsToSubtract: number): YearMonth
 
-        with(adjusterOrField: TemporalAdjuster|TemporalField, value?: number): YearMonth
+        plus(amount: TemporalAmount): YearMonth
+        plus(amountToAdd: number, unit: TemporalUnit): YearMonth
+        plusAmount(amount: TemporalAmount): YearMonth
+        plusAmountUnit(amountToAdd: number, unit: TemporalUnit): YearMonth
+        plusYears(yearsToAdd: number): YearMonth
+        plusMonths(monthsToAdd: number): YearMonth
+
+        with(adjuster: TemporalAdjuster): YearMonth
+        with(field: TemporalField, value: number): YearMonth
+        withYearMonth(newYear: number, newMonth: number): YearMonth
+        withAdjuster(adjuster: TemporalAdjuster): YearMonth
+        withFieldValue(field: TemporalField, newValue: number): YearMonth
+        withYear(year: number): YearMonth
+        withMonth(month: number): YearMonth
 
         isSupported(fieldOrUnit: TemporalField|ChronoUnit): boolean
+
+        year(): number
+
+        monthValue(): number
+
+        month(): Month
+
+        isLeapYear(): boolean
+
+        isValidDay(): boolean
+
+        lengthOfMonth(): number
+
+        lengthOfYear(): number
+
+        atDay(dayOfMonth: number): LocalDate
+
+        atEndOfMonth(): LocalDate
+
+        compareTo(other: YearMonth): number
+
+        isAfter(other: YearMonth): boolean
+
+        isBefore(other: YearMonth): boolean
+
+        equals(other: YearMonth): boolean
+
+        toJSON(): string
+
+        format(formatter: DateTimeFormatter): string
     }
     class ZoneId {
         static SYSTEM: ZoneId

--- a/dist/js-joda.d.ts
+++ b/dist/js-joda.d.ts
@@ -1163,39 +1163,24 @@ declare namespace JSJoda {
         static from(temporal: TemporalAccessor): YearMonth
 
         static now(zoneIdOrClock?: ZoneId|Clock): YearMonth
-        static now0(): YearMonth
-        static nowZoneId(zone: ZoneId): YearMonth
-        static nowClock(clock: Clock): YearMonth
 
         static of(year: number, monthOrNumber: Month|number): YearMonth
-        static ofNumberMonth(year: number, month: Month): YearMonth
-        static ofNumberNumber(year: number, month: number): YearMonth
 
         static parse(text: string, formatter?: DateTimeFormatter): YearMonth
-        static parseString(text: string): YearMonth
-        static parseStringFormatter(text: string, formatter: DateTimeFormatter): YearMonth
-
-        constructor(year: number, month: number)
 
         minus(amount: TemporalAmount): YearMonth
         minus(amountToSubtract: number, unit: TemporalUnit): YearMonth
-        minusAmount(amount: TemporalAmount): YearMonth
-        minusAmountUnit(amountToSubtract: number, unit: TemporalUnit): YearMonth
         minusYears(yearsToSubtract: number): YearMonth
         minusMonths(monthsToSubtract: number): YearMonth
 
         plus(amount: TemporalAmount): YearMonth
         plus(amountToAdd: number, unit: TemporalUnit): YearMonth
-        plusAmount(amount: TemporalAmount): YearMonth
-        plusAmountUnit(amountToAdd: number, unit: TemporalUnit): YearMonth
         plusYears(yearsToAdd: number): YearMonth
         plusMonths(monthsToAdd: number): YearMonth
 
         with(adjuster: TemporalAdjuster): YearMonth
         with(field: TemporalField, value: number): YearMonth
         withYearMonth(newYear: number, newMonth: number): YearMonth
-        withAdjuster(adjuster: TemporalAdjuster): YearMonth
-        withFieldValue(field: TemporalField, newValue: number): YearMonth
         withYear(year: number): YearMonth
         withMonth(month: number): YearMonth
 

--- a/test/typescript_defintions/js-joda-tests.ts
+++ b/test/typescript_defintions/js-joda-tests.ts
@@ -1,6 +1,8 @@
 import {
     ChronoField,
     ChronoUnit,
+    Clock,
+    DateTimeFormatter,
     DayOfWeek,
     Duration,
     Instant,
@@ -12,6 +14,7 @@ import {
     nativeJs,
     Period,
     TemporalAdjusters,
+    YearMonth,
     ZoneOffset,
     ZonedDateTime,
     ZoneId
@@ -442,4 +445,84 @@ function test_Duration() {
     var dt1 = LocalDateTime.parse('2012-12-24T12:00');
 
     Duration.between(dt1, dt1.plusHours(10)).toString();
+}
+
+function test_YearMonth() {
+    YearMonth.from(YearMonth.now());
+    YearMonth.from(LocalDate.now());
+    
+    YearMonth.now();
+    YearMonth.now(ZoneId.systemDefault());
+    YearMonth.now(Clock.systemUTC());
+    YearMonth.now0();
+    YearMonth.nowZoneId(ZoneId.systemDefault());
+    YearMonth.nowClock(Clock.systemUTC());
+    
+    YearMonth.of(2017, 10);
+    YearMonth.of(2017, Month.of(10));
+    YearMonth.ofNumberMonth(2017, Month.of(10));
+    YearMonth.ofNumberNumber(2017, 10);
+
+    YearMonth.parse("2017-10");
+    YearMonth.parse("2017-10", DateTimeFormatter.ofPattern("yyyy-MM"));
+    YearMonth.parseString("2017-10");
+    YearMonth.parseStringFormatter("2017-10", DateTimeFormatter.ofPattern("yyyy-MM"));
+
+    var duration = Duration.of(10, ChronoUnit.MONTHS);
+    var ym = new YearMonth(2017, 10);
+
+    ym.minus(duration);
+    ym.minus(10, ChronoUnit.DAYS);
+    ym.minusAmount(duration);
+    ym.minusAmountUnit(10, ChronoUnit.MONTHS);
+    ym.minusYears(10);
+    ym.minusMonths(10);
+
+    ym.plus(duration);
+    ym.plus(10, ChronoUnit.DAYS);
+    ym.plusAmount(duration);
+    ym.plusAmountUnit(10, ChronoUnit.MONTHS);
+    ym.plusYears(10);
+    ym.plusMonths(10);
+
+    ym.with(TemporalAdjusters.firstDayOfMonth());
+    ym.with(ChronoField.YEAR, 2018);
+    ym.withYearMonth(2018, 11);
+    ym.withAdjuster(TemporalAdjusters.firstDayOfMonth());
+    ym.withFieldValue(ChronoField.YEAR, 2018);
+    ym.withYear(2018);
+    ym.withMonth(11);
+
+    ym.isSupported(ChronoField.YEAR);
+    ym.isSupported(ChronoUnit.YEARS);
+
+    ym.year();
+
+    ym.monthValue();
+
+    ym.month()
+
+    ym.isLeapYear();
+
+    ym.isValidDay();
+
+    ym.lengthOfMonth();
+
+    ym.lengthOfYear();
+
+    ym.atDay(10);
+
+    ym.atEndOfMonth();
+
+    ym.compareTo(YearMonth.of(2017, 20));
+
+    ym.isAfter(YearMonth.of(2017, 20));
+
+    ym.isBefore(YearMonth.of(2017, 20));
+
+    ym.equals(YearMonth.of(2017, 20));
+
+    ym.toJSON();
+
+    ym.format(DateTimeFormatter.ofPattern("yyyy-MM"));
 }

--- a/test/typescript_defintions/js-joda-tests.ts
+++ b/test/typescript_defintions/js-joda-tests.ts
@@ -454,42 +454,29 @@ function test_YearMonth() {
     YearMonth.now();
     YearMonth.now(ZoneId.systemDefault());
     YearMonth.now(Clock.systemUTC());
-    YearMonth.now0();
-    YearMonth.nowZoneId(ZoneId.systemDefault());
-    YearMonth.nowClock(Clock.systemUTC());
     
     YearMonth.of(2017, 10);
     YearMonth.of(2017, Month.of(10));
-    YearMonth.ofNumberMonth(2017, Month.of(10));
-    YearMonth.ofNumberNumber(2017, 10);
 
     YearMonth.parse("2017-10");
     YearMonth.parse("2017-10", DateTimeFormatter.ofPattern("yyyy-MM"));
-    YearMonth.parseString("2017-10");
-    YearMonth.parseStringFormatter("2017-10", DateTimeFormatter.ofPattern("yyyy-MM"));
 
     var duration = Duration.of(10, ChronoUnit.MONTHS);
-    var ym = new YearMonth(2017, 10);
+    var ym = YearMonth.of(2017, 10);
 
     ym.minus(duration);
     ym.minus(10, ChronoUnit.DAYS);
-    ym.minusAmount(duration);
-    ym.minusAmountUnit(10, ChronoUnit.MONTHS);
     ym.minusYears(10);
     ym.minusMonths(10);
 
     ym.plus(duration);
     ym.plus(10, ChronoUnit.DAYS);
-    ym.plusAmount(duration);
-    ym.plusAmountUnit(10, ChronoUnit.MONTHS);
     ym.plusYears(10);
     ym.plusMonths(10);
 
     ym.with(TemporalAdjusters.firstDayOfMonth());
     ym.with(ChronoField.YEAR, 2018);
     ym.withYearMonth(2018, 11);
-    ym.withAdjuster(TemporalAdjusters.firstDayOfMonth());
-    ym.withFieldValue(ChronoField.YEAR, 2018);
     ym.withYear(2018);
     ym.withMonth(11);
 


### PR DESCRIPTION
This pull request:

* adds missing method definitions for `YearMonth` class
* splits `plus` and `minus` definitions into separate overloads
* adds tests for `YearMonth` in `js-joda-tests.ts`

Best regards,
Łukasz