### PR TITLE
⚠️ WIP: Rollup config

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,11 +1,14 @@
 {
   "presets": [
-    [
-      "es2015",
-      {
-        "loose": true
-      }
-    ]
+      ["env", {
+          "modules": false,
+          "loose": true,
+          "targets": {
+              "browsers": [
+                  "last 2 versions"
+              ]
+          }
+      }]
   ],
   "comments": false,
   "env": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
     "babel-plugin-istanbul": "^4.1.5",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-env": "^1.6.1",
     "chai": "^4.1.2",
     "coveralls": "^3.0.0",
     "esdoc": "^1.0.4",
@@ -70,6 +70,7 @@
     "nyc": "^11.4.1",
     "phantomjs-prebuilt": "^2.1.16",
     "rollup": "^0.56.2",
+    "rollup-plugin-babel": "^3.0.3",
     "typescript": "^2.6.2",
     "webpack": "^3.11.0"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,10 @@
+import babel from 'rollup-plugin-babel';
+
 export default {
     input: './src/js-joda.js',
+    plugins: [
+        babel()
+    ],
     output: {
         file: 'dist/js-joda.esm.js',
         format: 'es'


### PR DESCRIPTION
This is a WIP PR for the rollup / esm build

---


1. Replaced `babel-preset-2015` with `babel-preset-env`
2. Add `rollup-plugin-babel` to rollup config to transpile the source first.

---

## Reasoning

Generally `babel-preset-env` is the way to go, as it respects current browser functions & API and you have better control over the browser support. I added right now `last 2 version` however this can be set more strictly, if you want to support older browsers.

`rollup-plugin-babel` [1](https://github.com/rollup/rollup-plugin-babel#modules) requires that babel does not transform the sources as a module.  Thats why `modules: false` is set. As it defaults to `commonjs` (for node modules) 

I kept the `loose: true` option as you had it in before.

However this still needs testing. And I am not sure, if treeshaking will work, as I am getting a lot of `Circular dependency` warnings.

---

[1] - https://github.com/rollup/rollup-plugin-babel#modules
