### PR TITLE
Add `ZoneId#id()` to type definitions

### DIFF
--- a/dist/js-joda.d.ts
+++ b/dist/js-joda.d.ts
@@ -1234,6 +1234,8 @@ declare namespace JSJoda {
 
         hashCode(): number
 
+        id(): string
+
         normalized(): ZoneId
 
         rules(): ZoneRules

--- a/dist/js-joda.flow.js
+++ b/dist/js-joda.flow.js
@@ -777,6 +777,7 @@ declare module "js-joda" {
         getAvailableZoneIds(): string[];
         equals(other: any): boolean;
         hashCode(): number;
+        id(): string;
         normalized(): ZoneId;
         rules(): ZoneRules;
         toString(): string

--- a/test/typescript_defintions/js-joda-tests.ts
+++ b/test/typescript_defintions/js-joda-tests.ts
@@ -526,3 +526,9 @@ function test_DateTimeFormatter() {
 function test_DateTimeParseException() {
     new DateTimeParseException()
 }
+
+function test_ZoneId() {
+    var zoneId = ZoneId.SYSTEM;
+
+    zoneId.id();
+}


### PR DESCRIPTION
Hi, I noticed #264 and thought it would be a small change to fix it. I corrected both the TypeScript and Flow definitions assuming that the docs about the return type at https://github.com/js-joda/js-joda/blob/2ea179c3588f848b16254db41c19849cc8992e94/src/ZoneId.js#L133 are correct. Hope this is alright.