### PR TITLE
js-joda.d.ts: Remove LocalDateTime.ofYearDay

### DIFF
--- a/dist/js-joda.d.ts
+++ b/dist/js-joda.d.ts
@@ -854,8 +854,6 @@ declare namespace JSJoda {
 
         static ofInstant(instant: Instant, zoneId?: ZoneId): LocalDateTime
 
-        static ofYearDay(year: number, dayOfYear: number): LocalDateTime
-
         static parse(text: string, formatter?: DateTimeFormatter): LocalDateTime
 
         adjustInto(temporal: TemporalAdjuster): LocalDateTime


### PR DESCRIPTION
LocalDateTime does not have a static method `ofYearDay`:

https://js-joda.github.io/js-joda/esdoc/class/src/LocalDateTime.js~LocalDateTime.html

```
$ node
> var joda = require("js-joda");
undefined
> joda.LocalDateTime.ofYearDay
undefined
```