### PR TITLE
Some fixes to TS declarations

### DIFF
--- a/packages/core/dist/js-joda.d.ts
+++ b/packages/core/dist/js-joda.d.ts
@@ -117,9 +117,12 @@ export class Duration extends TemporalAmount {
     get(unit: TemporalUnit): number;
     isNegative(): boolean;
     isZero(): boolean;
-    minus(durationOrNumber: Duration | number, unit: ChronoUnit): Duration;
+    minus(duration: Duration): Duration;
+    minus(amount: number, unit: ChronoUnit): Duration;
+    // TODO: Internal. Remove in next major version.
     minusAmountUnit(amountToSubtract: number, unit: TemporalUnit): Duration;
     minusDays(daysToSubtract: number): Duration;
+    // TODO: Internal. Remove in next major version.
     minusDuration(duration: Duration): Duration;
     minusHours(hoursToSubtract: number): Duration;
     minusMillis(millisToSubtract: number): Duration;
@@ -129,9 +132,12 @@ export class Duration extends TemporalAmount {
     multipliedBy(multiplicand: number): Duration;
     nano(): number;
     negated(): Duration;
-    plus(durationOrNumber: Duration | number, unitOrNumber: TemporalUnit | number): Duration;
+    plus(duration: Duration): Duration;
+    plus(amount: number, unit: ChronoUnit): Duration;
+    // TODO: Internal. Remove in next major version.
     plusAmountUnit(amountToAdd: number, unit: TemporalUnit): Duration;
     plusDays(daysToAdd: number): Duration;
+    // TODO: Internal. Remove in next major version.
     plusDuration(duration: Duration): Duration;
     plusHours(hoursToAdd: number): Duration;
     plusMillis(millisToAdd: number): Duration;
@@ -292,7 +298,7 @@ export class LocalTime extends Temporal implements TemporalAdjuster {
     static NANOS_PER_HOUR: number;
     static NANOS_PER_DAY: number;
 
-    static FROM: TemporalQuery<LocalDate>;
+    static FROM: TemporalQuery<LocalTime>;
 
     static from(temporal: TemporalAccessor): LocalTime;
     static now(clockOrZone?: Clock | ZoneId): LocalTime;
@@ -390,7 +396,7 @@ export class Month extends TemporalAccessor implements TemporalAdjuster {
 }
 
 export class MonthDay extends TemporalAccessor implements TemporalAdjuster {
-    static FROM: TemporalQuery<LocalDate>;
+    static FROM: TemporalQuery<MonthDay>;
 
     static from(temporal: TemporalAccessor): MonthDay;
     static now(zoneIdOrClock?: ZoneId | Clock): MonthDay;
@@ -802,7 +808,7 @@ export class Year extends Temporal implements TemporalAdjuster {
     static MIN_VALUE: number;
     static MAX_VALUE: number;
 
-    static FROM: TemporalQuery<LocalDate>;
+    static FROM: TemporalQuery<Year>;
 
     static from(temporal: TemporalAccessor): Year;
     static isLeap(year: number): boolean;
@@ -835,7 +841,7 @@ export class Year extends Temporal implements TemporalAdjuster {
 }
 
 export class YearMonth extends Temporal implements TemporalAdjuster {
-    static FROM: TemporalQuery<LocalDate>;
+    static FROM: TemporalQuery<YearMonth>;
 
     static from(temporal: TemporalAccessor): YearMonth;
     static now(zoneIdOrClock?: ZoneId | Clock): YearMonth;
@@ -994,7 +1000,7 @@ export abstract class ChronoZonedDateTime extends Temporal {
 }
 
 export class ZonedDateTime extends ChronoZonedDateTime {
-    static FROM: TemporalQuery<LocalDate>;
+    static FROM: TemporalQuery<ZonedDateTime>;
 
     static from(temporal: TemporalAccessor): ZonedDateTime;
     static now(clockOrZone?: Clock | ZoneId): ZonedDateTime;
@@ -1027,6 +1033,7 @@ export class ZonedDateTime extends ChronoZonedDateTime {
     minusMonths(months: number): ZonedDateTime;
     minusNanos(nanos: number): ZonedDateTime;
     minusSeconds(seconds: number): ZonedDateTime;
+    // TODO: Internal. Remove in next major version.
     minusTemporalAmount(amount: TemporalAmount): ZonedDateTime;
     minusWeeks(weeks: number): ZonedDateTime;
     minusYears(years: number): ZonedDateTime;
@@ -1043,6 +1050,7 @@ export class ZonedDateTime extends ChronoZonedDateTime {
     plusMonths(months: number): ZonedDateTime;
     plusNanos(nanos: number): ZonedDateTime;
     plusSeconds(seconds: number): ZonedDateTime;
+    // TODO: Internal. Remove in next major version.
     plusTemporalAmount(amount: TemporalAmount): ZonedDateTime;
     plusWeeks(weeks: number): ZonedDateTime;
     plusYears(years: number): ZonedDateTime;
@@ -1060,8 +1068,10 @@ export class ZonedDateTime extends ChronoZonedDateTime {
     with(field: TemporalField, newValue: number): ZonedDateTime;
     withDayOfMonth(dayOfMonth: number): ZonedDateTime;
     withDayOfYear(dayOfYear: number): ZonedDateTime;
+    withEarlierOffsetAtOverlap(): ZonedDateTime;
     withFixedOffsetZone(): ZonedDateTime;
     withHour(hour: number): ZonedDateTime;
+    withLaterOffsetAtOverlap(): ZonedDateTime;
     withMinute(minute: number): ZonedDateTime;
     withMonth(month: number): ZonedDateTime;
     withNano(nanoOfSecond: number): ZonedDateTime;

--- a/packages/core/test/typescript_definitions/js-joda-tests.ts
+++ b/packages/core/test/typescript_definitions/js-joda-tests.ts
@@ -162,6 +162,8 @@ function test_LocalDate() {
     d.with(TemporalAdjusters.next(DayOfWeek.SATURDAY));
     d.with(TemporalAdjusters.lastInMonth(DayOfWeek.SATURDAY));
     d.with(TemporalAdjusters.firstInMonth(DayOfWeek.SATURDAY));
+
+    expectType<LocalDate>(d1.query(LocalDate.FROM));
 }
 
 function test_Instant() {
@@ -257,6 +259,8 @@ function test_LocalTime() {
     t = LocalTime.ofInstant(Instant.ofEpochMilli(new Date().getTime()));
     t = LocalTime.from(nativeJs(new Date()));
     t = LocalTime.from(nativeJs(moment()));
+
+    expectType<LocalTime>(t1.query(LocalTime.FROM));
 }
 
 function test_LocalDateTime() {
@@ -404,6 +408,8 @@ function test_LocalDateTime() {
     dt = LocalDateTime.ofInstant(Instant.ofEpochMilli(new Date().getTime()));
     dt = LocalDateTime.from(nativeJs(new Date()));
     dt = LocalDateTime.from(nativeJs(moment()));
+
+    expectType<LocalDateTime>(dt.query(LocalDateTime.FROM));
 }
 
 function test_ZonedDateTime() {
@@ -429,22 +435,23 @@ function test_ZonedDateTime() {
     ZonedDateTime.ofLocal(LocalDateTime.now(), ZoneId.SYSTEM, null)
     ZonedDateTime.ofLocal(LocalDateTime.now(), ZoneId.UTC, ZoneOffset.UTC)
 
-    var d = LocalDate.of(2016, 3, 18);
-    var zdt = d.atTime(LocalTime.NOON).atZone(ZoneId.of('UTC-05:00'));
+    var zdt = LocalDate.of(2016, 3, 18)
+        .atTime(LocalTime.NOON)
+        .atZone(ZoneId.of("UTC-05:00"));
 
     zdt.withZoneSameLocal(ZoneId.UTC);
-
     zdt.withZoneSameInstant(ZoneId.UTC);
 
-
-    var zdt = ZonedDateTime.now();
-
     zdt.plusWeeks(2);
-
     zdt.plusHours(2 * 7 * 24);
-
     zdt.plus(Duration.ofDays(1));
     zdt.minus(Duration.ofDays(1));
+    zdt.minus(5, ChronoUnit.WEEKS);
+
+    expectType<ZonedDateTime>(zdt.withEarlierOffsetAtOverlap());
+    expectType<ZonedDateTime>(zdt.withLaterOffsetAtOverlap());
+
+    expectType<ZonedDateTime>(zdt.query(ZonedDateTime.FROM));
 }
 
 function test_ZoneOffsetTransition() {
@@ -529,6 +536,12 @@ function test_Duration() {
     var dt1 = LocalDateTime.parse('2012-12-24T12:00');
 
     Duration.between(dt1, dt1.plusHours(10)).toString();
+
+    const dur = Duration.ofSeconds(1);
+    expectType<Duration>(dur.minus(Duration.ofNanos(1)));
+    expectType<Duration>(dur.minus(1, ChronoUnit.NANOS));
+    expectType<Duration>(dur.plus(Duration.ofNanos(1)));
+    expectType<Duration>(dur.plus(1, ChronoUnit.NANOS));
 }
 
 function test_Year() {
@@ -555,6 +568,8 @@ function test_Year() {
     year.minusYears(3);
 
     year.with(ChronoField.YEAR, 2015);
+
+    expectType<Year>(year.query(Year.FROM));
 }
 
 function test_YearMonth() {
@@ -594,34 +609,24 @@ function test_YearMonth() {
     ym.isSupported(ChronoUnit.YEARS);
 
     ym.year();
-
     ym.monthValue();
-
     ym.month();
-
     ym.isLeapYear();
-
     ym.isValidDay();
-
     ym.lengthOfMonth();
-
     ym.lengthOfYear();
-
     ym.atDay(10);
-
     ym.atEndOfMonth();
-
     ym.compareTo(YearMonth.of(2017, 20));
-
     ym.isAfter(YearMonth.of(2017, 20));
-
     ym.isBefore(YearMonth.of(2017, 20));
-
     ym.equals(YearMonth.of(2017, 20));
 
     ym.toJSON();
 
     ym.format(DateTimeFormatter.ofPattern('yyyy-MM'));
+
+    expectType<YearMonth>(ym.query(YearMonth.FROM));
 }
 
 function test_DateTimeFormatter() {
@@ -698,6 +703,12 @@ function test_Month() {
     expectType<boolean>(Month.OCTOBER.equals(Month.NOVEMBER));
 
     expectType<Month>(Month.valueOf('FEBRUARY'));
+}
+
+function test_MonthDay() {
+    const md = MonthDay.now();
+    
+    expectType<MonthDay>(md.query(MonthDay.FROM));
 }
 
 function test_Clock() {


### PR DESCRIPTION
- Some `FROM` static properties were correctly typed as `TemporalQuery` but for the wrong `Temporal`.
- `Duration` were missing methods `minus` and `plus` with a single `Duration`. The old methods were also wrong since `plus` previously accepted two arguments of type `number`.
- `ZonedDateTime` were missing methods `withEarlierOffsetAtOverlap` and `withLaterOffsetAtOverlap`.

All of them were fixed and tests added. Also I left some TODO comments for methods that are meant to be internal only, like `minusDuration` or `plusTemporalAmount`. This should be removed in the next major version since TS user could be relying on them. Or, if you want, I can remove them in this PR.