### PR TITLE
changed bitwise or to logical or

### DIFF
--- a/packages/core/src/Period.js
+++ b/packages/core/src/Period.js
@@ -76,7 +76,7 @@ export class Period extends TemporalAmount /* extends ChronoPeriod */ {
         const _months =  MathUtil.safeToInt(months);
         const _days = MathUtil.safeToInt(days);
 
-        if((_years || _months || _days) === 0){
+        if( _years === 0 && _months === 0 && _days === 0 ){
             if (!Period.ZERO) {
                 this._years = _years;
                 this._months =  _months;

--- a/packages/core/src/Period.js
+++ b/packages/core/src/Period.js
@@ -76,7 +76,7 @@ export class Period extends TemporalAmount /* extends ChronoPeriod */ {
         const _months =  MathUtil.safeToInt(months);
         const _days = MathUtil.safeToInt(days);
 
-        if((_years | _months | _days) === 0){
+        if((_years || _months || _days) === 0){
             if (!Period.ZERO) {
                 this._years = _years;
                 this._months =  _months;


### PR DESCRIPTION
To allow for safer parsing of integers, in JavaScript, the bitwise or (`|`) operator was switched to the logical or (`||`) operator.

Although this is different from the implementation in the threetenbp -https://github.com/ThreeTen/threetenbp/blob/master/src/main/java/org/threeten/bp/Period.java#L348 repository this change makes more sense in JavaScript since there is only the concept of a double.