### PR TITLE
Add Typescript for IsoChronology.INSTANCE

### DIFF
--- a/packages/core/dist/js-joda.d.ts
+++ b/packages/core/dist/js-joda.d.ts
@@ -1091,6 +1091,8 @@ export interface Locale {
 }
 
 export abstract class IsoChronology {
+    static INSTANCE: IsoChronology;
+
     static isLeapYear(prolepticYear: number): boolean;
 
     private constructor();


### PR DESCRIPTION
Allow this to pass Typescript type checking:

```ts
const timestamptzFormatter = new DateTimeFormatterBuilder()
  .parseCaseInsensitive()
  .append(timestampFormatter)
  .appendOffset('+HH:mm', 'Z')
  .toFormatter(ResolverStyle.STRICT)
  .withChronology(IsoChronology.INSTANCE);
```

While this is created during the `_init` it is not exposed via typescript. 