### PR TITLE
TypeScript: Add type definition for Instant.atZone

### DIFF
--- a/dist/js-joda.d.ts
+++ b/dist/js-joda.d.ts
@@ -212,6 +212,8 @@ declare namespace JSJoda {
 
         adjustInto(temporal: Temporal): Temporal
 
+        atZone(zone: ZoneId): ZonedDateTime
+
         compareTo(otherInstant: Instant): number
 
         epochSecond(): number
@@ -278,7 +280,7 @@ declare namespace JSJoda {
 
         private constructor()
     }
-    
+
     class SignStyle {
         static NORMAL: SignStyle;
         static NEVER: SignStyle;


### PR DESCRIPTION
This was already [documented](https://js-joda.github.io/js-joda/class/src/Instant.js~Instant.html#instance-method-atZone), but not part of the type definitions.