### PR TITLE
Adding missing DateTimeFormatter constants to types

### DIFF
--- a/dist/js-joda.d.ts
+++ b/dist/js-joda.d.ts
@@ -264,6 +264,9 @@ declare namespace JSJoda {
         static ISO_LOCAL_DATE: DateTimeFormatter
         static ISO_LOCAL_TIME: DateTimeFormatter
         static ISO_LOCAL_DATE_TIME: DateTimeFormatter
+        static ISO_INSTANT: DateTimeFormatter
+        static ISO_OFFSET_DATE_TIME: DateTimeFormatter
+        static ISO_ZONED_DATE_TIME: DateTimeFormatter
 
         static ofPattern(pattern: string): DateTimeFormatter
 

--- a/test/typescript_defintions/js-joda-tests.ts
+++ b/test/typescript_defintions/js-joda-tests.ts
@@ -513,3 +513,12 @@ function test_YearMonth() {
 
     ym.format(DateTimeFormatter.ofPattern("yyyy-MM"));
 }
+
+function test_DateTimeFormatter() {
+    ZonedDateTime.parse("2017-01-01T00:00:00+0200[Europe/Amsterdam]", DateTimeFormatter.ISO_ZONED_DATE_TIME)
+
+    ZonedDateTime.parse("2017-01-01T00:00:00+0200", DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+
+    ZonedDateTime.parse("2017-01-01T00:00:00.12345678", DateTimeFormatter.ISO_INSTANT)
+}
+


### PR DESCRIPTION
I noticed these were missing, and we need them :)