### PR TITLE
Error base name changed to "JsJodaException" and exceptions exposed in TS

### DIFF
--- a/packages/core/dist/js-joda.d.ts
+++ b/packages/core/dist/js-joda.d.ts
@@ -1124,18 +1124,29 @@ export function convert(
 
 export function use(plugin: Function): any;
 
-export class DateTimeParseException extends Error {
-    constructor(message?: string);
-}
-
 export class ZoneRulesProvider {
     static getRules(zoneId: string): ZoneRules;
     static getAvailableZoneIds(): string[];
 }
 
 export class DateTimeException extends Error {
-    constructor(message?: string);
+    constructor(message?: string, cause?: Error);
 }
+
+export class UnsupportedTemporalTypeException extends DateTimeException {}
+
+export class DateTimeParseException extends Error {
+    constructor(message?: string, text?: string, index?: number, cause?: Error);
+
+    parsedString(): string;
+    errorIndex(): number;
+}
+
+export class ArithmeticException extends Error {}
+export class IllegalArgumentException extends Error {}
+export class IllegalStateException extends Error {}
+export class NullPointerException extends Error {}
+
 
 export const __esModule: true;
 export as namespace JSJoda;

--- a/packages/core/src/errors.js
+++ b/packages/core/src/errors.js
@@ -4,8 +4,8 @@
  */
 
 function createErrorType(name, init, superErrorClass = Error) {
-    function E(message) {
-        if (!Error.captureStackTrace){
+    function JsJodaException(message) {
+        if (!Error.captureStackTrace) {
             this.stack = (new Error()).stack;
         } else {
             Error.captureStackTrace(this, this.constructor);
@@ -16,10 +16,10 @@ function createErrorType(name, init, superErrorClass = Error) {
             return `${this.name}: ${this.message}`;
         };
     }
-    E.prototype = new superErrorClass();
-    E.prototype.name = name;
-    E.prototype.constructor = E;
-    return E;
+    JsJodaException.prototype = Object.create(superErrorClass.prototype);
+    JsJodaException.prototype.name = name;
+    JsJodaException.prototype.constructor = JsJodaException;
+    return JsJodaException;
 }
 
 export const DateTimeException = createErrorType('DateTimeException', messageWithCause);

--- a/packages/core/test/typescript_definitions/js-joda-tests.ts
+++ b/packages/core/test/typescript_definitions/js-joda-tests.ts
@@ -31,6 +31,12 @@ import {
     ZoneOffsetTransitionRule,
     TemporalQueries,
     TemporalUnit,
+    ArithmeticException,
+    IllegalArgumentException,
+    IllegalStateException,
+    NullPointerException,
+    DateTimeException,
+    UnsupportedTemporalTypeException,
 } from '../../'
 
 // used below
@@ -682,10 +688,6 @@ function test_DateTimeFormatterBuilder() {
         .toFormatter();
 }
 
-function test_DateTimeParseException() {
-    new DateTimeParseException();
-}
-
 function test_ZoneId() {
     var zoneId = ZoneId.SYSTEM;
 
@@ -790,6 +792,45 @@ function test_TemporalQuery() {
     fmt.parse('', Year.FROM);
     fmt.parse('', YearMonth.FROM);
     fmt.parse('', ZonedDateTime.FROM);
+}
+
+
+function test_exceptions() {
+    try {
+        // imagine a not-so-good code that throws...
+    } catch (error) {
+        if (error instanceof ArithmeticException) {
+            expectType<string>(error.message);
+        }
+        else if (error instanceof IllegalArgumentException) {
+            expectType<string>(error.message);
+        }
+        else if (error instanceof IllegalStateException) {
+            expectType<string>(error.message);
+        }
+        else if (error instanceof NullPointerException) {
+            expectType<string>(error.message);
+        }
+        else if (error instanceof DateTimeException) {
+            expectType<string>(error.message);
+        }
+        else if (error instanceof UnsupportedTemporalTypeException) {
+            expectType<string>(error.message);
+            // notice this is assignable to DateTimeException since is
+            // a subtype.
+            expectType<DateTimeException>(error);
+        }
+        else if (error instanceof DateTimeParseException) {
+            expectType<string>(error.message);
+            expectType<string>(error.parsedString());
+            expectType<number>(error.errorIndex());
+        }
+    }
+
+    const e1 = new DateTimeException('message');
+    const e2 = new DateTimeParseException('message', 'text', 0, e1);
+    new DateTimeException();
+    new DateTimeParseException();
 }
 
 /**


### PR DESCRIPTION
The name of the function that is base of the rest of errors was previously `E`. The problem is that the name of the constructor function is usually exposed when inspecting through the console, and `E` is not very very descriptive. There are some tricks to compute dynamically the name of a function based on a given value, but those doesn't play well in ES5 environments. Instead, I changed the name of the function to `JsJodaException` that is more descriptive of where the error comes from if it is just console.logged.

I also added type declarations for exceptions classes as they can be used for user to check the name or via `instanceof`.