### PR TITLE
Add missing methods to `Temporal` interface

### DIFF
--- a/packages/core/dist/js-joda.d.ts
+++ b/packages/core/dist/js-joda.d.ts
@@ -11,9 +11,17 @@ declare namespace JSJoda {
     abstract class Temporal extends TemporalAccessor {
       isSupported(unit: TemporalUnit): boolean
 
+      minus(amountToSubtract: number, unit: TemporalUnit): Temporal
+
+      minus(amount: TemporalAmount): Temporal
+
       plus(amountToAdd: number, unit: TemporalUnit): Temporal
 
-      until(endExclusive: Temporal, unit: TemporalUnit): number
+      plus(amount: TemporalAmount): Temporal
+
+      until(endTemporal: Temporal, unit: TemporalUnit): number
+
+      with(adjuster: TemporalAdjuster): Temporal
 
       with(field: TemporalField, newValue: number): Temporal
     }

--- a/packages/core/dist/js-joda.d.ts
+++ b/packages/core/dist/js-joda.d.ts
@@ -9,6 +9,13 @@ declare namespace JSJoda {
     }
 
     abstract class Temporal extends TemporalAccessor {
+      isSupported(unit: TemporalUnit): boolean
+
+      plus(amountToAdd: number, unit: TemporalUnit): Temporal
+
+      until(endExclusive: Temporal, unit: TemporalUnit): number
+
+      with(field: TemporalField, newValue: number): Temporal
     }
 
     abstract class Clock {

--- a/packages/core/dist/js-joda.d.ts
+++ b/packages/core/dist/js-joda.d.ts
@@ -38,7 +38,7 @@ declare namespace JSJoda {
         abstract equals(other: any): boolean        
     }
 
-    class DayOfWeek extends Temporal {
+    class DayOfWeek extends TemporalAccessor {
         static MONDAY: DayOfWeek
         static TUESDAY: DayOfWeek
         static WEDNESDAY: DayOfWeek
@@ -444,7 +444,7 @@ declare namespace JSJoda {
 
         isBefore(other: LocalTime): boolean
 
-        isSupported(fieldOrUnit: ChronoField|ChronoUnit): boolean
+        isSupported(fieldOrUnit: TemporalField|TemporalUnit): boolean
 
         minus(amount: TemporalAmount): LocalTime
         minus(amountToSubtract: number, unit: ChronoUnit): LocalTime
@@ -532,7 +532,7 @@ declare namespace JSJoda {
         static verifyInt(value: number): void
     }
 
-    class Month extends Temporal {
+    class Month extends TemporalAccessor {
         static JANUARY: Month
         static FEBRUARY: Month
         static MARCH: Month
@@ -595,7 +595,7 @@ declare namespace JSJoda {
         value(): number
     }
 
-    class MonthDay extends Temporal {
+    class MonthDay extends TemporalAccessor {
         static from(temporal: TemporalAccessor): MonthDay
 
         static now(arg1?: ZoneId|Clock): MonthDay
@@ -1301,7 +1301,7 @@ declare namespace JSJoda {
         withYear(year: number): YearMonth
         withMonth(month: number): YearMonth
 
-        isSupported(fieldOrUnit: TemporalField|ChronoUnit): boolean
+        isSupported(fieldOrUnit: TemporalField|TemporalUnit): boolean
 
         year(): number
 

--- a/packages/core/src/DayOfWeek.js
+++ b/packages/core/src/DayOfWeek.js
@@ -11,7 +11,7 @@ import {assert, requireNonNull, requireInstance} from './assert';
 import {ChronoField} from './temporal/ChronoField';
 import {ChronoUnit} from './temporal/ChronoUnit';
 import {IllegalArgumentException} from './errors';
-import {Temporal} from './temporal/Temporal';
+import {TemporalAccessor} from './temporal/TemporalAccessor';
 import {TemporalQueries} from './temporal/TemporalQueries';
 import {createTemporalQuery} from './temporal/TemporalQuery';
 
@@ -27,7 +27,7 @@ import {createTemporalQuery} from './temporal/TemporalQuery';
  * DayOfWeek.SUNDAY
  *
  */
-export class DayOfWeek extends Temporal {
+export class DayOfWeek extends TemporalAccessor {
 
     /**
      *

--- a/packages/core/src/Instant.js
+++ b/packages/core/src/Instant.js
@@ -406,23 +406,6 @@ export class Instant extends Temporal {
 
     //-------------------------------------------------------------------------
     /**
-     * function overloading for {@link Instant.with}
-     *
-     * if called with 1 argument {@link Instant.withTemporalAdjuster} is called
-     * otherwise {@link Instant.with2}
-     *
-     * @param {!(TemporalAdjuster|TemporalField)} adjusterOrField
-     * @param {number} newValue
-     * @returns {Instant}
-     */
-    with(adjusterOrField, newValue){
-        if(arguments.length === 1){
-            return this.withTemporalAdjuster(adjusterOrField);
-        } else {
-            return this.with2(adjusterOrField, newValue);
-        }
-    }
-    /**
      * Returns an adjusted copy of this instant.
      *
      * This returns a new {@link Instant}, based on this one, with the date adjusted.
@@ -440,7 +423,7 @@ export class Instant extends Temporal {
      * @throws DateTimeException if the adjustment cannot be made
      * @throws ArithmeticException if numeric overflow occurs
      */
-    withTemporalAdjuster(adjuster) {
+    withAdjuster(adjuster) {
         requireNonNull(adjuster, 'adjuster');
         return adjuster.adjustInto(this);
     }
@@ -488,7 +471,7 @@ export class Instant extends Temporal {
      * @throws DateTimeException if the field cannot be set
      * @throws ArithmeticException if numeric overflow occurs
      */
-    with2(field, newValue) {
+    withFieldValue(field, newValue) {
         requireNonNull(field, 'field');
         if (field instanceof ChronoField) {
             field.checkValidValue(newValue);
@@ -550,19 +533,6 @@ export class Instant extends Temporal {
     }
 
     //-----------------------------------------------------------------------
-    /**
-     *
-     * @param {TemporalAmount|number} amount
-     * @param {TemporalUnit} unit - only required if first param is a TemporalAmount
-     * @return {Instant}
-     */
-    plus(amount, unit){
-        if(arguments.length === 1){
-            return this.plus1(amount);
-        } else {
-            return this.plus2(amount, unit);
-        }
-    }
 
     /**
      * @param {!TemporalAmount} amount
@@ -570,7 +540,7 @@ export class Instant extends Temporal {
      * @throws DateTimeException
      * @throws ArithmeticException
      */
-    plus1(amount) {
+    plusAmount(amount) {
         requireNonNull(amount, 'amount');
         return amount.addTo(this);
     }
@@ -582,7 +552,7 @@ export class Instant extends Temporal {
      * @throws DateTimeException
      * @throws ArithmeticException
      */
-    plus2(amountToAdd, unit) {
+    plusAmountUnit(amountToAdd, unit) {
         requireNonNull(amountToAdd, 'amountToAdd');
         requireNonNull(unit, 'unit');
         requireInstance(unit, TemporalUnit);
@@ -663,19 +633,6 @@ export class Instant extends Temporal {
     }
 
     //-----------------------------------------------------------------------
-    /**
-     *
-     * @param {TemporalAmount|number} amount
-     * @param {TemporalUnit} unit - only required if first param is a TemporalAmount
-     * @return {Instant}
-     */
-    minus(amount, unit){
-        if(arguments.length === 1){
-            return this.minus1(amount);
-        } else {
-            return this.minus2(amount, unit);
-        }
-    }
 
     /**
      * @param {!TemporalAmount} amount
@@ -683,7 +640,7 @@ export class Instant extends Temporal {
      * @throws DateTimeException
      * @throws ArithmeticException
      */
-    minus1(amount) {
+    minusAmount(amount) {
         requireNonNull(amount, 'amount');
         return amount.subtractFrom(this);
     }
@@ -695,8 +652,8 @@ export class Instant extends Temporal {
      * @throws DateTimeException
      * @throws ArithmeticException
      */
-    minus2(amountToSubtract, unit) {
-        return this.plus2(-1 * amountToSubtract, unit);
+    minusAmountUnit(amountToSubtract, unit) {
+        return this.plusAmountUnit(-1 * amountToSubtract, unit);
     }
 
     /**

--- a/packages/core/src/LocalDate.js
+++ b/packages/core/src/LocalDate.js
@@ -617,27 +617,6 @@ export class LocalDate extends ChronoLocalDate{
     }
 
     /**
-     * function overloading for the {@link LocalDate.with} method.
-     *
-     * calling "with" with one (or less) argument, assumes that the argument is an TemporalAdjuster
-     * and {@link LocalDate.withTemporalAdjuster} is called.
-     *
-     * Otherwise a TemporalField and newValue argument is expected and
-     * {@link LocalDate.withFieldAndValue} is called.
-     *
-     * @param {!(TemporalAdjuster|TemporalField)} fieldOrAdjuster
-     * @param {number} newValue - required if first argument is a TemporalField
-     * @return {LocalDate} the new LocalDate with the newValue set.
-     */
-    with(fieldOrAdjuster, newValue){
-        if(arguments.length < 2){
-            return this.withTemporalAdjuster(fieldOrAdjuster);
-        } else {
-            return this.withFieldAndValue(fieldOrAdjuster, newValue);
-        }
-    }
-
-    /**
      * Returns an adjusted copy of this date.
      *
      * This returns a new {@link LocalDate}, based on this one, with the date adjusted.
@@ -670,7 +649,7 @@ export class LocalDate extends ChronoLocalDate{
      * @throws {DateTimeException} if the adjustment cannot be made
      * @throws {ArithmeticException} if numeric overflow occurs
      */
-    withTemporalAdjuster(adjuster) {
+    withAdjuster(adjuster) {
         requireNonNull(adjuster, 'adjuster');
         // optimizations
         if (adjuster instanceof LocalDate) {
@@ -780,7 +759,7 @@ export class LocalDate extends ChronoLocalDate{
      * @throws {DateTimeException} if the field cannot be set
      * @throws {ArithmeticException} if numeric overflow occurs
      */
-    withFieldAndValue(field, newValue) {
+    withFieldValue(field, newValue) {
         assert(field != null, 'field', NullPointerException);
         if (field instanceof ChronoField) {
             const f = field;
@@ -872,40 +851,20 @@ export class LocalDate extends ChronoLocalDate{
     }
 
     /**
-     * function overloading for plus
-     *
-     * called with 1 (or less) arguments, p1 is expected to be a TemporalAmount and {@link LocalDate.plus1}
-     * is called.
-     *
-     * Otherwise {@link LocalDate.plus2} is called.
-     *
-     * @param {!(TemporalAmount|number)} p1
-     * @param {TemporalUnit} p2 - required if called with 2 arguments
-     * @return {LocalDate}
-     */
-    plus(p1, p2){
-        if(arguments.length < 2){
-            return this.plus1(p1);
-        } else {
-            return this.plus2(p1, p2);
-        }
-    }
-
-    /**
      * Returns a copy of this date with the specified period added.
      *
      * This method returns a new date based on this date with the specified period added.
      * The amount is typically {@link Period} but may be any other type implementing
      * the {@link TemporalAmount} interface.
      * The calculation is delegated to the specified adjuster, which typically calls
-     * back to {@link LocalDate.plus2}.
+     * back to {@link LocalDate.plusAmountUnit}.
      *
      * @param {!TemporalAmount} amount - the amount to add, not null
      * @return {LocalDate} a {@link LocalDate} based on this date with the addition made, not null
      * @throws {DateTimeException} if the addition cannot be made
      * @throws {ArithmeticException} if numeric overflow occurs
      */
-    plus1(amount) {
+    plusAmount(amount) {
         requireNonNull(amount, 'amount');
         return amount.addTo(this);
     }
@@ -923,7 +882,7 @@ export class LocalDate extends ChronoLocalDate{
      * @return {LocalDate} a {@link LocalDate} based on this date with the specified period added, not null
      * @throws {DateTimeException} if the unit cannot be added to this type
      */
-    plus2(amountToAdd, unit) {
+    plusAmountUnit(amountToAdd, unit) {
         requireNonNull(amountToAdd, 'amountToAdd');
         requireNonNull(unit, 'unit');
         if (unit instanceof ChronoUnit) {
@@ -1035,26 +994,6 @@ export class LocalDate extends ChronoLocalDate{
     }
 
     /**
-      * function overloading for minus
-      *
-      * called with 1 (or less) arguments, p1 is expected to be a TemporalAmount and {@link LocalDate.minus1}
-      * is called.
-      *
-      * Otherwise {@link LocalDate.minus2} is called.
-      *
-      * @param {!(TemporalAmount|number)} p1
-      * @param {TemporalUnit} p2 - required if called with 2 arguments
-      * @return {LocalDate}
-      */
-    minus(p1, p2){
-        if(arguments.length < 2){
-            return this.minus1(p1);
-        } else {
-            return this.minus2(p1, p2);
-        }
-    }
-
-    /**
      * Returns a copy of this date with the specified period subtracted.
      *
      * This method returns a new date based on this date with the specified period subtracted.
@@ -1068,7 +1007,7 @@ export class LocalDate extends ChronoLocalDate{
      * @throws {DateTimeException} if the subtraction cannot be made
      * @throws {ArithmeticException} if numeric overflow occurs
      */
-    minus1(amount) {
+    minusAmount(amount) {
         requireNonNull(amount, 'amount');
         return amount.subtractFrom(this);
     }
@@ -1086,10 +1025,10 @@ export class LocalDate extends ChronoLocalDate{
      * @return {LocalDate} a {@link LocalDate} based on this date with the specified period subtracted, not null
      * @throws {DateTimeException} if the unit cannot be added to this type
      */
-    minus2(amountToSubtract, unit) {
+    minusAmountUnit(amountToSubtract, unit) {
         requireNonNull(amountToSubtract, 'amountToSubtract');
         requireNonNull(unit, 'unit');
-        return this.plus2(-1 * amountToSubtract, unit);
+        return this.plusAmountUnit(-1 * amountToSubtract, unit);
     }
 
     /**

--- a/packages/core/src/LocalDateTime.js
+++ b/packages/core/src/LocalDateTime.js
@@ -593,23 +593,6 @@ implements Temporal, TemporalAdjuster, Serializable */ {
     }
 
     //-----------------------------------------------------------------------
-    /**
-     * function overloading for {@link LocalDateTime.with}
-     *
-     * if called with 1 argument, {@link LocalDateTime.withTemporalAdjuster} is applied,
-     * otherwise {@link LocalDateTime.with2}.
-     *
-     * @param {!(TemporalAdjuster|TemporalField)} adjusterOrField
-     * @param {number} newValue - only require if first argument is a TemporalField
-     * @returns {LocalDateTime}
-     */
-    with(adjusterOrField, newValue){
-        if(arguments.length === 1){
-            return this.withTemporalAdjuster(adjusterOrField);
-        } else {
-            return this.with2(adjusterOrField, newValue);
-        }
-    }
 
     /**
      * Returns an adjusted copy of this date-time.
@@ -653,7 +636,7 @@ implements Temporal, TemporalAdjuster, Serializable */ {
      * @throws {DateTimeException} if the adjustment cannot be made
      * @throws {ArithmeticException} if numeric overflow occurs
      */
-    withTemporalAdjuster(adjuster) {
+    withAdjuster(adjuster) {
         requireNonNull(adjuster, 'adjuster');
         // optimizations
         if (adjuster instanceof LocalDate) {
@@ -699,7 +682,7 @@ implements Temporal, TemporalAdjuster, Serializable */ {
      * @throws {DateTimeException} if the field cannot be set
      * @throws {ArithmeticException} if numeric overflow occurs
      */
-    with2(field, newValue) {
+    withFieldValue(field, newValue) {
         requireNonNull(field, 'field');
         if (field instanceof ChronoField) {
             if (field.isTimeBased()) {
@@ -855,23 +838,6 @@ implements Temporal, TemporalAdjuster, Serializable */ {
     }
 
     //-----------------------------------------------------------------------
-    /**
-     * function overloading for {@link LocalDateTime.plus}
-     *
-     * if called with 1 argument {@link LocalDateTime.plusTemporalAmount} is applied,
-     * otherwise {@link LocalDateTime.plus2}
-     *
-     * @param {!(TemporalAmount|number)} amount
-     * @param {TemporalUnit} unit
-     * @returns {LocalDateTime}
-     */
-    plus(amount, unit){
-        if(arguments.length === 1){
-            return this.plusTemporalAmount(amount);
-        } else {
-            return this.plus2(amount, unit);
-        }
-    }
 
     /**
      * Returns a copy of this date-time with the specified period added.
@@ -889,7 +855,7 @@ implements Temporal, TemporalAdjuster, Serializable */ {
      * @throws {DateTimeException} if the addition cannot be made
      * @throws {ArithmeticException} if numeric overflow occurs
      */
-    plusTemporalAmount(amount) {
+    plusAmount(amount) {
         requireNonNull(amount, 'amount');
         return amount.addTo(this);
     }
@@ -909,7 +875,7 @@ implements Temporal, TemporalAdjuster, Serializable */ {
      * @return {LocalDateTime} a {@link LocalDateTime} based on this date-time with the specified period added, not null
      * @throws {DateTimeException} if the unit cannot be added to this type
      */
-    plus2(amountToAdd, unit) {
+    plusAmountUnit(amountToAdd, unit) {
         requireNonNull(unit, 'unit');
         if (unit instanceof ChronoUnit) {
             switch (unit) {
@@ -1069,23 +1035,6 @@ implements Temporal, TemporalAdjuster, Serializable */ {
     }
 
     //-----------------------------------------------------------------------
-    /**
-     * function overloading for {@link LocalDateTime.minus}
-     *
-     * if called with 1 argument {@link LocalDateTime.minusTemporalAmount} is applied,
-     * otherwise {@link LocalDateTime.minus2}
-     *
-     * @param {!(TemporalAmount|number)} amount
-     * @param {TemporalUnit} unit
-     * @returns {LocalDateTime}
-     */
-    minus(amount, unit){
-        if(arguments.length === 1){
-            return this.minusTemporalAmount(amount);
-        } else {
-            return this.minus2(amount, unit);
-        }
-    }
 
     /**
      * Returns a copy of this date-time with the specified period subtracted.
@@ -1103,7 +1052,7 @@ implements Temporal, TemporalAdjuster, Serializable */ {
      * @throws {DateTimeException} if the subtraction cannot be made
      * @throws {ArithmeticException} if numeric overflow occurs
      */
-    minusTemporalAmount(amount) {
+    minusAmount(amount) {
         requireNonNull(amount, 'amount');
         return amount.subtractFrom(this);
     }
@@ -1123,9 +1072,9 @@ implements Temporal, TemporalAdjuster, Serializable */ {
      * @return {LocalDateTime} a {@link LocalDateTime} based on this date-time with the specified period subtracted, not null
      * @throws {DateTimeException} if the unit cannot be added to this type
      */
-    minus2(amountToSubtract, unit) {
+    minusAmountUnit(amountToSubtract, unit) {
         requireNonNull(unit, 'unit');
-        return this.plus2(-1 * amountToSubtract, unit);
+        return this.plusAmountUnit(-1 * amountToSubtract, unit);
     }
 
     //-----------------------------------------------------------------------

--- a/packages/core/src/LocalTime.js
+++ b/packages/core/src/LocalTime.js
@@ -501,24 +501,6 @@ export class LocalTime extends Temporal /** implements Temporal, TemporalAdjuste
     }
 
     /**
-     * function overloading for {@link LocalDate.with}
-     *
-     * if called with 1 (or less) arguments {@link LocalTime.withTemporalAdjuster} is called.
-     * Otherwise {@link LocalTime.with2} is called.
-     *
-     * @param {!(TemporalAdjuster|ChronoField)} adjusterOrField
-     * @param {number} newValue - only required if called with 2 arguments
-     * @return {LocalTime}
-     */
-    with(adjusterOrField, newValue){
-        if(arguments.length < 2){
-            return this.withTemporalAdjuster(adjusterOrField);
-        } else {
-            return this.with2(adjusterOrField, newValue);
-        }
-    }
-
-    /**
      * Returns an adjusted copy of this time.
      *
      * This returns a new {@link LocalTime}, based on this one, with the time adjusted.
@@ -539,7 +521,7 @@ export class LocalTime extends Temporal /** implements Temporal, TemporalAdjuste
      * @throws {DateTimeException} if the adjustment cannot be made
      * @throws {ArithmeticException} if numeric overflow occurs
      */
-    withTemporalAdjuster(adjuster) {
+    withAdjuster(adjuster) {
         requireNonNull(adjuster, 'adjuster');
         // optimizations
         if (adjuster instanceof LocalTime) {
@@ -629,7 +611,7 @@ export class LocalTime extends Temporal /** implements Temporal, TemporalAdjuste
      * @throws {DateTimeException} if the field cannot be set
      * @throws {ArithmeticException} if numeric overflow occurs
      */
-    with2(field, newValue) {
+    withFieldValue(field, newValue) {
         requireNonNull(field, 'field');
         requireInstance(field, TemporalField, 'field');
         if (field instanceof ChronoField) {
@@ -761,24 +743,6 @@ export class LocalTime extends Temporal /** implements Temporal, TemporalAdjuste
     //-----------------------------------------------------------------------
 
     /**
-     * function overloading for {@link LocalDate.plus}
-     *
-     * if called with 1 (or less) arguments {@link LocalTime.plus1} is called.
-     * Otherwise {@link LocalTime.plus2} is called.
-     *
-     * @param {!(TemporalAmount|number)} amount
-     * @param {ChronoUnit} unit - only required if called with 2 arguments
-     * @return {LocalTime}
-     */
-    plus(amount, unit){
-        if(arguments.length < 2){
-            return this.plus1(amount);
-        } else {
-            return this.plus2(amount, unit);
-        }
-    }
-
-    /**
      * Returns a copy of this date with the specified period added.
      *
      * This method returns a new time based on this time with the specified period added.
@@ -794,7 +758,7 @@ export class LocalTime extends Temporal /** implements Temporal, TemporalAdjuste
      * @throws {DateTimeException} if the addition cannot be made
      * @throws {ArithmeticException} if numeric overflow occurs
      */
-    plus1(amount) {
+    plusAmount(amount) {
         requireNonNull(amount, 'amount');
         return amount.addTo(this);
     }
@@ -814,7 +778,7 @@ export class LocalTime extends Temporal /** implements Temporal, TemporalAdjuste
      * @return {LocalTime} a {@link LocalTime} based on this time with the specified period added, not null
      * @throws {DateTimeException} if the unit cannot be added to this type
      */
-    plus2(amountToAdd, unit) {
+    plusAmountUnit(amountToAdd, unit) {
         requireNonNull(unit, 'unit');
         if (unit instanceof ChronoUnit) {
             switch (unit) {
@@ -932,23 +896,6 @@ export class LocalTime extends Temporal /** implements Temporal, TemporalAdjuste
     }
 
     //-----------------------------------------------------------------------
-    /**
-     * function overloading for {@link LocalDate.minus}
-     *
-     * if called with 1 (or less) arguments {@link LocalTime.minus1} is called.
-     * Otherwise {@link LocalTime.minus2} is called.
-     *
-     * @param {!(TemporalAmount|number)} amount
-     * @param {ChronoUnit} unit - only required if called with 2 arguments
-     * @return {LocalTime}
-     */
-    minus(amount, unit){
-        if(arguments.length < 2){
-            return this.minus1(amount);
-        } else {
-            return this.minus2(amount, unit);
-        }
-    }
 
     /**
      * Returns a copy of this time with the specified period subtracted.
@@ -967,7 +914,7 @@ export class LocalTime extends Temporal /** implements Temporal, TemporalAdjuste
      * @throws {ArithmeticException} if numeric overflow occurs
      */
 
-    minus1(amount) {
+    minusAmount(amount) {
         requireNonNull(amount, 'amount');
         return amount.subtractFrom(this);
     }
@@ -987,9 +934,9 @@ export class LocalTime extends Temporal /** implements Temporal, TemporalAdjuste
      * @return {LocalTime} a {@link LocalTime} based on this time with the specified period subtracted, not null
      * @throws {DateTimeException} if the unit cannot be added to this type
      */
-    minus2(amountToSubtract, unit) {
+    minusAmountUnit(amountToSubtract, unit) {
         requireNonNull(unit, 'unit');
-        return this.plus2(-1 * amountToSubtract, unit);
+        return this.plusAmountUnit(-1 * amountToSubtract, unit);
     }
 
     //-----------------------------------------------------------------------

--- a/packages/core/src/Month.js
+++ b/packages/core/src/Month.js
@@ -11,7 +11,7 @@ import {ChronoField} from './temporal/ChronoField';
 import {ChronoUnit} from './temporal/ChronoUnit';
 import {DateTimeException, IllegalArgumentException, UnsupportedTemporalTypeException} from './errors';
 import {IsoChronology} from './chrono/IsoChronology';
-import {Temporal} from './temporal/Temporal';
+import {TemporalAccessor} from './temporal/TemporalAccessor';
 import {TemporalQueries} from './temporal/TemporalQueries';
 
 /**
@@ -36,8 +36,8 @@ import {TemporalQueries} from './temporal/TemporalQueries';
  * Month.JULY, Month.AUGUST, Month.SEPTEMBER, Month.OCTOBER, Month.NOVEMBER, Month.DECEMBER
  *
  */
-export class Month extends Temporal {
-    
+export class Month extends TemporalAccessor {
+
     /**
      *
      * @param {number} ordinal

--- a/packages/core/src/MonthDay.js
+++ b/packages/core/src/MonthDay.js
@@ -14,7 +14,6 @@ import {DateTimeFormatterBuilder} from './format/DateTimeFormatterBuilder';
 import {IsoChronology} from './chrono/IsoChronology';
 import {LocalDate} from './LocalDate';
 import {Month} from './Month';
-import {Temporal} from './temporal/Temporal';
 import {TemporalAccessor} from './temporal/TemporalAccessor';
 import {TemporalQuery, createTemporalQuery} from './temporal/TemporalQuery';
 import {TemporalQueries} from './temporal/TemporalQueries';
@@ -52,7 +51,7 @@ import {ZoneId} from './ZoneId';
  *
  * This class is immutable and thread-safe.
  */
-export class MonthDay extends Temporal {
+export class MonthDay extends TemporalAccessor {
     /**
      * function overloading for {@link MonthDay.now}
      *

--- a/packages/core/src/Year.js
+++ b/packages/core/src/Year.js
@@ -463,24 +463,6 @@ export class Year extends Temporal {
     }
 
     //-----------------------------------------------------------------------
-    /**
-     * function overloading for {@link YearMonth.with}
-     *
-     * if called with 2 arguments and first argument is an instance of TemporalField, then {@link Year.withFieldValue} is executed,
-
-     * otherwise {@link Year.withAdjuster} is executed,
-     *
-     * @param {!(TemporalAdjuster|TemporalField|Number)} adjusterOrFieldOrNumber
-     * @param {?number} value nullable only of first argument is an instance of TemporalAdjuster
-     * @returns {Year}
-     */
-    with(adjusterOrFieldOrNumber, value) {
-        if (arguments.length === 2 && adjusterOrFieldOrNumber instanceof TemporalField) {
-            return this.withFieldValue(adjusterOrFieldOrNumber, value);
-        } else {
-            return this.withAdjuster(adjusterOrFieldOrNumber);
-        }
-    }
 
     /**
      * Returns an adjusted copy of this year.
@@ -563,25 +545,6 @@ export class Year extends Temporal {
     }
 
     /**
-     * function overloading for {@link Year.plus}
-     *
-     * if called with 1 arguments, then {@link Year.plusAmount} is executed.
-     *
-     * Otherwise {@link Year.plusAmountToAddUnit} is executed.
-     *
-     * @param {!(TemporalAmount|number)} amountOrNumber
-     * @param {?TemporalUnit} unit nullable only if first argument is an instance of TemporalAmount
-     * @returns {Year}
-     */
-    plus(amountOrNumber, unit) {
-        if (arguments.length === 1) {
-            return this.plusAmount(amountOrNumber);
-        } else {
-            return this.plusAmountToAddUnit(amountOrNumber, unit);
-        }
-    }
-
-    /**
      * Returns a copy of this year with the specified period added.
      *
      * This method returns a new year based on this year with the specified period added.
@@ -610,7 +573,7 @@ export class Year extends Temporal {
      * @throws DateTimeException if the addition cannot be made
      * @throws ArithmeticException if numeric overflow occurs
      */
-    plusAmountToAddUnit(amountToAdd, unit) {
+    plusAmountUnit(amountToAdd, unit) {
         requireNonNull(amountToAdd, 'amountToAdd');
         requireNonNull(unit, 'unit');
         requireInstance(unit, TemporalUnit, 'unit');
@@ -644,24 +607,6 @@ export class Year extends Temporal {
     }
 
     //-----------------------------------------------------------------------
-    /**
-     * function overloading for {@link Year.minus}
-     *
-     * if called with 1 argument, then {@link Year.minusAmount} is executed.
-     *
-     * Otherwise {@link Year.minusAmountToSubtractUnit} is executed.
-     *
-     * @param {!(TemporalAmount|number)} amountOrNumber
-     * @param {?TemporalUnit} unit
-     * @returns {Year}
-     */
-    minus(amountOrNumber, unit) {
-        if (arguments.length === 1) {
-            return this.minusAmount(amountOrNumber);
-        } else {
-            return this.minusAmountToSubtractUnit(amountOrNumber, unit);
-        }
-    }
 
     /**
      * Returns a copy of this year with the specified period subtracted.
@@ -692,7 +637,7 @@ export class Year extends Temporal {
      * @throws DateTimeException if the subtraction cannot be made
      * @throws ArithmeticException if numeric overflow occurs
      */
-    minusAmountToSubtractUnit(amountToSubtract, unit) {
+    minusAmountUnit(amountToSubtract, unit) {
         requireNonNull(amountToSubtract, 'amountToSubtract');
         requireNonNull(unit, 'unit');
         requireInstance(unit, TemporalUnit, 'unit');

--- a/packages/core/src/Year.js
+++ b/packages/core/src/Year.js
@@ -980,6 +980,77 @@ export class Year extends Temporal {
     toJSON() {
         return this.toString();
     }
+
+    /**
+     * Calculates the amount of time until another temporal in terms of the specified unit.
+     * This calculates the amount of time between two temporal objects in terms of a single {@link TemporalUnit}. The start and end points are this and the specified temporal. The end point is converted to be of the same type as the start point if different. The result will be negative if the end is before the start. For example, the amount in hours between two temporal objects can be calculated using `startTime.until(endTime, HOURS)`.
+     *
+     * The calculation returns a whole number, representing the number of complete units between the two temporals. For example, the amount in hours between the times 11:30 and 13:29 will only be one hour as it is one minute short of two hours.
+     *
+     * There are two equivalent ways of using this method. The first is to invoke this method directly. The second is to use `TemporalUnit.between(Temporal, Temporal)`:
+     *
+     * <pre>
+     *    // these two lines are equivalent
+     *    temporal = start.until(end, unit);
+     *    temporal = unit.between(start, end);
+     * </pre>
+     *
+     * The choice should be made based on which makes the code more readable.
+     * For example, this method allows the number of days between two dates to be calculated:
+     *
+     * <pre>
+     *   daysBetween = start.until(end, DAYS);
+     *   // or alternatively
+     *   daysBetween = DAYS.between(start, end);
+     * </pre>
+     *
+     * ### Implementation Requirements:
+     * Implementations must begin by checking to ensure that the input temporal object is of the same observable type as the implementation. They must then perform the calculation for all instances of {@link ChronoUnit}. An {@link UnsupportedTemporalTypeException} must be thrown for {@link ChronoUnit} instances that are unsupported.
+     * If the unit is not a {@link ChronoUnit}, then the result of this method is obtained by invoking `TemporalUnit.between(Temporal, Temporal)` passing this as the first argument and the converted input temporal as the second argument.
+     *
+     * In summary, implementations must behave in a manner equivalent to this pseudo-code:
+     *
+     * <pre>
+     *   // convert the end temporal to the same type as this class
+     *   if (unit instanceof ChronoUnit) {
+     *     // if unit is supported, then calculate and return result
+     *     // else throw UnsupportedTemporalTypeException for unsupported units
+     *   }
+     *   return unit.between(this, convertedEndTemporal);
+     * </pre>
+     *
+     * Note that the unit's between method must only be invoked if the two temporal objects have exactly the same type evaluated by `getClass()`.
+     *
+     * Implementations must ensure that no observable state is altered when this read-only method is invoked.
+     *
+     * @param {Temporal} endExclusive - the end temporal, exclusive, converted to be of the same type as this object, not null
+     * @param {TemporalUnit} unit - the unit to measure the amount in, not null
+     * @return {number} the amount of time between this temporal object and the specified one in terms of the unit; positive if the specified object is later than this one, negative if it is earlier than this one
+     * @throws DateTimeException - if the amount cannot be calculated, or the end temporal cannot be converted to the same type as this temporal
+     * @throws UnsupportedTemporalTypeException - if the unit is not supported
+     * @throws ArithmeticException - if numeric overflow occurs
+     */
+    until(endExclusive, unit) {
+        const end = Year.from(endExclusive);
+
+        if (unit instanceof ChronoUnit) {
+            const yearsUntil = end.value() - this.value();
+            switch (unit) {
+                case ChronoUnit.YEARS:
+                    return yearsUntil;
+                case ChronoUnit.DECADES:
+                    return MathUtil.intDiv(yearsUntil, 10);
+                case ChronoUnit.CENTURIES:
+                    return MathUtil.intDiv(yearsUntil, 100);
+                case ChronoUnit.MILLENNIA:
+                    return MathUtil.intDiv(yearsUntil, 1000);
+                case ChronoUnit.ERAS:
+                    return end.getLong(ChronoField.ERA) - this.getLong(ChronoField.ERA);
+            }
+            throw new UnsupportedTemporalTypeException('Unsupported unit: ' + unit);
+        }
+        return unit.between(this, end);
+    }
 }
 
 let PARSER;

--- a/packages/core/src/YearMonth.js
+++ b/packages/core/src/YearMonth.js
@@ -689,24 +689,6 @@ export class YearMonth extends Temporal {
     }
 
     //-----------------------------------------------------------------------
-    /**
-     * function overloading for {@link YearMonth.plus}
-     *
-     * if called with 1 arguments, then {@link YearMonth.plusAmount} is executed.
-     *
-     * Otherwise {@link YearMonth.plusAmountUnit} is executed.
-     *
-     * @param {!(TemporalAmount|number)} amountOrNumber
-     * @param {?TemporalUnit} unit nullable only if first argument is an instance of TemporalAmount
-     * @returns {YearMonth}
-     */
-    plus(amountOrNumber, unit) {
-        if (arguments.length === 1) {
-            return this.plusAmount(amountOrNumber);
-        } else {
-            return this.plusAmountUnit(amountOrNumber, unit);
-        }
-    }
 
     /**
      * Returns a copy of this year-month with the specified period added.
@@ -792,24 +774,6 @@ export class YearMonth extends Temporal {
     }
 
     //-----------------------------------------------------------------------
-    /**
-     * function overloading for {@link YearMonth.minus}
-     *
-     * if called with 1 arguments, then {@link YearMonth.minusAmount} is executed.
-     *
-     * Otherwise {@link YearMonth.minusAmountUnit} is executed.
-     *
-     * @param {!(TemporalAmount|number)} amountOrNumber
-     * @param {?TemporalUnit} unit
-     * @returns {YearMonth}
-     */
-    minus(amountOrNumber, unit) {
-        if (arguments.length === 1) {
-            return this.minusAmount(amountOrNumber);
-        } else {
-            return this.minusAmountUnit(amountOrNumber, unit);
-        }
-    }
 
     /**
      * Returns a copy of this year-month with the specified period subtracted.

--- a/packages/core/src/ZonedDateTime.js
+++ b/packages/core/src/ZonedDateTime.js
@@ -975,19 +975,6 @@ export class ZonedDateTime extends ChronoZonedDateTime {
     }
 
     //-----------------------------------------------------------------------
-    /**
-     * function overloading for {@link ZonedDateTime.with}
-     *
-     * if called with 1 argument {@link ZonedDateTime.withTemporalAdjuster} is applied
-     * otherwise {@link ZonedDateTime.with2}
-     */
-    with(){
-        if(arguments.length === 1){
-            return this.withTemporalAdjuster.apply(this, arguments);
-        } else {
-            return this.with2.apply(this, arguments);
-        }
-    }
 
     /**
      * Returns an adjusted copy of this date-time.
@@ -1041,7 +1028,7 @@ export class ZonedDateTime extends ChronoZonedDateTime {
      * @throws DateTimeException if the adjustment cannot be made
      * @throws ArithmeticException if numeric overflow occurs
      */
-    withTemporalAdjuster(adjuster) {
+    withAdjuster(adjuster) {
         // optimizations
         if (adjuster instanceof LocalDate) {
             return this._resolveLocal(LocalDateTime.of(adjuster, this._dateTime.toLocalTime()));
@@ -1110,7 +1097,7 @@ export class ZonedDateTime extends ChronoZonedDateTime {
      * @throws UnsupportedTemporalTypeException if the field is not supported
      * @throws ArithmeticException if numeric overflow occurs
      */
-    with2(field, newValue) {
+    withFieldValue(field, newValue) {
         if (field instanceof ChronoField) {
             switch (field) {
                 case ChronoField.INSTANT_SECONDS: return ZonedDateTime._create(newValue, this.nano(), this._zone);
@@ -1336,19 +1323,6 @@ export class ZonedDateTime extends ChronoZonedDateTime {
     }
 
     //-----------------------------------------------------------------------
-    /**
-     * function overloading for {@link ZonedDateTime.plus}
-     *
-     * if called with 1 argument {@link ZonedDateTime.plusTemporalAmount} is applied,
-     * otherwise {@link ZonedDateTime.plus2}
-     */
-    plus(){
-        if(arguments.length === 1){
-            return this.plusTemporalAmount.apply(this, arguments);
-        } else {
-            return this.plus2.apply(this, arguments);
-        }
-    }
 
     /**
      * Returns a copy of this date-time with the specified period added.
@@ -1366,7 +1340,7 @@ export class ZonedDateTime extends ChronoZonedDateTime {
      * @throws DateTimeException if the addition cannot be made
      * @throws ArithmeticException if numeric overflow occurs
      */
-    plusTemporalAmount(amount) {
+    plusAmount(amount) {
         requireNonNull(amount);
         return amount.addTo(this);
     }
@@ -1400,7 +1374,7 @@ export class ZonedDateTime extends ChronoZonedDateTime {
      * @return {ZonedDateTime} a {@link ZonedDateTime} based on this date-time with the specified period added, not null
      * @throws DateTimeException if the unit cannot be added to this type
      */
-    plus2(amountToAdd, unit) {
+    plusAmountUnit(amountToAdd, unit) {
         if (unit instanceof ChronoUnit) {
             if (unit.isDateBased()) {
                 return this._resolveLocal(this._dateTime.plus(amountToAdd, unit));
@@ -1580,19 +1554,6 @@ export class ZonedDateTime extends ChronoZonedDateTime {
     }
 
     //-----------------------------------------------------------------------
-    /**
-     * function overloading for {@link ZonedDateTime.minus}
-     *
-     * if called with 1 argument {@link ZonedDateTime.minusTemporalAmount} is applied,
-     * otherwise {@link ZonedDateTime.minus2}
-     */
-    minus(){
-        if(arguments.length === 1){
-            return this.minusTemporalAmount.apply(this, arguments);
-        } else {
-            return this.minus2.apply(this, arguments);
-        }
-    }
 
     /**
      * Returns a copy of this date-time with the specified period subtracted.
@@ -1610,7 +1571,7 @@ export class ZonedDateTime extends ChronoZonedDateTime {
      * @throws DateTimeException if the subtraction cannot be made
      * @throws ArithmeticException if numeric overflow occurs
      */
-    minusTemporalAmount(amount) {
+    minusAmount(amount) {
         requireNonNull(amount, 'amount');
         return amount.subtractFrom(this);
     }
@@ -1644,8 +1605,8 @@ export class ZonedDateTime extends ChronoZonedDateTime {
      * @return {ZonedDateTime} a {@link ZonedDateTime} based on this date-time with the specified period subtracted, not null
      * @throws DateTimeException if the unit cannot be added to this type
      */
-    minus2(amountToSubtract, unit) {
-        return this.plus2(-1 * amountToSubtract, unit);
+    minusAmountUnit(amountToSubtract, unit) {
+        return this.plusAmountUnit(-1 * amountToSubtract, unit);
     }
 
     //-----------------------------------------------------------------------

--- a/packages/core/src/chrono/ChronoLocalDate.js
+++ b/packages/core/src/chrono/ChronoLocalDate.js
@@ -10,7 +10,7 @@ import {ChronoField} from '../temporal/ChronoField';
 import {ChronoUnit} from '../temporal/ChronoUnit';
 import {DateTimeFormatter} from '../format/DateTimeFormatter';
 import {TemporalQueries} from '../temporal/TemporalQueries';
-import {Temporal} from '../temporal/Temporal';
+import {DefaultInterfaceTemporal} from '../temporal/DefaultInterfaceTemporal';
 
 import {LocalDate} from '../LocalDate';
 
@@ -180,7 +180,7 @@ import {LocalDate} from '../LocalDate';
  * In JDK 8, this is an interface with default methods.
  * Since there are no default methods in JDK 7, an abstract class is used.
  */
-export class ChronoLocalDate extends Temporal {
+export class ChronoLocalDate extends DefaultInterfaceTemporal {
 
     isSupported(fieldOrUnit) {
         if (fieldOrUnit instanceof ChronoField) {

--- a/packages/core/src/chrono/ChronoLocalDateTime.js
+++ b/packages/core/src/chrono/ChronoLocalDateTime.js
@@ -12,7 +12,7 @@ import {Instant} from '../Instant';
 import {ZoneOffset} from '../ZoneOffset';
 import {ChronoUnit} from '../temporal/ChronoUnit';
 import {ChronoField} from '../temporal/ChronoField';
-import {Temporal} from '../temporal/Temporal';
+import {DefaultInterfaceTemporal} from '../temporal/DefaultInterfaceTemporal';
 import {TemporalQueries} from '../temporal/TemporalQueries';
 
 /**
@@ -49,7 +49,7 @@ import {TemporalQueries} from '../temporal/TemporalQueries';
  *
  * @param D the date type
  */
-export class ChronoLocalDateTime extends Temporal {
+export class ChronoLocalDateTime extends DefaultInterfaceTemporal {
     /* <D extends ChronoLocalDate>
         extends DefaultInterfaceTemporal
         implements Temporal, TemporalAdjuster, Comparable<ChronoLocalDateTime<?>> */

--- a/packages/core/src/chrono/ChronoZonedDateTime.js
+++ b/packages/core/src/chrono/ChronoZonedDateTime.js
@@ -10,10 +10,10 @@ import {LocalDate} from '../LocalDate';
 import {MathUtil} from '../MathUtil';
 
 import {ChronoUnit} from '../temporal/ChronoUnit';
-import {Temporal} from '../temporal/Temporal';
+import {DefaultInterfaceTemporal} from '../temporal/DefaultInterfaceTemporal';
 import {TemporalQueries} from '../temporal/TemporalQueries';
 
-export class ChronoZonedDateTime  extends Temporal {
+export class ChronoZonedDateTime  extends DefaultInterfaceTemporal {
     query(query) {
         if (query === TemporalQueries.zoneId() || query === TemporalQueries.zone()) {
             return this.zone();

--- a/packages/core/src/format/DateTimeBuilder.js
+++ b/packages/core/src/format/DateTimeBuilder.js
@@ -14,7 +14,7 @@ import {ResolverStyle} from './ResolverStyle';
 import {IsoChronology} from '../chrono/IsoChronology';
 import {ChronoLocalDate} from '../chrono/ChronoLocalDate';
 import {ChronoField} from '../temporal/ChronoField';
-import {Temporal} from '../temporal/Temporal';
+import {TemporalAccessor} from '../temporal/TemporalAccessor';
 import {TemporalQueries} from '../temporal/TemporalQueries';
 
 import {LocalTime} from '../LocalTime';
@@ -36,7 +36,7 @@ import {ZoneOffset} from '../ZoneOffset';
  *
  *   @private
  */
-export class DateTimeBuilder extends Temporal {
+export class DateTimeBuilder extends TemporalAccessor {
 
     /**
      * Creates a new instance of the builder with a single field-value.

--- a/packages/core/src/temporal/DefaultInterfaceTemporal.js
+++ b/packages/core/src/temporal/DefaultInterfaceTemporal.js
@@ -1,0 +1,118 @@
+import {MAX_SAFE_INTEGER, MIN_SAFE_INTEGER} from '../MathUtil';
+import {requireInstance, requireNonNull} from '../assert';
+import {TemporalAdjuster} from './TemporalAdjuster';
+import {TemporalAmount} from './TemporalAmount';
+import {TemporalUnit} from './TemporalUnit';
+import {Temporal} from './Temporal';
+
+export class DefaultInterfaceTemporal extends Temporal {
+    /**
+     * Returns an adjusted object of the same type as this object with the adjustment made.
+     * This adjusts this date-time according to the rules of the specified adjuster. A simple adjuster might simply set the one of the fields, such as the year field. A more complex adjuster might set the date to the last day of the month. A selection of common adjustments is provided in {@link TemporalAdjusters}. These include finding the "last day of the month" and "next Wednesday". The adjuster is responsible for handling special cases, such as the varying lengths of month and leap years.
+     *
+     * Some example code indicating how and why this method is used:
+     *
+     * <pre>
+     *   date = date.with(Month.JULY);        // most key classes implement TemporalAdjuster
+     *   date = date.with(lastDayOfMonth());  // static import from TemporalAdjusters
+     *   date = date.with(next(WEDNESDAY));   // static import from TemporalAdjusters and DayOfWeek
+     * </pre>
+     *
+     * ### Specification for implementors
+     * Implementations must not alter either this object. Instead, an adjusted copy of the original must be returned. This provides equivalent, safe behavior for immutable and mutable implementations.
+     *
+     * @param {TemporalAdjuster} adjuster - the adjuster to use, not null
+     * @return {Temporal} an object of the same type with the specified adjustment made, not null
+     * @throws DateTimeException - if unable to make the adjustment
+     * @throws ArithmeticException - if numeric overflow occurs
+     */
+    withAdjuster(adjuster) {
+        requireNonNull(adjuster, 'adjuster');
+        requireInstance(adjuster, TemporalAdjuster, 'adjuster');
+        return adjuster.adjustInto(this);
+    }
+
+    /**
+     * Returns an object of the same type as this object with an amount added.
+     * This adjusts this temporal, adding according to the rules of the specified amount. The amount is typically a {@link Period} but may be any other type implementing the {@link TemporalAmount} interface, such as {@link Duration}.
+     *
+     * Some example code indicating how and why this method is used:
+     *
+     * <pre>
+     *   date = date.plus(period);                  // add a Period instance
+     *   date = date.plus(duration);                // add a Duration instance
+     *   date = date.plus(workingDays(6));          // example user-written workingDays method
+     * </pre>
+     *
+     * Note that calling plus followed by minus is not guaranteed to return the same date-time.
+     *
+     * ### Specification for implementors
+     * Implementations must not alter either this object. Instead, an adjusted copy of the original must be returned. This provides equivalent, safe behavior for immutable and mutable implementations.
+     *
+     * @param {TemporalAmount} amount - the amount to add, not null
+     * @return {Temporal} an object of the same type with the specified adjustment made, not null
+     * @throws DateTimeException - if the addition cannot be made
+     * @throws ArithmeticException - if numeric overflow occurs
+     */
+    plusAmount(amount) {
+        requireNonNull(amount, 'amount');
+        requireInstance(amount, TemporalAmount, 'amount');
+        return amount.addTo(this);
+    }
+
+    /**
+     * Returns an object of the same type as this object with an amount subtracted.
+     * This adjusts this temporal, subtracting according to the rules of the specified amount. The
+     * amount is typically a {@link Period} but may be any other type implementing the {@link TemporalAmount} interface, such as Duration.
+     *
+     * Some example code indicating how and why this method is used:
+     *
+     * <pre>
+     *   date = date.minus(period);                  // subtract a Period instance
+     *   date = date.minus(duration);                // subtract a Duration instance
+     *   date = date.minus(workingDays(6));          // example user-written workingDays method
+     * </pre>
+     *
+     * Note that calling plus followed by minus is not guaranteed to return the same date-time.
+     *
+     * ### Specification for implementors
+     * Implementations must not alter either this object. Instead, an adjusted copy of the original
+     * must be returned. This provides equivalent, safe behavior for immutable and mutable
+     * implementations.
+     *
+     * @param {TemporalAmount} amount - the amount to subtract, not null
+     * @return {Temporal} an object of the same type with the specified adjustment made, not null
+     * @throws DateTimeException - if the subtraction cannot be made
+     * @throws ArithmeticException - if numeric overflow occurs
+     */
+    minusAmount(amount) {
+        requireNonNull(amount, 'amount');
+        requireInstance(amount, TemporalAmount, 'amount');
+        return amount.subtractFrom(this);
+    }
+
+    /**
+     * Returns an object of the same type as this object with the specified period subtracted.
+     * This method returns a new object based on this one with the specified period subtracted. For example, on a {@link LocalDate}, this could be used to subtract a number of years, months or days. The returned object will have the same observable type as this object.
+     *
+     * In some cases, changing a field is not fully defined. For example, if the target object is a date representing the 31st March, then subtracting one month would be unclear. In cases like this, the field is responsible for resolving the result. Typically it will choose the previous valid date, which would be the last valid day of February in this example.
+     *
+     * If the implementation represents a date-time that has boundaries, such {@link as} LocalTime, then the permitted units must include the boundary unit, but no multiples of the boundary unit. For example, {@link LocalTime} must accept `DAYS` but not `WEEKS` or `MONTHS`.
+     *
+     * ### Specification for implementors
+     * Implementations must behave in a manor equivalent to the default method behavior.
+     * Implementations must not alter either this object or the specified temporal object. Instead, an adjusted copy of the original must be returned. This provides equivalent, safe behavior for immutable and mutable implementations.
+     *
+     * @param {number} amountToSubtract - the amount of the specified unit to subtract, may be negative
+     * @param {TemporalUnit} unit - the unit of the period to subtract, not null
+     * @return {Temporal} an object of the same type with the specified period subtracted, not null
+     * @throws DateTimeException - if the unit cannot be subtracted
+     * @throws ArithmeticException - if numeric overflow occurs
+     */
+    minusAmountUnit(amountToSubtract, unit) {
+        requireNonNull(amountToSubtract, 'amountToSubtract');
+        requireNonNull(unit, 'unit');
+        requireInstance(unit, TemporalUnit, 'unit');
+        return (amountToSubtract === MIN_SAFE_INTEGER ? this.plusAmountUnit(MAX_SAFE_INTEGER, unit).plusAmountUnit(1, unit) : this.plusAmount(-amountToSubtract, unit));
+    }
+}

--- a/packages/core/src/temporal/Temporal.js
+++ b/packages/core/src/temporal/Temporal.js
@@ -64,21 +64,140 @@ import { abstractMethodFail } from '../assert';
 export class Temporal extends TemporalAccessor {
     /**
      * Checks if the specified unit is supported.
-     * This checks if the specified unit can be added to, or subtracted from, this date-time. If false, then calling the `plus(long, TemporalUnit)` and minus methods will throw an exception.
-     *
-     * ### Implementation Requirements:
-     *
-     * Implementations must check and handle all units defined in {@link ChronoUnit}. If the unit is supported, then true must be returned, otherwise false must be returned.
+     * This checks if the date-time can be queried for the specified unit. If false, then calling the plus and minus methods will throw an exception.
+
+     * ### Specification for implementors
+     * Implementations must check and handle all fields defined in {@link ChronoUnit}. If the field is supported, then true is returned, otherwise false
      * If the field is not a {@link ChronoUnit}, then the result of this method is obtained by invoking `TemporalUnit.isSupportedBy(Temporal)` passing this as the argument.
-     *
-     * Implementations must ensure that no observable state is altered when this read-only method is invoked.
-     *
+
+     * Implementations must not alter this object.
+
      * @param {TemporalUnit} unit - the unit to check, null returns false
-     * @return {boolean} true if the unit can be added/subtracted, false if not
+     * @return {boolean} true if this date-time can be queried for the unit, false if not
      */
     // eslint-disable-next-line no-unused-vars
     isSupported(unit) {
         abstractMethodFail('isSupported');
+    }
+
+    /**
+     * function overloading for {@link Temporal.plus}
+     *
+     * Called with 1 (or less) arguments, p1 is expected to be a {@link TemporalAmount} and {@link Temporal.minusAmount} is called.
+     *
+     * Otherwise {@link Temporal.minusAmountUnit} is called.
+     *
+     * @param {!(TemporalAmount|number)} p1
+     * @param {TemporalUnit} p2
+     * @return {Temporal}
+     */
+    // eslint-disable-next-line no-unused-vars
+    minus(p1, p2) {
+        if (arguments.length < 2) {
+            return this.minusAmount(p1);
+        } else {
+            return this.minusAmountUnit(p1, p2);
+        }
+    }
+
+    /**
+     * Returns an object of the same type as this object with an amount subtracted.
+     * This adjusts this temporal, subtracting according to the rules of the specified amount. The
+     * amount is typically a {@link Period} but may be any other type implementing the {@link TemporalAmount} interface, such as Duration.
+     *
+     * Some example code indicating how and why this method is used:
+     *
+     * <pre>
+     *   date = date.minus(period);                  // subtract a Period instance
+     *   date = date.minus(duration);                // subtract a Duration instance
+     *   date = date.minus(workingDays(6));          // example user-written workingDays method
+     * </pre>
+     *
+     * Note that calling plus followed by minus is not guaranteed to return the same date-time.
+     *
+     * ### Specification for implementors
+     * Implementations must not alter either this object. Instead, an adjusted copy of the original
+     * must be returned. This provides equivalent, safe behavior for immutable and mutable
+     * implementations.
+     *
+     * @param {TemporalAmount} amount - the amount to subtract, not null
+     * @return {Temporal} an object of the same type with the specified adjustment made, not null
+     * @throws DateTimeException - if the subtraction cannot be made
+     * @throws ArithmeticException - if numeric overflow occurs
+     */
+    // eslint-disable-next-line no-unused-vars
+    minusAmount(amount) {
+        abstractMethodFail('minusAmount');
+    }
+
+    /**
+     * Returns an object of the same type as this object with the specified period subtracted.
+     * This method returns a new object based on this one with the specified period subtracted. For example, on a {@link LocalDate}, this could be used to subtract a number of years, months or days. The returned object will have the same observable type as this object.
+     *
+     * In some cases, changing a field is not fully defined. For example, if the target object is a date representing the 31st March, then subtracting one month would be unclear. In cases like this, the field is responsible for resolving the result. Typically it will choose the previous valid date, which would be the last valid day of February in this example.
+     *
+     * If the implementation represents a date-time that has boundaries, such {@link as} LocalTime, then the permitted units must include the boundary unit, but no multiples of the boundary unit. For example, {@link LocalTime} must accept `DAYS` but not `WEEKS` or `MONTHS`.
+     *
+     * ### Specification for implementors
+     * Implementations must behave in a manor equivalent to the default method behavior.
+     * Implementations must not alter either this object or the specified temporal object. Instead, an adjusted copy of the original must be returned. This provides equivalent, safe behavior for immutable and mutable implementations.
+     *
+     * @param {number} amountToSubtract - the amount of the specified unit to subtract, may be negative
+     * @param {TemporalUnit} unit - the unit of the period to subtract, not null
+     * @return {Temporal} an object of the same type with the specified period subtracted, not null
+     * @throws DateTimeException - if the unit cannot be subtracted
+     * @throws ArithmeticException - if numeric overflow occurs
+     */
+    // eslint-disable-next-line no-unused-vars
+    minusAmountUnit(amountToSubtract, unit) {
+        abstractMethodFail('minusAmountUnit');
+    }
+
+    /**
+     * function overloading for {@link Temporal.plus}
+     *
+     * Called with 1 (or less) arguments, p1 is expected to be a {@link TemporalAmount} and {@link Temporal.plusAmount} is called.
+     *
+     * Otherwise {@link Temporal.plusAmountUnit} is called.
+     *
+     * @param {!(TemporalAmount|number)} p1
+     * @param {TemporalUnit} p2
+     * @return {Temporal}
+     */
+    // eslint-disable-next-line no-unused-vars
+    plus(p1, p2) {
+        if (arguments.length < 2) {
+            return this.plusAmount(p1);
+        } else {
+            return this.plusAmountUnit(p1, p2);
+        }
+    }
+
+    /**
+     * Returns an object of the same type as this object with an amount added.
+     * This adjusts this temporal, adding according to the rules of the specified amount. The amount is typically a {@link Period} but may be any other type implementing the {@link TemporalAmount} interface, such as {@link Duration}.
+     *
+     * Some example code indicating how and why this method is used:
+     *
+     * <pre>
+     *   date = date.plus(period);                  // add a Period instance
+     *   date = date.plus(duration);                // add a Duration instance
+     *   date = date.plus(workingDays(6));          // example user-written workingDays method
+     * </pre>
+     *
+     * Note that calling plus followed by minus is not guaranteed to return the same date-time.
+     *
+     * ### Specification for implementors
+     * Implementations must not alter either this object. Instead, an adjusted copy of the original must be returned. This provides equivalent, safe behavior for immutable and mutable implementations.
+     *
+     * @param {TemporalAmount} amount - the amount to add, not null
+     * @return {Temporal} an object of the same type with the specified adjustment made, not null
+     * @throws DateTimeException - if the addition cannot be made
+     * @throws ArithmeticException - if numeric overflow occurs
+     */
+    // eslint-disable-next-line no-unused-vars
+    plusAmount(amount) {
+        abstractMethodFail('plusAmount');
     }
 
     /**
@@ -87,76 +206,119 @@ export class Temporal extends TemporalAccessor {
      *
      * In some cases, changing a field is not fully defined. For example, if the target object is a date representing the 31st January, then adding one month would be unclear. In cases like this, the field is responsible for resolving the result. Typically it will choose the previous valid date, which would be the last valid day of February in this example.
      *
-     * ### Implementation Requirements:
-     * Implementations must check and handle all units defined in {@link ChronoUnit}. If the unit is supported, then the addition must be performed. If unsupported, then an {@link UnsupportedTemporalTypeException} must be thrown.
+     * If the implementation represents a date-time that has boundaries, such as {@link LocalTime}, then the permitted units must include the boundary unit, but no multiples of the boundary unit. For example, {@link LocalTime} must accept `DAYS` but not `WEEKS` or `MONTHS`.
+     *
+     * ### Specification for implementors
+     * Implementations must check and handle all units defined in {@link ChronoUnit}. If the unit is supported, then the addition must be performed. If unsupported, then a {@link DateTimeException} must be thrown.
      * If the unit is not a {@link ChronoUnit}, then the result of this method is obtained by invoking `TemporalUnit.addTo(Temporal, long)` passing this as the first argument.
      *
-     * Implementations must not alter this object. Instead, an adjusted copy of the original must be returned. This provides equivalent, safe behavior for immutable and mutable implementations.
+     * Implementations must not alter either this object or the specified temporal object. Instead, an adjusted copy of the original must be returned. This provides equivalent, safe behavior for immutable and mutable implementations.
      *
      * @param {number} amountToAdd - the amount of the specified unit to add, may be negative
-     * @param {TemporalUnit} unit - the unit of the amount to add, not null
+     * @param {TemporalUnit} unit - the unit of the period to add, not null
      * @return {Temporal} an object of the same type with the specified period added, not null
      * @throws DateTimeException - if the unit cannot be added
-     * @throws UnsupportedTemporalTypeException - if the unit is not supported
      * @throws ArithmeticException - if numeric overflow occurs
      */
     // eslint-disable-next-line no-unused-vars
-    plus(amountToAdd, unit) {
-        abstractMethodFail('plus');
+    plusAmountUnit(amountToAdd, unit) {
+        abstractMethodFail('plusAmountUnit');
     }
 
     /**
-     * Calculates the amount of time until another temporal in terms of the specified unit.
-     * This calculates the amount of time between two temporal objects in terms of a single {@link TemporalUnit}. The start and end points are this and the specified temporal. The end point is converted to be of the same type as the start point if different. The result will be negative if the end is before the start. For example, the amount in hours between two temporal objects can be calculated using `startTime.until(endTime, HOURS)`.
+     * Calculates the period between this temporal and another temporal in terms of the specified unit.
+     * This calculates the period between two temporals in terms of a single unit. The start and end points are this and the specified temporal. The result will be negative if the end is before the start. For example, the period in hours between two temporal objects can be calculated using `startTime.until(endTime, HOURS)`.
      *
-     * The calculation returns a whole number, representing the number of complete units between the two temporals. For example, the amount in hours between the times 11:30 and 13:29 will only be one hour as it is one minute short of two hours.
+     * The calculation returns a whole number, representing the number of complete units between the two temporals. For example, the period in hours between the times 11:30 and 13:29 will only be one hour as it is one minute short of two hours.
      *
      * There are two equivalent ways of using this method. The first is to invoke this method directly. The second is to use `TemporalUnit.between(Temporal, Temporal)`:
      *
      * <pre>
      *    // these two lines are equivalent
-     *    temporal = start.until(end, unit);
-     *    temporal = unit.between(start, end);
+     *    between = thisUnit.between(start, end);
+     *    between = start.until(end, thisUnit);
      * </pre>
      *
      * The choice should be made based on which makes the code more readable.
      * For example, this method allows the number of days between two dates to be calculated:
      *
      * <pre>
-     *   daysBetween = start.until(end, DAYS);
-     *   // or alternatively
-     *   daysBetween = DAYS.between(start, end);
+     *    long daysBetween = DAYS.between(start, end);
+     *    // or alternatively
+     *    long daysBetween = start.until(end, DAYS);
      * </pre>
      *
-     * ### Implementation Requirements:
-     * Implementations must begin by checking to ensure that the input temporal object is of the same observable type as the implementation. They must then perform the calculation for all instances of {@link ChronoUnit}. An {@link UnsupportedTemporalTypeException} must be thrown for {@link ChronoUnit} instances that are unsupported.
-     * If the unit is not a {@link ChronoUnit}, then the result of this method is obtained by invoking `TemporalUnit.between(Temporal, Temporal)` passing this as the first argument and the converted input temporal as the second argument.
+     * ### Specification for implementors
+     * Implementations must begin by checking to ensure that the input temporal object is of the same observable type as the implementation. They must then perform the calculation for all instances of {@link ChronoUnit}. A {@link DateTimeException} must be thrown for {@link ChronoUnit} instances that are unsupported.
+     * If the unit is not a {@link ChronoUnit}, then the result of this method is obtained by invoking `TemporalUnit.between(Temporal, Temporal)` passing this as the first argument and the input temporal as the second argument.
      *
-     * In summary, implementations must behave in a manner equivalent to this pseudo-code:
+     * In summary, implementations must behave in a manner equivalent to this code:
      *
      * <pre>
-     *   // convert the end temporal to the same type as this class
+     *   // check input temporal is the same type as this class
      *   if (unit instanceof ChronoUnit) {
      *     // if unit is supported, then calculate and return result
-     *     // else throw UnsupportedTemporalTypeException for unsupported units
+     *     // else throw DateTimeException for unsupported units
      *   }
-     *   return unit.between(this, convertedEndTemporal);
+     *   return unit.between(this, endTemporal);
      * </pre>
      *
-     * Note that the unit's between method must only be invoked if the two temporal objects have exactly the same type evaluated by `getClass()`.
+     * The target object must not be altered by this method.
      *
-     * Implementations must ensure that no observable state is altered when this read-only method is invoked.
-     *
-     * @param {Temporal} endExclusive - the end temporal, exclusive, converted to be of the same type as this object, not null
-     * @param {TemporalUnit} unit - the unit to measure the amount in, not null
-     * @return {number} the amount of time between this temporal object and the specified one in terms of the unit; positive if the specified object is later than this one, negative if it is earlier than this one
-     * @throws DateTimeException - if the amount cannot be calculated, or the end temporal cannot be converted to the same type as this temporal
-     * @throws UnsupportedTemporalTypeException - if the unit is not supported
+     * @param {Temporal} endTemporal - the end temporal, of the same type as this object, not null
+     * @param {TemporalUnit} unit - the unit to measure the period in, not null
+     * @return {number} the amount of the period between this and the end
+     * @throws DateTimeException - if the period cannot be calculated
      * @throws ArithmeticException - if numeric overflow occurs
      */
     // eslint-disable-next-line no-unused-vars
-    until(endExclusive, unit) {
+    until(endTemporal, unit) {
         abstractMethodFail('until');
+    }
+
+    /**
+     * function overloading for {@link Temporal.with}
+     *
+     * Called with 1 (or less) arguments, p1 is expected to be a {@link TemporalAdjuster} and {@link Temporal.withAdjuster} is called.
+     *
+     * Otherwise {@link Temporal.withFieldValue} is called.
+     *
+     * @param {!(TemporalAdjuster|TemporalField)} p1
+     * @param {number} p2
+     * @return {Temporal}
+     */
+    // eslint-disable-next-line no-unused-vars
+    with(p1, p2) {
+        if (arguments.length < 2) {
+            return this.withAdjuster(p1);
+        } else {
+            return this.withFieldValue(p1, p2);
+        }
+    }
+
+    /**
+     * Returns an adjusted object of the same type as this object with the adjustment made.
+     * This adjusts this date-time according to the rules of the specified adjuster. A simple adjuster might simply set the one of the fields, such as the year field. A more complex adjuster might set the date to the last day of the month. A selection of common adjustments is provided in {@link TemporalAdjusters}. These include finding the "last day of the month" and "next Wednesday". The adjuster is responsible for handling special cases, such as the varying lengths of month and leap years.
+     *
+     * Some example code indicating how and why this method is used:
+     *
+     * <pre>
+     *   date = date.with(Month.JULY);        // most key classes implement TemporalAdjuster
+     *   date = date.with(lastDayOfMonth());  // static import from TemporalAdjusters
+     *   date = date.with(next(WEDNESDAY));   // static import from TemporalAdjusters and DayOfWeek
+     * </pre>
+     *
+     * ### Specification for implementors
+     * Implementations must not alter either this object. Instead, an adjusted copy of the original must be returned. This provides equivalent, safe behavior for immutable and mutable implementations.
+     *
+     * @param {TemporalAdjuster} adjuster - the adjuster to use, not null
+     * @return {Temporal} an object of the same type with the specified adjustment made, not null
+     * @throws DateTimeException - if unable to make the adjustment
+     * @throws ArithmeticException - if numeric overflow occurs
+     */
+    // eslint-disable-next-line no-unused-vars
+    withAdjuster(adjuster) {
+        abstractMethodFail('withAdjuster');
     }
 
     /**
@@ -165,21 +327,20 @@ export class Temporal extends TemporalAccessor {
      *
      * In some cases, changing a field is not fully defined. For example, if the target object is a date representing the 31st January, then changing the month to February would be unclear. In cases like this, the field is responsible for resolving the result. Typically it will choose the previous valid date, which would be the last valid day of February in this example.
      *
-     * ### Implementation Requirements:
-     * Implementations must check and handle all fields defined in {@link ChronoField}. If the field is supported, then the adjustment must be performed. If unsupported, then an {@link UnsupportedTemporalTypeException} must be thrown.
+     * ### Specification for implementors
+     * Implementations must check and handle all fields defined in {@link ChronoField}. If the field is supported, then the adjustment must be performed. If unsupported, then a {@link DateTimeException} must be thrown.
      * If the field is not a {@link ChronoField}, then the result of this method is obtained by invoking `TemporalField.adjustInto(Temporal, long)` passing this as the first argument.
      *
-     * Implementations must not alter this object. Instead, an adjusted copy of the original must be returned. This provides equivalent, safe behavior for immutable and mutable implementations.
+     * Implementations must not alter either this object or the specified temporal object. Instead, an adjusted copy of the original must be returned. This provides equivalent, safe behavior for immutable and mutable implementations.
      *
      * @param {TemporalField} field - the field to set in the result, not null
      * @param {number} newValue - the new value of the field in the result
      * @return {Temporal} an object of the same type with the specified field set, not null
      * @throws DateTimeException - if the field cannot be set
-     * @throws UnsupportedTemporalTypeException - if the field is not supported
      * @throws ArithmeticException - if numeric overflow occurs
      */
     // eslint-disable-next-line no-unused-vars
-    with(field, newValue) {
-        abstractMethodFail('with');
+    withFieldValue(field, newValue) {
+        abstractMethodFail('withFieldValue');
     }
 }

--- a/packages/core/src/temporal/Temporal.js
+++ b/packages/core/src/temporal/Temporal.js
@@ -5,6 +5,7 @@
  */
 
 import {TemporalAccessor} from './TemporalAccessor';
+import { abstractMethodFail } from '../assert';
 
 /**
  * Framework-level interface defining read-write access to a temporal object,
@@ -60,4 +61,125 @@ import {TemporalAccessor} from './TemporalAccessor';
  *
  * @interface
  */
-export class Temporal extends TemporalAccessor {}
+export class Temporal extends TemporalAccessor {
+    /**
+     * Checks if the specified unit is supported.
+     * This checks if the specified unit can be added to, or subtracted from, this date-time. If false, then calling the `plus(long, TemporalUnit)` and minus methods will throw an exception.
+     *
+     * ### Implementation Requirements:
+     *
+     * Implementations must check and handle all units defined in {@link ChronoUnit}. If the unit is supported, then true must be returned, otherwise false must be returned.
+     * If the field is not a {@link ChronoUnit}, then the result of this method is obtained by invoking `TemporalUnit.isSupportedBy(Temporal)` passing this as the argument.
+     *
+     * Implementations must ensure that no observable state is altered when this read-only method is invoked.
+     *
+     * @param {TemporalUnit} unit - the unit to check, null returns false
+     * @return {boolean} true if the unit can be added/subtracted, false if not
+     */
+    // eslint-disable-next-line no-unused-vars
+    isSupported(unit) {
+        abstractMethodFail('isSupported');
+    }
+
+    /**
+     * Returns an object of the same type as this object with the specified period added.
+     * This method returns a new object based on this one with the specified period added. For example, on a {@link LocalDate}, this could be used to add a number of years, months or days. The returned object will have the same observable type as this object.
+     *
+     * In some cases, changing a field is not fully defined. For example, if the target object is a date representing the 31st January, then adding one month would be unclear. In cases like this, the field is responsible for resolving the result. Typically it will choose the previous valid date, which would be the last valid day of February in this example.
+     *
+     * ### Implementation Requirements:
+     * Implementations must check and handle all units defined in {@link ChronoUnit}. If the unit is supported, then the addition must be performed. If unsupported, then an {@link UnsupportedTemporalTypeException} must be thrown.
+     * If the unit is not a {@link ChronoUnit}, then the result of this method is obtained by invoking `TemporalUnit.addTo(Temporal, long)` passing this as the first argument.
+     *
+     * Implementations must not alter this object. Instead, an adjusted copy of the original must be returned. This provides equivalent, safe behavior for immutable and mutable implementations.
+     *
+     * @param {number} amountToAdd - the amount of the specified unit to add, may be negative
+     * @param {TemporalUnit} unit - the unit of the amount to add, not null
+     * @return {Temporal} an object of the same type with the specified period added, not null
+     * @throws DateTimeException - if the unit cannot be added
+     * @throws UnsupportedTemporalTypeException - if the unit is not supported
+     * @throws ArithmeticException - if numeric overflow occurs
+     */
+    // eslint-disable-next-line no-unused-vars
+    plus(amountToAdd, unit) {
+        abstractMethodFail('plus');
+    }
+
+    /**
+     * Calculates the amount of time until another temporal in terms of the specified unit.
+     * This calculates the amount of time between two temporal objects in terms of a single {@link TemporalUnit}. The start and end points are this and the specified temporal. The end point is converted to be of the same type as the start point if different. The result will be negative if the end is before the start. For example, the amount in hours between two temporal objects can be calculated using `startTime.until(endTime, HOURS)`.
+     *
+     * The calculation returns a whole number, representing the number of complete units between the two temporals. For example, the amount in hours between the times 11:30 and 13:29 will only be one hour as it is one minute short of two hours.
+     *
+     * There are two equivalent ways of using this method. The first is to invoke this method directly. The second is to use `TemporalUnit.between(Temporal, Temporal)`:
+     *
+     * <pre>
+     *    // these two lines are equivalent
+     *    temporal = start.until(end, unit);
+     *    temporal = unit.between(start, end);
+     * </pre>
+     *
+     * The choice should be made based on which makes the code more readable.
+     * For example, this method allows the number of days between two dates to be calculated:
+     *
+     * <pre>
+     *   daysBetween = start.until(end, DAYS);
+     *   // or alternatively
+     *   daysBetween = DAYS.between(start, end);
+     * </pre>
+     *
+     * ### Implementation Requirements:
+     * Implementations must begin by checking to ensure that the input temporal object is of the same observable type as the implementation. They must then perform the calculation for all instances of {@link ChronoUnit}. An {@link UnsupportedTemporalTypeException} must be thrown for {@link ChronoUnit} instances that are unsupported.
+     * If the unit is not a {@link ChronoUnit}, then the result of this method is obtained by invoking `TemporalUnit.between(Temporal, Temporal)` passing this as the first argument and the converted input temporal as the second argument.
+     *
+     * In summary, implementations must behave in a manner equivalent to this pseudo-code:
+     *
+     * <pre>
+     *   // convert the end temporal to the same type as this class
+     *   if (unit instanceof ChronoUnit) {
+     *     // if unit is supported, then calculate and return result
+     *     // else throw UnsupportedTemporalTypeException for unsupported units
+     *   }
+     *   return unit.between(this, convertedEndTemporal);
+     * </pre>
+     *
+     * Note that the unit's between method must only be invoked if the two temporal objects have exactly the same type evaluated by `getClass()`.
+     *
+     * Implementations must ensure that no observable state is altered when this read-only method is invoked.
+     *
+     * @param {Temporal} endExclusive - the end temporal, exclusive, converted to be of the same type as this object, not null
+     * @param {TemporalUnit} unit - the unit to measure the amount in, not null
+     * @return {number} the amount of time between this temporal object and the specified one in terms of the unit; positive if the specified object is later than this one, negative if it is earlier than this one
+     * @throws DateTimeException - if the amount cannot be calculated, or the end temporal cannot be converted to the same type as this temporal
+     * @throws UnsupportedTemporalTypeException - if the unit is not supported
+     * @throws ArithmeticException - if numeric overflow occurs
+     */
+    // eslint-disable-next-line no-unused-vars
+    until(endExclusive, unit) {
+        abstractMethodFail('until');
+    }
+
+    /**
+     * Returns an object of the same type as this object with the specified field altered.
+     * This returns a new object based on this one with the value for the specified field changed. For example, on a {@link LocalDate}, this could be used to set the year, month or day-of-month. The returned object will have the same observable type as this object.
+     *
+     * In some cases, changing a field is not fully defined. For example, if the target object is a date representing the 31st January, then changing the month to February would be unclear. In cases like this, the field is responsible for resolving the result. Typically it will choose the previous valid date, which would be the last valid day of February in this example.
+     *
+     * ### Implementation Requirements:
+     * Implementations must check and handle all fields defined in {@link ChronoField}. If the field is supported, then the adjustment must be performed. If unsupported, then an {@link UnsupportedTemporalTypeException} must be thrown.
+     * If the field is not a {@link ChronoField}, then the result of this method is obtained by invoking `TemporalField.adjustInto(Temporal, long)` passing this as the first argument.
+     *
+     * Implementations must not alter this object. Instead, an adjusted copy of the original must be returned. This provides equivalent, safe behavior for immutable and mutable implementations.
+     *
+     * @param {TemporalField} field - the field to set in the result, not null
+     * @param {number} newValue - the new value of the field in the result
+     * @return {Temporal} an object of the same type with the specified field set, not null
+     * @throws DateTimeException - if the field cannot be set
+     * @throws UnsupportedTemporalTypeException - if the field is not supported
+     * @throws ArithmeticException - if numeric overflow occurs
+     */
+    // eslint-disable-next-line no-unused-vars
+    with(field, newValue) {
+        abstractMethodFail('with');
+    }
+}

--- a/packages/core/test/LocalTimeTest.js
+++ b/packages/core/test/LocalTimeTest.js
@@ -192,19 +192,19 @@ describe('js-joda LocalTime', () => {
         // directly use the "overloaded" function to make sure we test the correct one :)
         it('should fail if field is null', () => {
             expect(() => {
-                testTime.with2(null, 1);
+                testTime.withFieldValue(null, 1);
             }).to.throw(NullPointerException);
         });
         
         it('should fail for unsupported ChronoField', () => {
             expect(() => {
-                testTime.with2(ChronoField.DAY_OF_MONTH, 1);
+                testTime.withFieldValue(ChronoField.DAY_OF_MONTH, 1);
             }).to.throw(UnsupportedTemporalTypeException);
         });
         
         it('should fail if field is not a TemporalField', () => {
             expect(() => {
-                testTime.with2({}, 1);
+                testTime.withFieldValue({}, 1);
             }).to.throw(IllegalArgumentException);
         });
         

--- a/packages/core/test/reference/temporal/MockFieldValue.js
+++ b/packages/core/test/reference/temporal/MockFieldValue.js
@@ -6,12 +6,12 @@
 
 import {DateTimeException} from '../../../src/errors';
 import {ChronoField} from '../../../src/temporal/ChronoField';
-import {Temporal} from '../../../src/temporal/Temporal';
+import {TemporalAccessor} from '../../../src/temporal/TemporalAccessor';
 
 /**
  * Mock simple date-time with one field-value.
  */
-export class MockFieldValue extends Temporal {
+export class MockFieldValue extends TemporalAccessor {
 
     constructor(field, value) {
         super();

--- a/packages/core/test/temporal/TemporalTest.js
+++ b/packages/core/test/temporal/TemporalTest.js
@@ -1,0 +1,95 @@
+import { expect } from 'chai';
+
+import '../_init';
+
+import {LocalDate} from '../../src/LocalDate';
+import {ChronoUnit} from '../../src/temporal/ChronoUnit';
+import {Period} from '../../src/Period';
+import {ChronoField} from '../../src/temporal/ChronoField';
+
+describe('js-joda Temporal', () => {
+    describe('isSupported', () => {
+        const temporal = LocalDate.of(2019, 5, 4);
+
+        it('should return true for supported units', () => {
+            expect(temporal.isSupported(ChronoUnit.DECADES)).to.equal(true);
+            expect(temporal.isSupported(ChronoUnit.YEARS)).to.equal(true);
+            expect(temporal.isSupported(ChronoUnit.MONTHS)).to.equal(true);
+            expect(temporal.isSupported(ChronoUnit.DAYS)).to.equal(true);
+        });
+
+        it('should return false for unsupported units', () => {
+            expect(temporal.isSupported(ChronoUnit.HOURS)).to.equal(false);
+            expect(temporal.isSupported(ChronoUnit.MINUTES)).to.equal(false);
+            expect(temporal.isSupported(ChronoUnit.SECONDS)).to.equal(false);
+            expect(temporal.isSupported(ChronoUnit.MILLIS)).to.equal(false);
+        });
+    });
+
+    describe('minus', () => {
+        const temporal = LocalDate.of(2019, 5, 4);
+
+        it('should subtract a temporal amount', () => {
+            const result = temporal.minus(Period.ofMonths(2));
+
+            expect(LocalDate.of(2019, 3, 4).equals(result)).to.equal(true);
+        });
+
+        it('should subtract a value of a given unit', () => {
+            const result = temporal.minus(2, ChronoUnit.MONTHS);
+
+            expect(LocalDate.of(2019, 3, 4).equals(result)).to.equal(true);
+        });
+    });
+
+    describe('plus', () => {
+        const temporal = LocalDate.of(2019, 5, 4);
+
+        it('should add a temporal amount', () => {
+            const result = temporal.plus(Period.ofMonths(2));
+
+            expect(LocalDate.of(2019, 7, 4).equals(result)).to.equal(true);
+        });
+
+        it('should add a value of a given unit', () => {
+            const result = temporal.plus(2, ChronoUnit.MONTHS);
+
+            expect(LocalDate.of(2019, 7, 4).equals(result)).to.equal(true);
+        });
+    });
+
+    describe('until', () => {
+        const temporal = LocalDate.of(2019, 5, 4);
+
+        it('should return the difference in a given unit', () => {
+            const result = temporal.until(LocalDate.of(2020, 1, 4), ChronoUnit.MONTHS);
+
+            expect(result).to.equal(8);
+        });
+    });
+
+    describe('with', () => {
+        const temporal = LocalDate.of(2019, 5, 4);
+
+        it('should be adjusted by a temporal adjuster', () => {
+            const nextYearAdjuster = {
+                adjustInto(temporal) {
+                    if (temporal.isSupported(ChronoUnit.YEARS)) {
+                        return temporal.plus(1, ChronoUnit.YEARS);
+                    }
+                    throw new Error('unsupported');
+                }
+            };
+
+            const result = temporal.with(nextYearAdjuster);
+
+            expect(LocalDate.of(2020, 5, 4).equals(result)).to.equal(true);
+        });
+
+        it('should change the given field', () => {
+            const result = temporal.with(ChronoField.MONTH_OF_YEAR, 10);
+
+            expect(LocalDate.of(2019, 10, 4).equals(result)).to.equal(true);
+        });
+    });
+});

--- a/packages/core/test/typescript_definitions/js-joda-tests.ts
+++ b/packages/core/test/typescript_definitions/js-joda-tests.ts
@@ -17,6 +17,8 @@ import {
     Period,
     ResolverStyle,
     SignStyle,
+    Temporal,
+    TemporalAdjuster,
     TemporalAdjusters,
     Year,
     YearMonth,
@@ -700,3 +702,29 @@ function test_Clock() {
  * Don't let TypeScript infer the type, give it explicitly.
  */
 declare function expectType<T>(v: T): T;
+
+function test_Temporal() {
+  const temporal: Temporal = Year.now();
+
+  temporal.isSupported(ChronoUnit.YEARS);
+
+  temporal.minus(4, ChronoUnit.YEARS);
+  temporal.minus(Period.ofYears(4));
+
+  temporal.plus(4, ChronoUnit.YEARS);
+  temporal.plus(Period.ofYears(4));
+
+  temporal.until(Year.of(2020), ChronoUnit.YEARS);
+
+  const nextYear: TemporalAdjuster = {
+    adjustInto(temporal: Temporal): Temporal {
+      if (temporal.isSupported(ChronoUnit.YEARS)) {
+        return temporal.plus(1, ChronoUnit.YEARS);
+      }
+      throw new Error('unsupported')
+    }
+  }
+
+  temporal.with(nextYear);
+  temporal.with(ChronoField.YEAR, 2020);
+}


### PR DESCRIPTION
The `Temporal` interface was missing some methods which are necessary to work with `Temporal` objects. This resolves #360.

This PR adds the abstract methods defined in the [`java.time` API for `Temporal`](https://docs.oracle.com/javase/8/docs/api/java/time/temporal/Temporal.html). Additionally, to be more consistent with the `java.time` API, the superclass of some classes has been adjusted from `Temporal` to `TemporalAccessor`