### PR TITLE
Fixed types of DateTimeFormatterBuilder.prototype.toFormatter to allow zero arguments

### DIFF
--- a/packages/core/dist/js-joda.d.ts
+++ b/packages/core/dist/js-joda.d.ts
@@ -266,7 +266,7 @@ export class DateTimeFormatterBuilder {
     parseCaseSensitive(): DateTimeFormatterBuilder;
     parseLenient(): DateTimeFormatterBuilder;
     parseStrict(): DateTimeFormatterBuilder;
-    toFormatter(resolverStyle: ResolverStyle): DateTimeFormatter;
+    toFormatter(resolverStyle?: ResolverStyle): DateTimeFormatter;
 }
 
 // TODO: js-joda doesn't have Chronology yet. Methods like `LocalDate.chronology()`

--- a/packages/core/test/typescript_definitions/js-joda-tests.ts
+++ b/packages/core/test/typescript_definitions/js-joda-tests.ts
@@ -672,6 +672,9 @@ function test_DateTimeFormatterBuilder() {
         .appendPattern("yyyy-MM-dd HH:mm:ss")
         .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, true)
         .toFormatter(ResolverStyle.LENIENT);
+    const formatter5: DateTimeFormatter = new DateTimeFormatterBuilder()
+        .appendPattern("yyyy-MM-dd HH:mm:ss")
+        .toFormatter();
 }
 
 function test_DateTimeParseException() {


### PR DESCRIPTION
Previously the parameter `resolverStyle` was required.