### PR TITLE
updates for js-joda-locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+### next
+
+#### bugfixes
+
+ * fix error when parsing dates from string with e.g. WeekOfWeekbasedYear fields
+ * fix call to `substring` in generating error message when parsing  
+
 ### 1.8.2 
 
 #### public API

--- a/src/errors.js
+++ b/src/errors.js
@@ -12,7 +12,9 @@ function createErrorType(name, init, superErrorClass = Error) {
         }
         this.message = message;
         init && init.apply(this, arguments);
-
+        this.toString = function () {
+            return `${this.name}: ${this.message}`;
+        };
     }
     E.prototype = new superErrorClass();
     E.prototype.name = name;

--- a/src/format/DateTimeBuilder.js
+++ b/src/format/DateTimeBuilder.js
@@ -190,7 +190,7 @@ export class DateTimeBuilder extends Temporal {
             this._addObject(date);
             for (const fieldName in this.fieldValues.keySet()) {
                 const field = ChronoField.byName(fieldName);
-                if (field !== null) {
+                if (field) {
                     if (this.fieldValues.get(field) !== undefined) { // undefined if "removed" in EnumMap
                         if (field.isDateBased()) {
                             let val1;

--- a/src/format/DateTimeFormatter.js
+++ b/src/format/DateTimeFormatter.js
@@ -502,7 +502,7 @@ export class DateTimeFormatter {
     _createError(text, ex) {
         let abbr = '';
         if (text.length > 64) {
-            abbr = text.subString(0, 64) + '...';
+            abbr = text.substring(0, 64) + '...';
         } else {
             abbr = text;
         }


### PR DESCRIPTION
fix two bugs in handling parsing of locale specific fields

add a `toString` to errors