### PR TITLE
Add TypeScript definitions for Instant.toJSON()

### DIFF
--- a/dist/js-joda.d.ts
+++ b/dist/js-joda.d.ts
@@ -243,6 +243,8 @@ declare namespace JSJoda {
 
         toEpochMilli(): number
 
+        toJSON(): string;
+
         toString(): string
 
         truncatedTo(unit: TemporalUnit): Instant

--- a/test/typescript_definitions/js-joda-tests.ts
+++ b/test/typescript_definitions/js-joda-tests.ts
@@ -142,6 +142,13 @@ function test_LocalDate() {
     d.with(TemporalAdjusters.firstInMonth(DayOfWeek.SATURDAY));
 }
 
+function test_Instant() {
+    let i = Instant.parse('2019-03-24T23:32:46.488Z');
+
+    i.toString();
+    i.toJSON();
+}
+
 function test_LocalTime() {
     LocalTime.now();
     LocalTime.now(ZoneOffset.UTC);


### PR DESCRIPTION
Types definitions for method `toJSON()` were missing in `Instant` class.