### PR TITLE
Add ZoneRulesProvider TypeScript definition

### DIFF
--- a/dist/js-joda.d.ts
+++ b/dist/js-joda.d.ts
@@ -1678,6 +1678,16 @@ declare namespace JSJoda {
     class DateTimeParseException extends Error {
         constructor(message?: string)
     }
+
+    class ZoneRulesProvider {
+        static getRules(zoneId: string): ZoneRules
+
+        static getAvailableZoneIds(): string[]
+    }
+
+    class DateTimeException extends Error {
+        constructor(message?: string)
+    }
 }
 
 export = JSJoda;


### PR DESCRIPTION
Adding ZoneRulesProvider and DateTimeException types to TypeScript definition file. I believe these are manually maintained?

Let me know if anything additional is required.