### PR TITLE
Adding private constructors and abstract modifiers to TypeScript definitions

### DIFF
--- a/dist/js-joda.d.ts
+++ b/dist/js-joda.d.ts
@@ -1364,20 +1364,84 @@ declare namespace JSJoda {
         rules(): ZoneRules
     }
 
+    class ZoneOffsetTransition {
+        static of(transition: LocalDateTime, offsetBefore: ZoneOffset, offsetAfter: ZoneOffset): ZoneOffsetTransition
+
+        private constructor()
+
+        instant(): Instant
+
+        toEpochSecond(): number
+
+        dateTimeBefore(): LocalDateTime
+
+        dateTimeAfter(): LocalDateTime
+
+        offsetBefore(): ZoneOffset
+
+        offsetAfter(): ZoneOffset
+
+        duration(): Duration
+
+        durationSeconds(): number
+
+        isGap(): boolean
+
+        isOverlap(): boolean
+
+        isValidOffset(offset: ZoneOffset): boolean
+
+        validOffsets(): ZoneOffset[]
+
+        compareTo(transition: ZoneOffsetTransition): number
+
+        equals(other: any): boolean
+
+        hashCode(): number
+
+        toString(): string
+    }
+
+    interface ZoneOffsetTransitionRule {
+        // TODO: Not implemented yet
+    }
+
     abstract class ZoneRules {
         static of(offest: ZoneOffset): ZoneRules
 
-        isFixedOffset(): boolean
-
-        isValidOffset(localDateTime: LocalDateTime, offset: ZoneOffset): boolean
+        abstract isFixedOffset(): boolean
 
         offset(instantOrLocalDateTime: Instant|LocalDateTime): ZoneOffset
 
-        offsetOfEpochMilli(epochMilli: number): ZoneOffset
+        toJSON(): string
 
-        offsetOfInstant(instant: Instant): ZoneOffset
+        abstract offsetOfEpochMilli(epochMilli: number): ZoneOffset
 
-        offsetOfLocalDateTime(localDateTime: LocalDateTime): ZoneOffset
+        abstract offsetOfInstant(instant: Instant): ZoneOffset
+
+        abstract offsetOfLocalDateTime(localDateTime: LocalDateTime): ZoneOffset
+
+        abstract validOffsets(localDateTime: LocalDateTime): ZoneOffset[]
+
+        abstract transition(localDateTime: LocalDateTime): ZoneOffsetTransition
+
+        abstract standardOffset(instant: Instant): ZoneOffset
+
+        abstract daylightSavings(instant: Instant): Duration
+
+        abstract isDaylightSavings(instant: Instant): boolean
+
+        abstract isValidOffset(localDateTime: LocalDateTime, offset: ZoneOffset): boolean
+
+        abstract nextTransition(instant: Instant): ZoneOffsetTransition
+
+        abstract previousTransition(instant: Instant): ZoneOffsetTransition
+
+        abstract transitions(): ZoneOffsetTransition[]
+
+        abstract transitionRules(): ZoneOffsetTransitionRule[]
+
+        abstract toString(): string
     }
 
     abstract class ChronoZonedDateTime extends Temporal {

--- a/dist/js-joda.d.ts
+++ b/dist/js-joda.d.ts
@@ -7,6 +7,7 @@ declare namespace JSJoda {
 
         range(field: TemporalField): ValueRange
     }
+
     abstract class Temporal extends TemporalAccessor {
     }
 
@@ -25,6 +26,7 @@ declare namespace JSJoda {
 
         abstract zone(): any
     }
+
     class DayOfWeek extends Temporal {
         static MONDAY: DayOfWeek
         static TUESDAY: DayOfWeek
@@ -33,6 +35,8 @@ declare namespace JSJoda {
         static FRIDAY: DayOfWeek
         static SATURDAY: DayOfWeek
         static SUNDAY: DayOfWeek
+
+        private constructor()
 
         static from(temporal: TemporalAccessor): DayOfWeek
 
@@ -64,15 +68,17 @@ declare namespace JSJoda {
 
         value(): number
     }
-    class TemporalAmount {
-        addTo<T extends Temporal>(temporal: T): T
 
-        get(unit: TemporalUnit): number
+    abstract class TemporalAmount {
+        abstract addTo<T extends Temporal>(temporal: T): T
 
-        units(): TemporalUnit[]
+        abstract get(unit: TemporalUnit): number
 
-        subtractFrom<T extends Temporal>(temporal: T): T
+        abstract units(): TemporalUnit[]
+
+        abstract subtractFrom<T extends Temporal>(temporal: T): T
     }
+
     class Duration extends TemporalAmount {
         static ZERO: Duration
 
@@ -95,6 +101,8 @@ declare namespace JSJoda {
         static ofSeconds(seconds: number): Duration
 
         static parse(text: string): Duration
+
+        private constructor()
 
         abs(): Duration
 
@@ -180,6 +188,7 @@ declare namespace JSJoda {
 
         withSeconds(seconds: number): Duration
     }
+
     class Instant extends Temporal {
         static EPOCH: Instant
         static MIN: Instant
@@ -196,6 +205,8 @@ declare namespace JSJoda {
         static ofEpochSecond(epochSecond: number, nanoAdjustment?: number): Instant
 
         static parse(text: string): Instant
+
+        private constructor()
 
         adjustInto(temporal: Temporal): Temporal
 
@@ -255,11 +266,15 @@ declare namespace JSJoda {
         withTemporalAdjuster(adjuster: TemporalAdjuster): Instant
 
     }
+
     class ResolverStyle {
         static STRICT: ResolverStyle
         static SMART: ResolverStyle
         static LENIENT: ResolverStyle
+
+        private constructor()
     }
+
     class DateTimeFormatter {
         static ISO_LOCAL_DATE: DateTimeFormatter
         static ISO_LOCAL_TIME: DateTimeFormatter
@@ -273,6 +288,8 @@ declare namespace JSJoda {
         static parsedExcessDays(): TemporalQuery
 
         static parsedLeapSecond(): boolean
+
+        private constructor()
 
         chronology(): any
 
@@ -298,6 +315,7 @@ declare namespace JSJoda {
 
         withResolverStyle(resolverStyle: ResolverStyle): DateTimeFormatter
     }
+
     class DateTimeFormatterBuilder {
         constructor()
 
@@ -337,9 +355,13 @@ declare namespace JSJoda {
 
         toFormatter(resolverStyle: ResolverStyle): DateTimeFormatter
     }
-    class Chronology {
-        // TODO: this
-    }
+
+    // TODO: js-joda doesn't have Chronology yet. Methods like `LocalDate.chronology()`
+    // actually return an `IsoChronology` so Chronology is an alias type of that class
+    // for now. Change this if Chronology is added.
+    type Chronology = IsoChronology
+
+
     class LocalTime extends Temporal {
         static MIN: LocalTime
         static MAX: LocalTime
@@ -372,6 +394,8 @@ declare namespace JSJoda {
         static ofSecondOfDay(secondOfDay?: number, nanoOfSecond?: number): LocalTime
 
         static parse(text: String, formatter?: DateTimeFormatter): LocalTime
+
+        private constructor()
 
         adjustInto(temporal: TemporalAdjuster): Temporal
 
@@ -454,6 +478,7 @@ declare namespace JSJoda {
 
         withTemporalAdjuster(adjuster: TemporalAdjuster): LocalTime
     }
+
     class MathUtil {
         static compareNumbers(a: number, b: number): number
 
@@ -481,6 +506,7 @@ declare namespace JSJoda {
 
         static verifyInt(value: number): void
     }
+
     class Month extends Temporal {
         static JANUARY: Month
         static FEBRUARY: Month
@@ -500,6 +526,8 @@ declare namespace JSJoda {
         static of(month: number): Month
 
         static values(): Month[]
+
+        private constructor()
 
         adjustInto(temporal: Temporal): Temporal
 
@@ -531,6 +559,7 @@ declare namespace JSJoda {
 
         value(): number
     }
+
     class MonthDay extends Temporal {
         static from(temporal: TemporalAccessor): MonthDay
 
@@ -547,6 +576,8 @@ declare namespace JSJoda {
         static parseString(text: string): MonthDay
 
         static parseStringFormatter(text: string, formatter: DateTimeFormatter): MonthDay
+
+        private constructor()
 
         adjustInto(temporal: Temporal): Temporal
 
@@ -588,8 +619,10 @@ declare namespace JSJoda {
 
         withMonth(month: number): MonthDay
     }
-    interface TemporalField {
+
+    abstract class TemporalField {
     }
+
     class ChronoField {
         static NANO_OF_SECOND: ChronoField
         static NANO_OF_DAY: ChronoField
@@ -622,6 +655,8 @@ declare namespace JSJoda {
         static INSTANT_SECONDS: ChronoField
         static OFFSET_SECONDS: ChronoField
 
+        private constructor()
+
         baseUnit(): number
 
         checkValidIntValue(value: number): number
@@ -648,21 +683,23 @@ declare namespace JSJoda {
 
         toString(): string
     }
-    class TemporalUnit {
-        addTo<T extends Temporal>(temporal: T, amount: number): T
 
-        between(temporal1: Temporal, temporal2: Temporal): number
+    abstract class TemporalUnit {
+        abstract addTo<T extends Temporal>(temporal: T, amount: number): T
 
-        duration(): Duration
+        abstract between(temporal1: Temporal, temporal2: Temporal): number
 
-        isDateBased(): boolean
+        abstract duration(): Duration
 
-        isDurationEstimated(): boolean
+        abstract isDateBased(): boolean
 
-        isSupportedBy(temporal: Temporal): boolean
+        abstract isDurationEstimated(): boolean
 
-        isTimeBased(): boolean
+        abstract isSupportedBy(temporal: Temporal): boolean
+
+        abstract isTimeBased(): boolean
     }
+
     class ChronoUnit extends TemporalUnit {
         static MICROS: ChronoUnit
         static MILLIS: ChronoUnit
@@ -679,6 +716,8 @@ declare namespace JSJoda {
         static MILLENNIA: ChronoUnit
         static ERAS: ChronoUnit
         static FOREVER: ChronoUnit
+
+        private constructor()
 
         addTo<T extends Temporal>(temporal: T, amount: number): T
 
@@ -698,6 +737,7 @@ declare namespace JSJoda {
 
         toString(): string
     }
+
     class IsoFields {
         static DAY_OF_QUARTER: IsoFields
         static QUARTER_OF_YEAR: IsoFields
@@ -705,14 +745,18 @@ declare namespace JSJoda {
         static WEEK_BASED_YEAR: IsoFields
         static WEEK_BASED_YEARS: IsoFields
         static QUARTER_YEARS: IsoFields
+
+        private constructor()
     }
-    class ChronoLocalDate extends Temporal {
+
+    abstract class ChronoLocalDate extends Temporal {
         adjustInto(temporal: TemporalAdjuster): this
 
         format(formatter: DateTimeFormatter): string
 
         isSupported(fieldOrUnit: TemporalField|TemporalUnit): boolean
     }
+
     class LocalDate extends ChronoLocalDate {
         static MIN: LocalDate
         static MAX: LocalDate
@@ -731,6 +775,8 @@ declare namespace JSJoda {
         static ofYearDay(year: number, dayOfYear: number): LocalDate
 
         static parse(text: string, formatter?: DateTimeFormatter): LocalDate
+
+        private constructor()
 
         atStartOfDay(): LocalDateTime
         atStartOfDay(zone: ZoneId): ZonedDateTime
@@ -829,6 +875,7 @@ declare namespace JSJoda {
 
         year(): number
     }
+
     abstract class ChronoLocalDateTime extends Temporal {
         adjustInto(temporal: any): any
 
@@ -838,6 +885,7 @@ declare namespace JSJoda {
 
         toInstant(offset: ZoneOffset): Instant
     }
+
     class LocalDateTime extends ChronoLocalDateTime {
         static MIN: LocalDateTime
         static MAX: LocalDateTime
@@ -855,6 +903,8 @@ declare namespace JSJoda {
         static ofInstant(instant: Instant, zoneId?: ZoneId): LocalDateTime
 
         static parse(text: string, formatter?: DateTimeFormatter): LocalDateTime
+
+        private constructor()
 
         adjustInto(temporal: TemporalAdjuster): LocalDateTime
 
@@ -979,9 +1029,7 @@ declare namespace JSJoda {
 
         year(): number
     }
-    class OffsetDateTime {
-        // TODO
-    }
+
     class Period extends TemporalAmount {
         static ZERO: Period
 
@@ -1002,6 +1050,8 @@ declare namespace JSJoda {
         static ofYears(years: number): Period
 
         static parse(text: string): Period
+
+        private constructor()
 
         addTo<T extends Temporal>(temporal: T): T
 
@@ -1061,9 +1111,11 @@ declare namespace JSJoda {
 
         years(): number
     }
-    class TemporalAdjuster {
-        adjustInto(temporal: Temporal): Temporal
+
+    abstract class TemporalAdjuster {
+        abstract adjustInto(temporal: Temporal): Temporal
     }
+
     class TemporalAdjusters {
         static dayOfWeekInMonth(ordinal: number, dayOfWeek: DayOfWeek): TemporalAdjuster
 
@@ -1090,7 +1142,10 @@ declare namespace JSJoda {
         static previous(dayOfWeek: DayOfWeek): TemporalAdjuster
 
         static previousOrSame(dayOfWeek: DayOfWeek): TemporalAdjuster
+
+        private constructor()
     }
+
     class TemporalQueries {
         static chronology(): TemporalQuery
 
@@ -1105,14 +1160,20 @@ declare namespace JSJoda {
         static zone(): TemporalQuery
 
         static zoneId(): TemporalQuery
+
+        private constructor()
     }
-    class TemporalQuery {
-        queryFrom(temporal: TemporalAccessor): any
+
+    abstract class TemporalQuery {
+        abstract queryFrom(temporal: TemporalAccessor): any
     }
+
     class ValueRange {
         static of(min: number, max: number): ValueRange
         static of(min: number, maxSmallest: number, maxLargest: number): ValueRange
         static of(minSmallest: number, minLargest: number, maxSmallest: number, maxLargest: number): ValueRange
+
+        private constructor()
 
         checkValidIntValue(value: number, field: TemporalField): number
 
@@ -1140,6 +1201,7 @@ declare namespace JSJoda {
 
         toString(): string
     }
+
     class Year extends Temporal {
         static MIN_VALUE: number;
         static MAX_VALUE: number;
@@ -1154,6 +1216,8 @@ declare namespace JSJoda {
 
         static parse(text: string, formatter?: DateTimeFormatter): Year
 
+        private constructor()
+
         atMonth(monthOrNumber: Month|number): YearMonth
 
         plus(amountOrNumber: TemporalAmount|number, unit?: TemporalUnit): Year
@@ -1162,6 +1226,7 @@ declare namespace JSJoda {
 
         value(): number
     }
+
     class YearMonth extends Temporal {
         static from(temporal: TemporalAccessor): YearMonth
 
@@ -1170,6 +1235,8 @@ declare namespace JSJoda {
         static of(year: number, monthOrNumber: Month|number): YearMonth
 
         static parse(text: string, formatter?: DateTimeFormatter): YearMonth
+
+        private constructor()
 
         minus(amount: TemporalAmount): YearMonth
         minus(amountToSubtract: number, unit: TemporalUnit): YearMonth
@@ -1219,7 +1286,8 @@ declare namespace JSJoda {
 
         format(formatter: DateTimeFormatter): string
     }
-    class ZoneId {
+
+    abstract class ZoneId {
         static SYSTEM: ZoneId
         static UTC: ZoneId
 
@@ -1234,14 +1302,15 @@ declare namespace JSJoda {
 
         hashCode(): number
 
-        id(): string
+        abstract id(): string
 
         normalized(): ZoneId
 
-        rules(): ZoneRules
+        abstract rules(): ZoneRules
 
         toString(): string
     }
+
     class ZoneOffset extends ZoneId {
         static MAX_SECONDS: ZoneOffset
         static UTC: ZoneOffset
@@ -1259,6 +1328,8 @@ declare namespace JSJoda {
         static ofTotalMinutes(totalMinutes: number): ZoneOffset
 
         static ofTotalSeconds(totalSeconds: number): ZoneOffset
+
+        private constructor()
 
         adjustInto(temporal: Temporal): Temporal
 
@@ -1282,14 +1353,18 @@ declare namespace JSJoda {
 
         totalSeconds(): number
     }
+
     class ZoneRegion extends ZoneId {
         static ofId(zoneId: string): ZoneId
+
+        private constructor()
 
         id(): string
 
         rules(): ZoneRules
     }
-    class ZoneRules {
+
+    abstract class ZoneRules {
         static of(offest: ZoneOffset): ZoneRules
 
         isFixedOffset(): boolean
@@ -1303,8 +1378,8 @@ declare namespace JSJoda {
         offsetOfInstant(instant: Instant): ZoneOffset
 
         offsetOfLocalDateTime(localDateTime: LocalDateTime): ZoneOffset
-
     }
+
     abstract class ChronoZonedDateTime extends Temporal {
         compareTo(other: ChronoZonedDateTime): number
 
@@ -1324,6 +1399,7 @@ declare namespace JSJoda {
 
         toInstant(): Instant
     }
+
     class ZonedDateTime extends ChronoZonedDateTime {
         static from(temporal: TemporalAccessor): ZonedDateTime
 
@@ -1343,6 +1419,8 @@ declare namespace JSJoda {
         static ofStrict(localDateTime: LocalDateTime, offset: ZoneOffset, zone: ZoneId): ZonedDateTime
 
         static parse(text: string, formatter?: DateTimeFormatter): ZonedDateTime
+
+        private constructor()
 
         dayOfMonth(): number
 
@@ -1430,8 +1508,6 @@ declare namespace JSJoda {
 
         toLocalTime(): LocalTime
 
-        toOffsetDateTime(): OffsetDateTime
-
         toString(): string
 
         truncatedTo(unit: TemporalUnit): ZonedDateTime
@@ -1469,18 +1545,32 @@ declare namespace JSJoda {
 
         zone(): ZoneId
     }
+
     class TextStyle {
+        static FULL: TextStyle
+        static FULL_STANDALONE: TextStyle
+        static SHORT: TextStyle
+        static SHORT_STANDALONE: TextStyle
+        static NARROW: TextStyle
+        static NARROW_STANDALONE: TextStyle
+
+        private constructor()
+
         asNormal(): TextStyle
 
         asStandalone(): TextStyle
 
         isStandalone(): boolean
     }
-    class Locale {
-        // TODO
+
+    interface Locale {
+        // TODO: Not implemented yet
     }
+
     abstract class IsoChronology {
         static isLeapYear(prolepticYear: number): boolean
+
+        private constructor()
 
         resolveDate(fieldValues: any, resolverStyle: any): any
 
@@ -1490,10 +1580,12 @@ declare namespace JSJoda {
     }
 
     function nativeJs(date: Date|any, zone?: ZoneId): TemporalAccessor;
+
     function convert(temporal: LocalDate|LocalDateTime|ZonedDateTime, zone?: ZoneId): {
         toDate: () => Date,
         toEpochMilli: () => number
     };
+
     function use(plugin: Function):any;
 
     class DateTimeParseException extends Error {

--- a/test/typescript_definitions/js-joda-tests.ts
+++ b/test/typescript_definitions/js-joda-tests.ts
@@ -16,9 +16,12 @@ import {
     TemporalAdjusters,
     YearMonth,
     ZoneOffset,
+    ZoneOffsetTransition,
+    ZoneRules,
     ZonedDateTime,
     ZoneId,
-    DateTimeParseException
+    DateTimeParseException,
+    ZoneOffsetTransitionRule,
 } from '../../'
 
 // used below
@@ -413,6 +416,50 @@ function test_ZonedDateTime() {
     zdt.plusHours(2 * 7 * 24);
 }
 
+function test_ZoneOffsetTransition() {
+    const zot = ZoneOffsetTransition.of(LocalDateTime.now(), ZoneOffset.UTC, ZoneOffset.ofHours(2));
+
+    expectType<Instant>(zot.instant());
+    expectType<number>(zot.toEpochSecond());;
+    expectType<LocalDateTime>(zot.dateTimeAfter());
+    expectType<LocalDateTime>(zot.dateTimeBefore());
+    expectType<ZoneOffset>(zot.offsetAfter());
+    expectType<ZoneOffset>(zot.offsetBefore());
+    expectType<Duration>(zot.duration());
+    expectType<number>(zot.durationSeconds());
+    expectType<boolean>(zot.isGap());
+    expectType<boolean>(zot.isOverlap());
+    expectType<boolean>(zot.isValidOffset(ZoneOffset.UTC));
+    expectType<ZoneOffset[]>(zot.validOffsets());
+    expectType<boolean>(zot.equals({}));
+    expectType<number>(zot.compareTo(undefined! as ZoneOffsetTransition));
+    expectType<number>(zot.hashCode());
+    expectType<string>(zot.toString());
+}
+
+function test_ZoneRules() {
+    const zr = ZoneRules.of(ZoneOffset.UTC);
+
+    expectType<boolean>(zr.isFixedOffset());
+    expectType<ZoneOffset>(zr.offset(Instant.now()));
+    expectType<ZoneOffset>(zr.offset(LocalDateTime.now()));
+    expectType<string>(zr.toJSON());
+    expectType<ZoneOffset>(zr.offsetOfEpochMilli(0));
+    expectType<ZoneOffset>(zr.offsetOfInstant(Instant.now()));
+    expectType<ZoneOffset>(zr.offsetOfLocalDateTime(LocalDateTime.now()));
+    expectType<ZoneOffset[]>(zr.validOffsets(LocalDateTime.now()));
+    expectType<ZoneOffsetTransition>(zr.transition(LocalDateTime.now()));
+    expectType<ZoneOffset>(zr.standardOffset(Instant.now()));
+    expectType<Duration>(zr.daylightSavings(Instant.now()));
+    expectType<boolean>(zr.isDaylightSavings(Instant.now()));
+    expectType<boolean>(zr.isValidOffset(LocalDateTime.now(), ZoneOffset.UTC));
+    expectType<ZoneOffsetTransition>(zr.nextTransition(Instant.now()));
+    expectType<ZoneOffsetTransition>(zr.previousTransition(Instant.now()));
+    expectType<ZoneOffsetTransition[]>(zr.transitions());
+    expectType<ZoneOffsetTransitionRule[]>(zr.transitionRules());
+    expectType<string>(zr.toString());
+}
+
 function test_Period() {
 
     Period.parse('P1Y10M').toString();
@@ -535,3 +582,9 @@ function test_ZoneId() {
 
     zoneId.id();
 }
+
+/**
+ * Use this to check if an expression is of type T.
+ * Don't let TypeScript infer the type, give it explicitly.
+ */
+declare function expectType<T>(v: T): T;


### PR DESCRIPTION
This PR is an attempt to improve the TypeScript types definitions an bring them closer to implementation. Closes #279.

As discussed in #279, the constructor of many classes are implementation details, but since constructors were previously removed from TS defs for classes they were all _newable_ with a zero-parameter constructor. Following the JSDoc annotations in source code and the docs of the [ThreeTen backport](https://www.threeten.org/threetenbp/apidocs/index.html) I made the following changes:

- All enums have got now a private constructor so they are not instantiable nor extensible.
- Most of the classes marked as `final` in ThreeTenBP (for instance `Instant` or `ValueRange`) now have got a private constructor. And exception was made for `DateTimeFormatterBuilder` since the that constructor seems to be public.
- Some classes are now marked as `abstract`.

**Other changes I made:**

- Enums values added to `TextStyle`.
- Class `OffsetDateTime` and method `ZonedDateTime.toOffsetDateTime()` were both removed since are not implemented in JS.
- Since `Chronology` doesn't exist as a class in JS it is now an alias type for `IsoChronology`.
- `TemporalField` was previously declared as an `interface` but is a `class` in JS, so it is now declared as an abstract class.
- `ZoneRules` were missing a lot of abstract methods that are now declared.
- Added the definition type for `ZoneOffsetTransition`.

**Some questions:**

- Is `MathUtil` meant to be used by users of the library? It has type definitions but it looks as an internal utility class to me.
- `TemporalAccesor`, `ChronoLocalDate` and maybe other classes are interfaces or abstract classes in ThreeTenBP, but here are implemented as full classes with concrete methods. Why? I didn't type those as `abstract` for that reason. 

**A little problem:**

Js-Joda simulates interfaces as classes where every method has an `abstractMethodFail` assertion. It has a drawback: a class "implementing" that interface must use `extends`, but JS has single inheritance so a class cannot really "implement" more than one.

In TypeScript there is an `interface` keyword that creates a new type that can be implemented by classes and a class can implements many of them. However we cannot use `interfaces` in type definitions since they are elided when transpiling to JS (are just compile time artifacts) and classes who implemented those doesn't have an `extend` clause (except that the class extends some base class in addition to implement some interfaces). Then any method that expect and object to be an instance of any of those "interfaces" (at runtime) will break.

I suppose that is not a problem for most users of the library since very few, I guess, are implementing those interfaces.