### PR TITLE
Improve TS declarations with no breaking change

### DIFF
--- a/packages/core/dist/js-joda.d.ts
+++ b/packages/core/dist/js-joda.d.ts
@@ -770,20 +770,15 @@ declare namespace JSJoda {
         toString(): string
     }
 
-    class IsoFields extends TemporalField {
-        static DAY_OF_QUARTER: IsoFields
-        static QUARTER_OF_YEAR: IsoFields
-        static WEEK_OF_WEEK_BASED_YEAR: IsoFields
-        static WEEK_BASED_YEAR: IsoFields
+    class IsoFields {
+        static DAY_OF_QUARTER: TemporalField
+        static QUARTER_OF_YEAR: TemporalField
+        static WEEK_OF_WEEK_BASED_YEAR: TemporalField
+        static WEEK_BASED_YEAR: TemporalField
         static WEEK_BASED_YEARS: TemporalUnit
         static QUARTER_YEARS: TemporalUnit
 
         private constructor()
-
-        isDateBased(): boolean
-        isTimeBased(): boolean
-        name(): string
-        getDisplayName(): string
     }
 
     abstract class ChronoLocalDate extends Temporal {

--- a/packages/core/dist/js-joda.d.ts
+++ b/packages/core/dist/js-joda.d.ts
@@ -24,7 +24,11 @@ declare namespace JSJoda {
 
         abstract millis(): number
 
-        abstract zone(): any
+        abstract zone(): ZoneId
+
+        abstract withZone(zone: ZoneId): Clock
+
+        abstract equals(other: any): boolean        
     }
 
     class DayOfWeek extends Temporal {

--- a/packages/core/dist/js-joda.d.ts
+++ b/packages/core/dist/js-joda.d.ts
@@ -645,9 +645,12 @@ declare namespace JSJoda {
     }
 
     abstract class TemporalField {
+        abstract isDateBased(): boolean
+        abstract isTimeBased(): boolean
+        abstract name(): string
     }
 
-    class ChronoField {
+    class ChronoField extends TemporalField {
         static NANO_OF_SECOND: ChronoField
         static NANO_OF_DAY: ChronoField
         static MICRO_OF_SECOND: ChronoField
@@ -763,15 +766,20 @@ declare namespace JSJoda {
         toString(): string
     }
 
-    class IsoFields {
+    class IsoFields extends TemporalField {
         static DAY_OF_QUARTER: IsoFields
         static QUARTER_OF_YEAR: IsoFields
         static WEEK_OF_WEEK_BASED_YEAR: IsoFields
         static WEEK_BASED_YEAR: IsoFields
-        static WEEK_BASED_YEARS: IsoFields
-        static QUARTER_YEARS: IsoFields
+        static WEEK_BASED_YEARS: TemporalUnit
+        static QUARTER_YEARS: TemporalUnit
 
         private constructor()
+
+        isDateBased(): boolean
+        isTimeBased(): boolean
+        name(): string
+        getDisplayName(): string
     }
 
     abstract class ChronoLocalDate extends Temporal {

--- a/packages/core/dist/js-joda.d.ts
+++ b/packages/core/dist/js-joda.d.ts
@@ -114,7 +114,7 @@ declare namespace JSJoda {
 
         dividedBy(divisor: number): Duration
 
-        equals(otherDuration: any): boolean
+        equals(other: any): boolean
 
         get(unit: TemporalUnit): number
 
@@ -218,7 +218,7 @@ declare namespace JSJoda {
 
         epochSecond(): number
 
-        equals(otherInstant: any): boolean
+        equals(other: any): boolean
 
         get(field: TemporalField): number
 
@@ -549,7 +549,7 @@ declare namespace JSJoda {
 
         compareTo(other: Month): number
 
-        equals(other: Month): boolean
+        equals(other: any): boolean
 
         firstDayOfYear(leapYear: boolean): number
 
@@ -611,7 +611,7 @@ declare namespace JSJoda {
 
         dayOfMonth(): number
 
-        equals(obj: any): boolean
+        equals(other: any): boolean
 
         format(formatter: DateTimeFormatter): string
 
@@ -821,7 +821,7 @@ declare namespace JSJoda {
 
         dayOfYear(): number
 
-        equals(otherDate: any): boolean
+        equals(other: any): boolean
 
         get(field: TemporalField): number
 
@@ -959,7 +959,7 @@ declare namespace JSJoda {
 
         isBefore(other: LocalDateTime): boolean
 
-        isEqual(other: any): boolean
+        isEqual(other: LocalDateTime): boolean
 
         isSupported(fieldOrUnit: TemporalField|TemporalUnit): boolean
 
@@ -1084,7 +1084,7 @@ declare namespace JSJoda {
 
         days(): number
 
-        equals(obj: any): boolean
+        equals(other: any): boolean
 
         get(unit: TemporalUnit): number
 
@@ -1305,7 +1305,7 @@ declare namespace JSJoda {
 
         isBefore(other: YearMonth): boolean
 
-        equals(other: YearMonth): boolean
+        equals(other: any): boolean
 
         toJSON(): string
 
@@ -1360,7 +1360,7 @@ declare namespace JSJoda {
 
         compareTo(other: ZoneOffset): number
 
-        equals(obj: any): boolean
+        equals(other: any): boolean
 
         get(field: TemporalField): number
 

--- a/packages/core/dist/js-joda.d.ts
+++ b/packages/core/dist/js-joda.d.ts
@@ -184,7 +184,7 @@ declare namespace JSJoda {
 
         toString(): string
 
-        units(): any
+        units(): TemporalUnit[]
 
         withNanos(nanoOfSecond: number): Duration
 
@@ -1126,7 +1126,7 @@ declare namespace JSJoda {
 
         toTotalMonths(): number
 
-        units(): ChronoUnit[]
+        units(): TemporalUnit[]
 
         withDays(days: number): Period
 

--- a/packages/core/dist/js-joda.d.ts
+++ b/packages/core/dist/js-joda.d.ts
@@ -1232,24 +1232,32 @@ declare namespace JSJoda {
         static MAX_VALUE: number;
 
         static from(temporal: TemporalAccessor): Year
-
         static isLeap(year: number): boolean
-
-        static now(zoneIdOrClock?: ZoneId|Clock): Year
-
+        static now(zoneIdOrClock?: ZoneId | Clock): Year
         static of(isoYear: number): Year
-
         static parse(text: string, formatter?: DateTimeFormatter): Year
 
         private constructor()
 
-        atMonth(monthOrNumber: Month|number): YearMonth
-
-        plus(amountOrNumber: TemporalAmount|number, unit?: TemporalUnit): Year
-
-        minus(amountOrNumber: TemporalAmount|number, unit?: TemporalUnit): Year
-
+        atDay(dayOfYear: number): LocalDate
+        atMonth(month: Month | number): YearMonth
+        atMonthDay(monthDay: MonthDay): LocalDate
+        compareTo(other: Year): number
+        equals(other: any): boolean
+        isAfter(other: Year): boolean
+        isBefore(other: Year): boolean
+        isLeap(): boolean
+        isValidMonthDay(monthDay: MonthDay): boolean
+        length(): number
+        plus(amount: TemporalAmount): Year
+        plus(amountToAdd: number, unit: TemporalUnit): Year
+        plusYears(yearsToAdd: number): Year
+        minus(amount: TemporalAmount): Year
+        minus(amountToSubtract: number, unit: TemporalUnit): Year
+        minusYears(yearsToSubtract: number): Year
         value(): number
+        with(adjuster: TemporalAdjuster): Year
+        with(field: TemporalField, newValue: number): Year
     }
 
     class YearMonth extends Temporal {

--- a/packages/core/dist/js-joda.d.ts
+++ b/packages/core/dist/js-joda.d.ts
@@ -932,7 +932,7 @@ declare namespace JSJoda {
         static now(clockOrZone?: Clock|ZoneId): LocalDateTime
 
         static of(date: LocalDate, time: LocalTime): LocalDateTime
-        static of(year?: number, month?: Month|number, dayOfMonth?: number, hour?: number, minute?: number, second?: number, nanoSecond?: number): LocalDateTime
+        static of(year: number, month: Month|number, dayOfMonth: number, hour?: number, minute?: number, second?: number, nanoSecond?: number): LocalDateTime
 
         static ofEpochSecond(epochSecond: number, offset:ZoneOffset): LocalDateTime
         static ofEpochSecond(epochSecond: number, nanoOfSecond: number, offset:ZoneOffset): LocalDateTime

--- a/packages/core/test/typescript_definitions/js-joda-tests.ts
+++ b/packages/core/test/typescript_definitions/js-joda-tests.ts
@@ -453,7 +453,7 @@ function test_ZoneOffsetTransition() {
     expectType<boolean>(zot.isOverlap());
     expectType<boolean>(zot.isValidOffset(ZoneOffset.UTC));
     expectType<ZoneOffset[]>(zot.validOffsets());
-    expectType<boolean>(zot.equals({}));
+    expectType<boolean>(zot.equals(zot));
     expectType<number>(zot.compareTo(undefined! as ZoneOffsetTransition));
     expectType<number>(zot.hashCode());
     expectType<string>(zot.toString());

--- a/packages/core/test/typescript_definitions/js-joda-tests.ts
+++ b/packages/core/test/typescript_definitions/js-joda-tests.ts
@@ -688,6 +688,13 @@ function test_Month() {
     expectType<Month>(Month.valueOf('FEBRUARY'));
 }
 
+function test_Clock() {
+    const clock = Clock.systemUTC();
+
+    expectType<ZoneId>(clock.zone());
+    expectType<Clock>(clock.withZone(ZoneId.UTC));
+}
+
 /**
  * Use this to check if an expression is of type T.
  * Don't let TypeScript infer the type, give it explicitly.

--- a/packages/core/test/typescript_definitions/js-joda-tests.ts
+++ b/packages/core/test/typescript_definitions/js-joda-tests.ts
@@ -39,6 +39,16 @@ declare function moment(): any;
  *  For more information, see e.g. http:
  */
 
+function test_ChronoUnit() {
+    const cu = ChronoUnit.DAYS;
+
+    expectType<LocalDate>(cu.addTo(LocalDate.now(), 1));
+    expectType<number>(cu.between(LocalDate.now(), LocalDate.now()));
+    expectType<Duration>(cu.duration());
+    expectType<boolean>(cu.isDateBased());
+    expectType<string>(cu.toString());
+}
+
 function test_LocalDate() {
     LocalDate.now();
     LocalDate.now(ZoneOffset.UTC);

--- a/packages/core/test/typescript_definitions/js-joda-tests.ts
+++ b/packages/core/test/typescript_definitions/js-joda-tests.ts
@@ -12,11 +12,13 @@ import {
     LocalDateTime,
     LocalTime,
     Month,
+    MonthDay,
     nativeJs,
     Period,
     ResolverStyle,
     SignStyle,
     TemporalAdjusters,
+    Year,
     YearMonth,
     ZoneOffset,
     ZoneOffsetTransition,
@@ -518,6 +520,32 @@ function test_Duration() {
     var dt1 = LocalDateTime.parse('2012-12-24T12:00');
 
     Duration.between(dt1, dt1.plusHours(10)).toString();
+}
+
+function test_Year() {
+    const year = Year.now();
+
+    expectType<LocalDate>(year.atDay(2));
+    expectType<YearMonth>(year.atMonth(5));
+    expectType<YearMonth>(year.atMonth(Month.DECEMBER));
+    expectType<LocalDate>(year.atMonthDay(MonthDay.of(6, 22)));
+
+    expectType<boolean>(year.isAfter(Year.of(2020)));
+    expectType<boolean>(year.isBefore(Year.of(2020)));
+    expectType<boolean>(year.isLeap());
+    expectType<boolean>(year.isValidMonthDay(MonthDay.of(2, 29)));
+    expectType<number>(year.compareTo(Year.of(2020)));
+    
+    expectType<number>(year.length());
+
+    year.plus(Period.ofYears(2));
+    year.plus(1, ChronoUnit.YEARS);
+    year.plusYears(3);
+    year.minus(Period.ofYears(2));
+    year.minus(1, ChronoUnit.YEARS);
+    year.minusYears(3);
+
+    year.with(ChronoField.YEAR, 2015);
 }
 
 function test_YearMonth() {

--- a/packages/extra/dist/js-joda-extra.d.ts
+++ b/packages/extra/dist/js-joda-extra.d.ts
@@ -1,12 +1,8 @@
-declare module JSJoda {
-  class Duration {}
-  class Instant {}
-}
+/// <reference types="@js-joda/core" />
+
+import { Instant, Duration } from '@js-joda/core';
 
 declare namespace JSJodaExtra {
-  import Duration = JSJoda.Duration;
-  import Instant = JSJoda.Instant;
-
   class Interval {
     static of(
       startInstant: Instant,

--- a/packages/extra/test/typescript_definitions/js-joda-extra-tests.ts
+++ b/packages/extra/test/typescript_definitions/js-joda-extra-tests.ts
@@ -1,6 +1,7 @@
 import {
   Instant,
   Duration,
+  LocalDate,
 } from '../../../core'
 import {
   Interval
@@ -14,7 +15,7 @@ function test_Interval() {
   Interval.of(instant, instant);
   Interval.of(instant, duration);
   Interval.ofInstantInstant(instant, instant);
-  Interval.ofInstantDuration(instant, instant);
+  Interval.ofInstantDuration(instant, duration);
   Interval.parse('2019-08-09T20:38:43.298Z/2019-08-09T20:38:43.298Z');
 
   const interval = new Interval(instant, instant);
@@ -45,4 +46,6 @@ function test_Interval() {
   interval.equals({});
   interval.hashCode();
   interval.toString();
+
+  LocalDate.ofInstant(interval.end());
 }


### PR DESCRIPTION
Improve TypeScript declarations without requiring a major release.

It does **not** supersede #353. It takes some of the changes of that PR but only those that are safe and don't make a breaking change. My intention is, if this PR is accepted and merged, rebase #353 so it still can be applied for a major release with presumably other breaking changes.

This PR adds missing methods to `Year`, remove some `any` types, fix some `TemporalUnit` previously typed as `IsoField` and fix the types of `@js-joda/extra` without changing to ES module.

It removes the `LocalDateTime.of` that takes zero arguments, now requiring at least three. This is not a breaking change since the call with zero arguments fails at runtime anyway.

Fixes #347 