### PR TITLE
Add config for fr-FR, sv and sv-SE locales

### DIFF
--- a/packages/locale/build_package.prebuilt.json
+++ b/packages/locale/build_package.prebuilt.json
@@ -24,12 +24,23 @@
         "fr": [
             "fr.*"
         ],
+        "fr-fr": [
+            "fr",
+            "fr-FR"
+        ],
         "it": [
             "it.*"
         ],
         "it-it": [
             "it",
             "it-IT"
+        ],
+        "sv": [
+            "sv.*"
+        ],
+        "sv-se": [
+            "sv",
+            "sv-SE"
         ],
         "zh": [
             "zh.*"


### PR DESCRIPTION
Adds config for the locales I suggested in #384. I'm only planning to use the fr-FR and sv-SE locales, but I included sv as well to match the other locales.