### PR TITLE
Fix DateTimeFormatter.withLocale() definition (typescript/flow)

### DIFF
--- a/dist/js-joda.d.ts
+++ b/dist/js-joda.d.ts
@@ -294,7 +294,7 @@ declare namespace JSJoda {
 
         withChronology(chrono: any): any
 
-        withLocale(): DateTimeFormatter
+        withLocale(locale: Locale): DateTimeFormatter
 
         withResolverStyle(resolverStyle: ResolverStyle): DateTimeFormatter
     }

--- a/dist/js-joda.flow.js
+++ b/dist/js-joda.flow.js
@@ -183,7 +183,7 @@ declare module "js-joda" {
         parseUnresolved(text: any, position: any): any;
         toString(): string;
         withChronology(chrono: any): any;
-        withLocale(): DateTimeFormatter;
+        withLocale(locale: Locale): DateTimeFormatter;
         withResolverStyle(resolverStyle: ResolverStyle): DateTimeFormatter
     }
 


### PR DESCRIPTION
`locale` parameter was missing from `DateTimeFormatter.withLocale()` method. 


![image](https://user-images.githubusercontent.com/2136620/47709230-1c87c180-dc30-11e8-9873-de9b0e396b2b.png)
