### PR TITLE
Fixes and cleanups to TemporalFields and TemporalUnits

### DIFF
--- a/packages/core/dist/js-joda.d.ts
+++ b/packages/core/dist/js-joda.d.ts
@@ -464,36 +464,247 @@ export abstract class TemporalField {
  * The standard set of fields can be extended by implementing {@link TemporalField}.
  */
 export class ChronoField extends TemporalField {
-    static NANO_OF_SECOND: ChronoField;
-    static NANO_OF_DAY: ChronoField;
-    static MICRO_OF_SECOND: ChronoField;
-    static MICRO_OF_DAY: ChronoField;
-    static MILLI_OF_SECOND: ChronoField;
-    static MILLI_OF_DAY: ChronoField;
-    static SECOND_OF_MINUTE: ChronoField;
-    static SECOND_OF_DAY: ChronoField;
-    static MINUTE_OF_HOUR: ChronoField;
-    static MINUTE_OF_DAY: ChronoField;
-    static HOUR_OF_AMPM: ChronoField;
-    static CLOCK_HOUR_OF_AMPM: ChronoField;
-    static HOUR_OF_DAY: ChronoField;
-    static CLOCK_HOUR_OF_DAY: ChronoField;
-    static AMPM_OF_DAY: ChronoField;
-    static DAY_OF_WEEK: ChronoField;
+    /**
+     * This represents concept of the count of
+     * days within the period of a week where the weeks are aligned to the start of the month.
+     * This field is typically used with `ALIGNED_WEEK_OF_MONTH`.
+     */
     static ALIGNED_DAY_OF_WEEK_IN_MONTH: ChronoField;
+    /**
+     * This represents concept of the count of days
+     * within the period of a week where the weeks are aligned to the start of the year.
+     * This field is typically used with `ALIGNED_WEEK_OF_YEAR`.
+     */
     static ALIGNED_DAY_OF_WEEK_IN_YEAR: ChronoField;
-    static DAY_OF_MONTH: ChronoField;
-    static DAY_OF_YEAR: ChronoField;
-    static EPOCH_DAY: ChronoField;
+    /**
+     * This represents concept of the count of weeks within
+     * the period of a month where the weeks are aligned to the start of the month. This field
+     * is typically used with `ALIGNED_DAY_OF_WEEK_IN_MONTH`.
+     */
     static ALIGNED_WEEK_OF_MONTH: ChronoField;
+    /**
+     * his represents concept of the count of weeks within
+     * the period of a year where the weeks are aligned to the start of the year. This field
+     * is typically used with `ALIGNED_DAY_OF_WEEK_IN_YEAR`.
+     */
     static ALIGNED_WEEK_OF_YEAR: ChronoField;
-    static MONTH_OF_YEAR: ChronoField;
-    static PROLEPTIC_MONTH: ChronoField;
-    static YEAR_OF_ERA: ChronoField;
-    static YEAR: ChronoField;
+    /**
+     * This counts the AM/PM within the day, from 0 (AM) to 1 (PM).
+     */
+    static AMPM_OF_DAY: ChronoField;
+    /**
+     * This counts the hour within the AM/PM, from 1 to 12.
+     * This is the hour that would be observed on a standard 12-hour analog wall clock.
+     */
+    static CLOCK_HOUR_OF_AMPM: ChronoField;
+    /**
+     * This counts the hour within the AM/PM, from 1 to 24.
+     * This is the hour that would be observed on a 24-hour analog wall clock.
+     */
+    static CLOCK_HOUR_OF_DAY: ChronoField;
+    /**
+     * This represents the concept of the day within the month.
+     * In the default ISO calendar system, this has values from 1 to 31 in most months.
+     * April, June, September, November have days from 1 to 30, while February has days from
+     * 1 to 28, or 29 in a leap year.
+     */
+    static DAY_OF_MONTH: ChronoField;
+    /**
+     * This represents the standard concept of the day of the week.
+     * In the default ISO calendar system, this has values from Monday (1) to Sunday (7).
+     * The {@link DayOfWeek} class can be used to interpret the result.
+     */
+    static DAY_OF_WEEK: ChronoField;
+    /**
+     * This represents the concept of the day within the year.
+     * In the default ISO calendar system, this has values from 1 to 365 in standard years and
+     * 1 to 366 in leap years.
+     */
+    static DAY_OF_YEAR: ChronoField;
+    /**
+     * This field is the sequential count of days where
+     * 1970-01-01 (ISO) is zero. Note that this uses the local time-line, ignoring offset and
+     * time-zone.
+     */
+    static EPOCH_DAY: ChronoField;
+    /**
+     * This represents the concept of the era, which is the largest
+     * division of the time-line. This field is typically used with `YEAR_OF_ERA`.
+     * 
+     * In the default ISO calendar system, there are two eras defined, 'BCE' and 'CE'. The era
+     * 'CE' is the one currently in use and year-of-era runs from 1 to the maximum value.
+     * The era 'BCE' is the previous era, and the year-of-era runs backwards.
+     */
     static ERA: ChronoField;
+    /**
+     * This counts the hour within the AM/PM, from 0 to 11.
+     * This is the hour that would be observed on a standard 12-hour digital clock.
+     */
+    static HOUR_OF_AMPM: ChronoField;
+    /**
+     * This counts the hour within the day, from 0 to 23. This is
+     * the hour that would be observed on a standard 24-hour digital clock.
+     */
+    static HOUR_OF_DAY: ChronoField;
+    /**
+     * This represents the concept of the sequential count of
+     * seconds where `1970-01-01T00:00Z` (ISO) is zero. This field may be used with `NANO_OF_DAY`
+     * to represent the fraction of the day.
+     * 
+     * An Instant represents an instantaneous point on the time-line. On their own they have
+     * no elements which allow a local date-time to be obtained. Only when paired with an offset
+     * or time-zone can the local date or time be found. This field allows the seconds part of
+     * the instant to be queried.
+     */
     static INSTANT_SECONDS: ChronoField;
+    /**
+     * This counts the microsecond within the day, from `0` to
+     * `(24 * 60 * 60 * 1_000_000) - 1`.
+     * 
+     * This field is used to represent the micro-of-day handling any fraction of the second.
+     * Implementations of {@link TemporalAccessor} should provide a value for this field if they
+     * can return a value for `SECOND_OF_DAY` filling unknown precision with zero.
+     * 
+     * When this field is used for setting a value, it should behave in the same way as
+     * setting `NANO_OF_DAY` with the value multiplied by 1,000.
+     */
+    static MICRO_OF_DAY: ChronoField;
+    /**
+     * This counts the microsecond within the second, from 0 to 999,999.
+     * 
+     * This field is used to represent the micro-of-second handling any fraction of the second.
+     * Implementations of {@link TemporalAccessor} should provide a value for this field if they
+     * can return a value for `SECOND_OF_MINUTE`, `SECOND_OF_DAY` or `INSTANT_SECONDS` filling
+     * unknown precision with zero.
+     */
+    static MICRO_OF_SECOND: ChronoField;
+    /**
+     * This counts the millisecond within the day, from 0 to
+     * `(24 * 60 * 60 * 1,000) - 1`.
+     * 
+     * This field is used to represent the milli-of-day handling any fraction of the second.
+     * Implementations of {@link TemporalAccessor} should provide a value for this field if they
+     * can return a value for `SECOND_OF_DAY` filling unknown precision with zero.
+     * 
+     * When this field is used for setting a value, it should behave in the same way as
+     * setting `NANO_OF_DAY` with the value multiplied by 1,000,000.
+     */
+    static MILLI_OF_DAY: ChronoField;
+    /**
+     * This counts the millisecond within the second, from 0 to
+     * 999.
+     * 
+     * This field is used to represent the milli-of-second handling any fraction of the second.
+     * Implementations of {@link TemporalAccessor} should provide a value for this field if they can
+     * return a value for `SECOND_OF_MINUTE`, `SECOND_OF_DAY` or `INSTANT_SECONDS` filling unknown
+     * precision with zero.
+     * 
+     * When this field is used for setting a value, it should behave in the same way as
+     * setting `NANO_OF_SECOND` with the value multiplied by 1,000,000.
+     */
+    static MILLI_OF_SECOND: ChronoField;
+    /**
+     * This counts the minute within the day, from 0 to `(24 * 60) - 1`.
+     */
+    static MINUTE_OF_DAY: ChronoField;
+    /**
+     * This counts the minute within the hour, from 0 to 59.
+     */
+    static MINUTE_OF_HOUR: ChronoField;
+    /**
+     * The month-of-year, such as March. This represents the concept
+     * of the month within the year. In the default ISO calendar system, this has values from
+     * January (1) to December (12).
+     */
+    static MONTH_OF_YEAR: ChronoField;
+    /**
+     * This counts the nanosecond within the day, from 0 to
+     * `(24 * 60 * 60 * 1,000,000,000) - 1`.
+     * 
+     * This field is used to represent the nano-of-day handling any fraction of the second.
+     * Implementations of {@link TemporalAccessor} should provide a value for this field if they
+     * can return a value for `SECOND_OF_DAY` filling unknown precision with zero.
+     */
+    static NANO_OF_DAY: ChronoField;
+    /**
+     * This counts the nanosecond within the second, from 0
+     * to 999,999,999.
+     * 
+     * This field is used to represent the nano-of-second handling any fraction of the second.
+     * Implementations of {@link TemporalAccessor} should provide a value for this field if they
+     * can return a value for `SECOND_OF_MINUTE`, `SECOND_OF_DAY` or `INSTANT_SECONDS` filling
+     * unknown precision with zero.
+     * 
+     * When this field is used for setting a value, it should set as much precision as the
+     * object stores, using integer division to remove excess precision. For example, if the
+     * {@link TemporalAccessor} stores time to millisecond precision, then the nano-of-second must
+     * be divided by 1,000,000 before replacing the milli-of-second.
+     */
+    static NANO_OF_SECOND: ChronoField;
+    /**
+     * This represents the concept of the offset in seconds of
+     * local time from UTC/Greenwich.
+     * 
+     * A {@link ZoneOffset} represents the period of time that local time differs from
+     * UTC/Greenwich. This is usually a fixed number of hours and minutes. It is equivalent to
+     * the total amount of the offset in seconds. For example, during the winter Paris has an
+     * offset of +01:00, which is 3600 seconds.
+     */
     static OFFSET_SECONDS: ChronoField;
+    /**
+     * The proleptic-month, which counts months sequentially
+     * from year 0.
+     * 
+     * The first month in year zero has the value zero. The value increase for later months
+     * and decrease for earlier ones. Note that this uses the local time-line, ignoring offset
+     * and time-zone.
+     */
+    static PROLEPTIC_MONTH: ChronoField;
+    /**
+     * This counts the second within the day, from 0 to
+     * (24 * 60 * 60) - 1.
+     */
+    static SECOND_OF_DAY: ChronoField;
+    /**
+     * This counts the second within the minute, from 0 to 59.
+     */
+    static SECOND_OF_MINUTE: ChronoField;
+    /**
+     * The proleptic year, such as 2012. This represents the concept of
+     * the year, counting sequentially and using negative numbers. The proleptic year is not
+     * interpreted in terms of the era.
+     * 
+     * The standard mental model for a date is based on three concepts - year, month and day.
+     * These map onto the `YEAR`, `MONTH_OF_YEAR` and `DAY_OF_MONTH` fields. Note that there is no
+     * reference to eras. The full model for a date requires four concepts - era, year, month and
+     * day. These map onto the `ERA`, `YEAR_OF_ERA`, `MONTH_OF_YEAR` and `DAY_OF_MONTH` fields.
+     * Whether this field or `YEAR_OF_ERA` is used depends on which mental model is being used.
+     */
+    static YEAR: ChronoField;
+    /**
+     * This represents the concept of the year within the era. This
+     * field is typically used with `ERA`. The standard mental model for a date is based on three
+     * concepts - year, month and day. These map onto the `YEAR`, `MONTH_OF_YEAR` and
+     * `DAY_OF_MONTH` fields. Note that there is no reference to eras. The full model for a date
+     * requires four concepts - era, year, month and day. These map onto the `ERA`, `YEAR_OF_ERA`,
+     * `MONTH_OF_YEAR` and `DAY_OF_MONTH` fields. Whether this field or `YEAR` is used depends on
+     * which mental model is being used.
+     * 
+     * In the default ISO calendar system, there are two eras defined, 'BCE' and 'CE'.
+     * The era 'CE' is the one currently in use and year-of-era runs from 1 to the maximum value.
+     * The era 'BCE' is the previous era, and the year-of-era runs backwards.
+     * 
+     * For example, subtracting a year each time yield the following:
+     * - year-proleptic 2 = 'CE' year-of-era 2
+     * - year-proleptic 1 = 'CE' year-of-era 1
+     * - year-proleptic 0 = 'BCE' year-of-era 1
+     * - year-proleptic -1 = 'BCE' year-of-era 2
+     * 
+     * Note that the ISO-8601 standard does not actually define eras. Note also that the
+     * ISO eras do not align with the well-known AD/BC eras due to the change between the Julian
+     * and Gregorian calendar systems.
+     */
+    static YEAR_OF_ERA: ChronoField;
 
     private constructor();
 
@@ -524,11 +735,49 @@ export class ChronoField extends TemporalField {
  * including quarter-of-year and week-based-year.
  */
 export namespace IsoFields {
+    /**
+     * This field allows the day-of-quarter value to be queried and set. The day-of-quarter has
+     * values from 1 to 90 in Q1 of a standard year, from 1 to 91 in Q1 of a leap year, from
+     * 1 to 91 in Q2 and from 1 to 92 in Q3 and Q4.
+     * 
+     * The day-of-quarter can only be calculated if the day-of-year, month-of-year and year are available.
+     * 
+     * When setting this field, the value is allowed to be partially lenient, taking any value from
+     * 1 to 92. If the quarter has less than 92 days, then day 92, and potentially day 91, is in
+     * the following quarter.
+     */
     export const DAY_OF_QUARTER: TemporalField;
+    /**
+     * This field allows the quarter-of-year value to be queried and set. The quarter-of-year has
+     * values from 1 to 4.
+     * 
+     * The day-of-quarter can only be calculated if the month-of-year is available.
+     */
     export const QUARTER_OF_YEAR: TemporalField;
+    /**
+     * The field that represents the week-of-week-based-year.
+     */
     export const WEEK_OF_WEEK_BASED_YEAR: TemporalField;
+    /**
+     * The field that represents the week-based-year.
+     */
     export const WEEK_BASED_YEAR: TemporalField;
+    /**
+     * The unit that represents week-based-years for the purpose of addition and subtraction.
+     * 
+     * This allows a number of week-based-years to be added to, or subtracted from, a date.
+     * The unit is equal to either 52 or 53 weeks. The estimated duration of a week-based-year is
+     * the same as that of a standard ISO year at 365.2425 Days.
+     * 
+     * The rules for addition add the number of week-based-years to the existing value for the
+     * week-based-year field. If the resulting week-based-year only has 52 weeks, then the date
+     * will be in week 1 of the following week-based-year.
+     */
     export const WEEK_BASED_YEARS: TemporalUnit;
+    /**
+     * Unit that represents the concept of a quarter-year. For the ISO calendar system, it is equal
+     * to 3 months. The estimated duration of a quarter-year is one quarter of 365.2425 days.
+     */
     export const QUARTER_YEARS: TemporalUnit;
 }
 

--- a/packages/core/dist/js-joda.d.ts
+++ b/packages/core/dist/js-joda.d.ts
@@ -1150,13 +1150,13 @@ export class ValueRange {
     private constructor();
 
     checkValidIntValue(value: number, field: TemporalField): number;
-    checkValidValue(value: number, field: TemporalField): any;
+    checkValidValue(value: number, field: TemporalField): number;
     equals(other: any): boolean;
     hashCode(): number;
     isFixed(): boolean;
     isIntValue(): boolean;
     isValidIntValue(value: number): boolean;
-    isValidValue(value: any): boolean;
+    isValidValue(value: number): boolean;
     largestMinimum(): number;
     maximum(): number;
     minimum(): number;

--- a/packages/core/dist/js-joda.d.ts
+++ b/packages/core/dist/js-joda.d.ts
@@ -427,12 +427,42 @@ export class MonthDay extends TemporalAccessor implements TemporalAdjuster {
     withMonth(month: number): MonthDay;
 }
 
+/**
+ * A field of date-time, such as month-of-year or hour-of-minute.
+ */
 export abstract class TemporalField {
+    /** Checks if this field is supported by the temporal object. */
+    abstract isSupportedBy(temporal: TemporalAccessor): boolean;
+    /** Checks if this field represents a component of a date. */
     abstract isDateBased(): boolean;
+    /** Checks if this field represents a component of a time. */
     abstract isTimeBased(): boolean;
+    /** Gets the unit that the field is measured in. */
+    abstract baseUnit(): TemporalUnit;
+    /** Gets the range that the field is bound by. */
+    abstract rangeUnit(): TemporalUnit;
+    /** Gets the range of valid values for the field. */
+    abstract range(): ValueRange;
+    /** 
+     * Get the range of valid values for this field using the temporal object to
+     * refine the result.
+     */
+    abstract rangeRefinedBy(temporal: TemporalAccessor): ValueRange;
+    /** Gets the value of this field from the specified temporal object. */
+    abstract getFrom(temporal: TemporalAccessor): number;
+    /** Returns a copy of the specified temporal object with the value of this field set. */
+    abstract adjustInto<R extends Temporal>(temporal: R, newValue: number): R;
     abstract name(): string;
+    abstract displayName(/* TODO: locale */): string;
+    abstract equals(other: any): boolean;
 }
 
+/**
+ A standard set of fields.
+ *
+ * This set of fields provide field-based access to manipulate a date, time or date-time.
+ * The standard set of fields can be extended by implementing {@link TemporalField}.
+ */
 export class ChronoField extends TemporalField {
     static NANO_OF_SECOND: ChronoField;
     static NANO_OF_DAY: ChronoField;
@@ -467,9 +497,15 @@ export class ChronoField extends TemporalField {
 
     private constructor();
 
-    baseUnit(): number;
+    isSupportedBy(temporal: TemporalAccessor): boolean;
+    baseUnit(): TemporalUnit;
+    /** Checks that the specified value is valid for this field. */
+    checkValidValue(value: number): number;
+    /**
+     * Checks that the specified value is valid for this field and
+     * is within the range of a safe integer.
+     */
     checkValidIntValue(value: number): number;
-    checkValidValue(value: number): any;
     displayName(): string;
     equals(other: any): boolean;
     getFrom(temporal: TemporalAccessor): number;
@@ -478,31 +514,22 @@ export class ChronoField extends TemporalField {
     name(): string;
     range(): ValueRange;
     rangeRefinedBy(temporal: TemporalAccessor): ValueRange;
-    rangeUnit(): number;
+    rangeUnit(): TemporalUnit;
+    adjustInto<R extends Temporal>(temporal: R, newValue: number): R;
     toString(): string;
 }
 
+/**
+ * Fields and units specific to the ISO-8601 calendar system,
+ * including quarter-of-year and week-based-year.
+ */
 export namespace IsoFields {
-    // TODO: Get rid of this class and typed all constants as TemporalField once
-    // the base class is ready and fixed (getDisplayName)
-    class Field extends TemporalField {
-        private constructor();
-
-        isDateBased(): boolean;
-        isTimeBased(): boolean;
-        name(): string;
-        getDisplayName(): string;
-    }
-
-    export const DAY_OF_QUARTER: Field;
-    export const QUARTER_OF_YEAR: Field;
-    export const WEEK_OF_WEEK_BASED_YEAR: Field;
-    export const WEEK_BASED_YEAR: Field;
+    export const DAY_OF_QUARTER: TemporalField;
+    export const QUARTER_OF_YEAR: TemporalField;
+    export const WEEK_OF_WEEK_BASED_YEAR: TemporalField;
+    export const WEEK_BASED_YEAR: TemporalField;
     export const WEEK_BASED_YEARS: TemporalUnit;
     export const QUARTER_YEARS: TemporalUnit;
-
-    // This allows non-exported types, otherwise everyting is exported
-    export {};
 }
 
 export abstract class TemporalUnit {
@@ -552,7 +579,7 @@ export abstract class ChronoLocalDate extends Temporal implements TemporalAdjust
     isSupported(fieldOrUnit: TemporalField | TemporalUnit): boolean;
 }
 
-export class LocalDate extends ChronoLocalDate  implements TemporalAdjuster {
+export class LocalDate extends ChronoLocalDate implements TemporalAdjuster {
     static MIN: LocalDate;
     static MAX: LocalDate;
     static EPOCH_0: LocalDate;

--- a/packages/core/dist/js-joda.d.ts
+++ b/packages/core/dist/js-joda.d.ts
@@ -75,7 +75,7 @@ export class DayOfWeek extends TemporalAccessor implements TemporalAdjuster {
     adjustInto(temporal: Temporal): Temporal;
     compareTo(other: DayOfWeek): number;
     equals(other: any): boolean;
-    getDisplayName(style: TextStyle, locale: Locale): string;
+    displayName(style: TextStyle, locale: Locale): string;
     getLong(field: TemporalField): number;
     isSupported(field: TemporalField): boolean;
     minus(days: number): DayOfWeek;
@@ -380,7 +380,7 @@ export class Month extends TemporalAccessor implements TemporalAdjuster {
     firstDayOfYear(leapYear: boolean): number;
     firstMonthOfQuarter(): Month;
     get(field: TemporalField): number;
-    getDisplayName(style: TextStyle, locale: Locale): string;
+    displayName(style: TextStyle, locale: Locale): string;
     getLong(field: TemporalField): number;
     isSupported(field: TemporalField): boolean;
     length(leapYear: boolean): number;

--- a/packages/core/dist/js-joda.d.ts
+++ b/packages/core/dist/js-joda.d.ts
@@ -782,37 +782,121 @@ export namespace IsoFields {
 }
 
 export abstract class TemporalUnit {
+    /** Returns a copy of the specified temporal object with the specified period added. */
     abstract addTo<T extends Temporal>(temporal: T, amount: number): T;
+    /**
+     * Calculates the period in terms of this unit between two temporal objects of the same type.
+     * 
+     * Returns the period between temporal1 and temporal2 in terms of this unit; a positive number
+     * if `temporal2` is later than `temporal1`, negative if earlier.
+     */
     abstract between(temporal1: Temporal, temporal2: Temporal): number;
+    /** Gets the duration of this unit, which may be an estimate. */
     abstract duration(): Duration;
+    /** Checks if this unit is date-based. */
     abstract isDateBased(): boolean;
+    /** Checks if the duration of the unit is an estimate. */
     abstract isDurationEstimated(): boolean;
+    /** Checks if this unit is supported by the specified temporal object. */
     abstract isSupportedBy(temporal: Temporal): boolean;
+    /** Checks if this unit is time-based. */
     abstract isTimeBased(): boolean;
 }
 
 export class ChronoUnit extends TemporalUnit {
+    /**
+     * Unit that represents the concept of a nanosecond, the smallest supported unit
+     * of time. For the ISO calendar system, it is equal to the 1,000,000,000th part of the second unit.
+     */
     static NANOS: ChronoUnit;
+    /**
+     * Unit that represents the concept of a microsecond. For the ISO calendar
+     * system, it is equal to the 1,000,000th part of the second unit.
+     */
     static MICROS: ChronoUnit;
+    /**
+     * Unit that represents the concept of a millisecond. For the ISO calendar
+     * system, it is equal to the 1000th part of the second unit.
+     */
     static MILLIS: ChronoUnit;
+    /**
+     * Unit that represents the concept of a second. For the ISO calendar system,
+     * it is equal to the second in the SI system of units, except around a leap-second.
+     */
     static SECONDS: ChronoUnit;
+    /**
+     * Unit that represents the concept of a minute. For the ISO calendar system,
+     * it is equal to 60 seconds.
+     */
     static MINUTES: ChronoUnit;
+    /**
+     * Unit that represents the concept of an hour. For the ISO calendar system,
+     * it is equal to 60 minutes.
+     */
     static HOURS: ChronoUnit;
+    /**
+     * Unit that represents the concept of half a day, as used in AM/PM. For
+     * the ISO calendar system, it is equal to 12 hours.
+     */
     static HALF_DAYS: ChronoUnit;
+    /**
+     * Unit that represents the concept of a day. For the ISO calendar system, it
+     * is the standard day from midnight to midnight. The estimated duration of a day is 24 Hours.
+     */
     static DAYS: ChronoUnit;
+    /**
+     * Unit that represents the concept of a week. For the ISO calendar system,
+     * it is equal to 7 Days.
+     */
     static WEEKS: ChronoUnit;
+    /**
+     * Unit that represents the concept of a month. For the ISO calendar system,
+     * the length of the month varies by month-of-year. The estimated duration of a month is
+     * one twelfth of 365.2425 Days.
+     */
     static MONTHS: ChronoUnit;
+    /**
+     * Unit that represents the concept of a year. For the ISO calendar system, it
+     * is equal to 12 months. The estimated duration of a year is 365.2425 Days.
+     */
     static YEARS: ChronoUnit;
+    /**
+     * Unit that represents the concept of a decade. For the ISO calendar system,
+     * it is equal to 10 years.
+     */
     static DECADES: ChronoUnit;
+    /**
+     * Unit that represents the concept of a century. For the ISO calendar
+     * system, it is equal to 100 years.
+     */
     static CENTURIES: ChronoUnit;
+    /**
+     * Unit that represents the concept of a millennium. For the ISO calendar
+     * system, it is equal to 1,000 years.
+     */
     static MILLENNIA: ChronoUnit;
+    /**
+     * Unit that represents the concept of an era. The ISO calendar system doesn't
+     * have eras thus it is impossible to add an era to a date or date-time. The estimated duration
+     * of the era is artificially defined as 1,000,000,000 Years.
+     */
     static ERAS: ChronoUnit;
+    /**
+     * Artificial unit that represents the concept of forever. This is primarily
+     * used with {@link TemporalField} to represent unbounded fields such as the year or era. The
+     * estimated duration of the era is artificially defined as the largest duration supported by
+     * {@link Duration}.
+     */
     static FOREVER: ChronoUnit;
 
     private constructor();
 
     addTo<T extends Temporal>(temporal: T, amount: number): T;
     between(temporal1: Temporal, temporal2: Temporal): number;
+    /**
+     * Compares this ChronoUnit to the specified {@link TemporalUnit}.
+     * The comparison is based on the total length of the durations.
+     */
     compareTo(other: TemporalUnit): number;
     duration(): Duration;
     isDateBased(): boolean;

--- a/packages/core/src/DayOfWeek.js
+++ b/packages/core/src/DayOfWeek.js
@@ -155,7 +155,7 @@ export class DayOfWeek extends TemporalAccessor {
      * @return {string} the text value of the day-of-week, not null
      */
     // eslint-disable-next-line no-unused-vars
-    getDisplayName(style, locale) {
+    displayName(style, locale) {
         throw new IllegalArgumentException('Pattern using (localized) text not implemented yet!');
         // return new DateTimeFormatterBuilder().appendText(ChronoField.DAY_OF_WEEK, style).toFormatter(locale).format(this);
     }

--- a/packages/core/src/Month.js
+++ b/packages/core/src/Month.js
@@ -87,7 +87,7 @@ export class Month extends TemporalAccessor {
      * @return {string} the text value of the day-of-week, not null
      */
     // eslint-disable-next-line no-unused-vars
-    getDisplayName(style, locale) {
+    displayName(style, locale) {
         // TODO:
         throw new IllegalArgumentException('Pattern using (localized) text not implemented yet!');
     }

--- a/packages/core/src/temporal/ChronoField.js
+++ b/packages/core/src/temporal/ChronoField.js
@@ -22,68 +22,189 @@ import {YearConstants} from '../YearConstants';
  * just with slightly different rules.
  * The documentation of each field explains how it operates.
  *
- * ### Static properties of Class {@link ChronoField}
+ * ### Static properties:
  *
- * ChronoField.NANO_OF_SECOND
- *
- * ChronoField.NANO_OF_DAY
- *
- * ChronoField.MICRO_OF_SECOND
- *
- * ChronoField.MICRO_OF_DAY
- *
- * ChronoField.MILLI_OF_SECOND
- *
- * ChronoField.MILLI_OF_DAY
- *
- * ChronoField.SECOND_OF_MINUTE
- *
- * ChronoField.SECOND_OF_DAY
- *
- * ChronoField.MINUTE_OF_HOUR
- *
- * ChronoField.MINUTE_OF_DAY
- *
- * ChronoField.HOUR_OF_AMPM
- *
- * ChronoField.CLOCK_HOUR_OF_AMPM
- *
- * ChronoField.HOUR_OF_DAY
- *
- * ChronoField.CLOCK_HOUR_OF_DAY
- *
- * ChronoField.AMPM_OF_DAY
- *
- * ChronoField.DAY_OF_WEEK
- *
- * ChronoField.ALIGNED_DAY_OF_WEEK_IN_MONTH
- *
- * ChronoField.ALIGNED_DAY_OF_WEEK_IN_YEAR
- *
- * ChronoField.DAY_OF_MONTH
- *
- * ChronoField.DAY_OF_YEAR
- *
- * ChronoField.EPOCH_DAY
- *
- * ChronoField.ALIGNED_WEEK_OF_MONTH
- *
- * ChronoField.ALIGNED_WEEK_OF_YEAR
- *
- * ChronoField.MONTH_OF_YEAR
- *
- * ChronoField.PROLEPTIC_MONTH
- *
- * ChronoField.YEAR_OF_ERA
- *
- * ChronoField.YEAR
- *
- * ChronoField.ERA
- *
- * ChronoField.INSTANT_SECONDS
- *
- * ChronoField.OFFSET_SECONDS
- *
+ * - `ChronoField.ALIGNED_DAY_OF_WEEK_IN_MONTH`: This represents concept of the count of
+ * days within the period of a week where the weeks are aligned to the start of the month.
+ * This field is typically used with `ALIGNED_WEEK_OF_MONTH`.
+ * 
+ * - `ChronoField.ALIGNED_DAY_OF_WEEK_IN_YEAR`: This represents concept of the count of days
+ * within the period of a week where the weeks are aligned to the start of the year.
+ * This field is typically used with `ALIGNED_WEEK_OF_YEAR`.
+ * 
+ * - `ChronoField.ALIGNED_WEEK_OF_MONTH`: This represents concept of the count of weeks within
+ * the period of a month where the weeks are aligned to the start of the month. This field
+ * is typically used with `ALIGNED_DAY_OF_WEEK_IN_MONTH`.
+ * 
+ * - `ChronoField.ALIGNED_WEEK_OF_YEAR`: This represents concept of the count of weeks within
+ * the period of a year where the weeks are aligned to the start of the year. This field
+ * is typically used with `ALIGNED_DAY_OF_WEEK_IN_YEAR`.
+ * 
+ * - `ChronoField.AMPM_OF_DAY`: This counts the AM/PM within the day, from 0 (AM) to 1 (PM).
+ * 
+ * - `ChronoField.CLOCK_HOUR_OF_AMPM`: This counts the hour within the AM/PM, from 1 to 12.
+ * This is the hour that would be observed on a standard 12-hour analog wall clock.
+ * 
+ * - `ChronoField.CLOCK_HOUR_OF_DAY`: This counts the hour within the AM/PM, from 1 to 24.
+ * This is the hour that would be observed on a 24-hour analog wall clock.
+ * 
+ * - `ChronoField.DAY_OF_MONTH`: This represents the concept of the day within the month.
+ * In the default ISO calendar system, this has values from 1 to 31 in most months.
+ * April, June, September, November have days from 1 to 30, while February has days from
+ * 1 to 28, or 29 in a leap year.
+ * 
+ * - `ChronoField.DAY_OF_WEEK`: This represents the standard concept of the day of the week.
+ * In the default ISO calendar system, this has values from Monday (1) to Sunday (7).
+ * The {@link DayOfWeek} class can be used to interpret the result.
+ * 
+ * - `ChronoField.DAY_OF_YEAR`: This represents the concept of the day within the year.
+ * In the default ISO calendar system, this has values from 1 to 365 in standard years and
+ * 1 to 366 in leap years.
+ * 
+ * - `ChronoField.EPOCH_DAY`: This field is the sequential count of days where
+ * 1970-01-01 (ISO) is zero. Note that this uses the local time-line, ignoring offset and
+ * time-zone.
+ * 
+ * - `ChronoField.ERA`: This represents the concept of the era, which is the largest
+ * division of the time-line. This field is typically used with `YEAR_OF_ERA`.
+ * 
+ *     In the default ISO calendar system, there are two eras defined, 'BCE' and 'CE'. The era
+ * 'CE' is the one currently in use and year-of-era runs from 1 to the maximum value.
+ * The era 'BCE' is the previous era, and the year-of-era runs backwards.
+ * 
+ * - `ChronoField.HOUR_OF_AMPM`: This counts the hour within the AM/PM, from 0 to 11.
+ * This is the hour that would be observed on a standard 12-hour digital clock.
+ * 
+ * - `ChronoField.HOUR_OF_DAY`: This counts the hour within the day, from 0 to 23. This is
+ * the hour that would be observed on a standard 24-hour digital clock.
+ * 
+ * - `ChronoField.INSTANT_SECONDS`: This represents the concept of the sequential count of
+ * seconds where 1970-01-01T00:00Z (ISO) is zero. This field may be used with `NANO_OF_DAY`
+ * to represent the fraction of the day.
+ * 
+ *     An Instant represents an instantaneous point on the time-line. On their own they have
+ * no elements which allow a local date-time to be obtained. Only when paired with an offset
+ * or time-zone can the local date or time be found. This field allows the seconds part of
+ * the instant to be queried.
+ * 
+ * - `ChronoField.MICRO_OF_DAY`: This counts the microsecond within the day, from 0 to
+ * (24 * 60 * 60 * 1,000,000) - 1.
+ * 
+ *     This field is used to represent the micro-of-day handling any fraction of the second.
+ * Implementations of {@link TemporalAccessor} should provide a value for this field if they
+ * can return a value for `SECOND_OF_DAY` filling unknown precision with zero.
+ * 
+ *     When this field is used for setting a value, it should behave in the same way as
+ * setting `NANO_OF_DAY` with the value multiplied by 1,000.
+ * 
+ * - `ChronoField.MICRO_OF_SECOND`: This counts the microsecond within the second, from 0
+ * to 999,999.
+ * 
+ *     This field is used to represent the micro-of-second handling any fraction of the second.
+ * Implementations of {@link TemporalAccessor} should provide a value for this field if they
+ * can return a value for `SECOND_OF_MINUTE`, `SECOND_OF_DAY` or `INSTANT_SECONDS` filling
+ * unknown precision with zero.
+ * 
+ * - `ChronoField.MILLI_OF_DAY`: This counts the millisecond within the day, from 0 to
+ * (24 * 60 * 60 * 1,000) - 1.
+ * 
+ *     This field is used to represent the milli-of-day handling any fraction of the second.
+ * Implementations of {@link TemporalAccessor} should provide a value for this field if they
+ * can return a value for `SECOND_OF_DAY` filling unknown precision with zero.
+ * 
+ *     When this field is used for setting a value, it should behave in the same way as
+ * setting `NANO_OF_DAY` with the value multiplied by 1,000,000.
+ * 
+ * - `ChronoField.MILLI_OF_SECOND`: This counts the millisecond within the second, from 0 to
+ * 999.
+ * 
+ *     This field is used to represent the milli-of-second handling any fraction of the second.
+ * Implementations of {@link TemporalAccessor} should provide a value for this field if they can
+ * return a value for `SECOND_OF_MINUTE`, `SECOND_OF_DAY` or `INSTANT_SECONDS` filling unknown
+ * precision with zero.
+ * 
+ *     When this field is used for setting a value, it should behave in the same way as
+ * setting `NANO_OF_SECOND` with the value multiplied by 1,000,000.
+ * 
+ * - `ChronoField.MINUTE_OF_DAY`: This counts the minute within the day, from 0 to (24 * 60) - 1.
+ * 
+ * - `ChronoField.MINUTE_OF_HOUR`: This counts the minute within the hour, from 0 to 59.
+ * 
+ * - `ChronoField.MONTH_OF_YEAR`: The month-of-year, such as March. This represents the concept
+ * of the month within the year. In the default ISO calendar system, this has values from
+ * January (1) to December (12).
+ * 
+ * - `ChronoField.NANO_OF_DAY`: This counts the nanosecond within the day, from 0 to
+ * (24 * 60 * 60 * 1,000,000,000) - 1.
+ * 
+ *     This field is used to represent the nano-of-day handling any fraction of the second.
+ * Implementations of {@link TemporalAccessor} should provide a value for this field if they
+ * can return a value for `SECOND_OF_DAY` filling unknown precision with zero.
+ * 
+ * - `ChronoField.NANO_OF_SECOND`: This counts the nanosecond within the second, from 0
+ * to 999,999,999.
+ * 
+ *     This field is used to represent the nano-of-second handling any fraction of the second.
+ * Implementations of {@link TemporalAccessor} should provide a value for this field if they
+ * can return a value for `SECOND_OF_MINUTE`, `SECOND_OF_DAY` or `INSTANT_SECONDS` filling
+ * unknown precision with zero.
+ * 
+ *     When this field is used for setting a value, it should set as much precision as the
+ * object stores, using integer division to remove excess precision. For example, if the
+ * {@link TemporalAccessor} stores time to millisecond precision, then the nano-of-second must
+ * be divided by 1,000,000 before replacing the milli-of-second.
+ * 
+ * - `ChronoField.OFFSET_SECONDS`: This represents the concept of the offset in seconds of
+ * local time from UTC/Greenwich.
+ * 
+ *     A {@link ZoneOffset} represents the period of time that local time differs from
+ * UTC/Greenwich. This is usually a fixed number of hours and minutes. It is equivalent to
+ * the total amount of the offset in seconds. For example, during the winter Paris has an
+ * offset of +01:00, which is 3600 seconds.
+ * 
+ * - `ChronoField.PROLEPTIC_MONTH`: The proleptic-month, which counts months sequentially
+ * from year 0.
+ * 
+ *     The first month in year zero has the value zero. The value increase for later months
+ * and decrease for earlier ones. Note that this uses the local time-line, ignoring offset
+ * and time-zone.
+ * 
+ * - `ChronoField.SECOND_OF_DAY`: This counts the second within the day, from 0 to
+ * (24 * 60 * 60) - 1.
+ * 
+ * - `ChronoField.SECOND_OF_MINUTE`: This counts the second within the minute, from 0 to 59.
+ * 
+ * - `ChronoField.YEAR`: The proleptic year, such as 2012. This represents the concept of
+ * the year, counting sequentially and using negative numbers. The proleptic year is not
+ * interpreted in terms of the era.
+ * 
+ *     The standard mental model for a date is based on three concepts - year, month and day.
+ * These map onto the `YEAR`, `MONTH_OF_YEAR` and `DAY_OF_MONTH` fields. Note that there is no
+ * reference to eras. The full model for a date requires four concepts - era, year, month and
+ * day. These map onto the `ERA`, `YEAR_OF_ERA`, `MONTH_OF_YEAR` and `DAY_OF_MONTH` fields.
+ * Whether this field or `YEAR_OF_ERA` is used depends on which mental model is being used.
+ * 
+ * - `ChronoField.YEAR_OF_ERA`: This represents the concept of the year within the era. This
+ * field is typically used with `ERA`. The standard mental model for a date is based on three
+ * concepts - year, month and day. These map onto the `YEAR`, `MONTH_OF_YEAR` and
+ * `DAY_OF_MONTH` fields. Note that there is no reference to eras. The full model for a date
+ * requires four concepts - era, year, month and day. These map onto the `ERA`, `YEAR_OF_ERA`,
+ * `MONTH_OF_YEAR` and `DAY_OF_MONTH` fields. Whether this field or `YEAR` is used depends on
+ * which mental model is being used.
+ * 
+ *     In the default ISO calendar system, there are two eras defined, 'BCE' and 'CE'.
+ * The era 'CE' is the one currently in use and year-of-era runs from 1 to the maximum value.
+ * The era 'BCE' is the previous era, and the year-of-era runs backwards.
+ * 
+ *     For example, subtracting a year each time yield the following:
+ *    - year-proleptic 2 = 'CE' year-of-era 2
+ *    - year-proleptic 1 = 'CE' year-of-era 1
+ *    - year-proleptic 0 = 'BCE' year-of-era 1
+ *    - year-proleptic -1 = 'BCE' year-of-era 2
+ * 
+ *     Note that the ISO-8601 standard does not actually define eras. Note also that the
+ * ISO eras do not align with the well-known AD/BC eras due to the change between the Julian
+ * and Gregorian calendar systems.
  */
 export class ChronoField extends TemporalField {
 
@@ -121,39 +242,34 @@ export class ChronoField extends TemporalField {
     }
 
     /**
-     *
-     * @returns {string}
+     * @return {string}
      */
     name(){
         return this._name;
     }
 
     /**
-     *
-     * @returns {!TemporalUnit}
+     * @return {TemporalUnit} the period unit defining the base unit of the field.
      */
     baseUnit(){
         return this._baseUnit;
     }
 
     /**
-     *
-     * @returns {!TemporalUnit}
+     * @return {TemporalUnit} the period unit defining the range of the field.
      */
     rangeUnit(){
         return this._rangeUnit;
     }
 
     /**
-     *
-     * @returns {!ValueRange}
+     * @return {ValueRange} the range of valid values for the field.
      */
     range(){
         return this._range;
     }
 
     /**
-     *
      * @returns {string}
      */
     displayName(){
@@ -161,18 +277,38 @@ export class ChronoField extends TemporalField {
     }
 
     /**
+     * Checks that the specified value is valid for this field.
      *
-     * @param {number} value
-     * @returns {*}
+     * This validates that the value is within the outer range of valid values
+     * returned by {@link range}.
+     *
+     * This method checks against the range of the field in the ISO-8601 calendar system.
+     *
+     * @param {!number} value the value to check.
+     * @returns {number} the value that was passed in.
      */
     checkValidValue(value) {
         return this.range().checkValidValue(value, this.name());
     }
 
     /**
-     * Checks if this field represents a component of a date.
+     * Checks that the specified value is valid and fits in an `int`.
      *
-     * @return {boolean} true if it is a component of a date
+     * This validates that the value is within the outer range of valid values
+     * returned by {@link range}.
+     * It also checks that all valid values are within the bounds of an `int`.
+     *
+     * This method checks against the range of the field in the ISO-8601 calendar system.
+     *
+     * @param {number} value the value to check.
+     * @return {number} the value that was passed in.
+     */
+    checkValidIntValue(value) {
+        return this.range().checkValidIntValue(value, this);
+    }
+
+    /**
+     * @return {boolean} `true` if it is a component of a date, `false` otherwise.
      */
     isDateBased() {
         const dateBased =
@@ -193,9 +329,7 @@ export class ChronoField extends TemporalField {
     }
 
     /**
-     * Checks if this field represents a component of a time.
-     *
-     * @return {boolean} true if it is a component of a time
+     * @return {boolean} `true` if it is a component of a time, `false` otherwise.
      */
     isTimeBased() {
         const timeBased =
@@ -218,69 +352,26 @@ export class ChronoField extends TemporalField {
     }
 
     /**
-     * Get the range of valid values for this field using the temporal object to
-     * refine the result.
-     *
-     * This uses the temporal object to find the range of valid values for the field.
-     * This is similar to {@link range}, however this method refines the result
-     * using the temporal. For example, if the field is {@link DAY_OF_MONTH} the
-     * {@link range} method is not accurate as there are four possible month lengths,
-     * 28, 29, 30 and 31 days. Using this method with a date allows the range to be
-     * accurate, returning just one of those four options.
-     *
-     * There are two equivalent ways of using this method.
-     * The first is to invoke this method directly.
-     * The second is to use {@link TemporalAccessor#range}:
-     * <pre>
-     *   // these two lines are equivalent, but the second approach is recommended
-     *   temporal = thisField.rangeRefinedBy(temporal);
-     *   temporal = temporal.range(thisField);
-     * </pre>
-     * It is recommended to use the second approach, {@link range},
-     * as it is a lot clearer to read in code.
-     *
-     * Implementations should perform any queries or calculations using the fields
-     * available in {@link ChronoField}.
-     * If the field is not supported a {@link DateTimeException} must be thrown.
-     *
-     * @param {!TemporalAccessor} temporal - the temporal object used to refine the result, not null
-     * @return {ValueRange} the range of valid values for this field, not null
-     * @throws DateTimeException if the range for the field cannot be obtained
+     * @param {!TemporalAccessor} temporal the temporal object used to refine the result.
+     * @return {ValueRange} the range of valid values for this field.
+     * @throws {DateTimeException} if the range for the field cannot be obtained.
      */
     rangeRefinedBy(temporal) {
         return temporal.range(this);
     }
 
-    /**
-     * Checks that the specified value is valid and fits in an `int`.
-     *
-     * This validates that the value is within the outer range of valid values
-     * returned by {@link range}.
-     * It also checks that all valid values are within the bounds of an `int`.
-     *
-     * This method checks against the range of the field in the ISO-8601 calendar system.
-     * This range may be incorrect for other calendar systems.
-     * Use {@link Chronology#range} to access the correct range
-     * for a different calendar system.
-     *
-     * @param {number} value - the value to check
-     * @return {number} the value that was passed in
-     */
-    checkValidIntValue(value) {
-        return this.range().checkValidIntValue(value, this);
-    }
+    
 
     /**
-     *
-     * @param {TemporalAccessor} temporal
-     * @returns {number}
+     * @param {!TemporalAccesor} temporal the temporal object to query.
+     * @return {number} the value of this field.
+     * @throws {DateTimeException} if a value for the field cannot be obtained.
      */
     getFrom(temporal) {
         return temporal.getLong(this);
     }
 
     /**
-     *
      * @returns {string}
      */
     toString(){
@@ -288,7 +379,6 @@ export class ChronoField extends TemporalField {
     }
 
     /**
-     *
      * @param {*} other
      * @returns {boolean}
      */
@@ -297,18 +387,18 @@ export class ChronoField extends TemporalField {
     }
 
     /**
-     *
-     * @param {Temporal} temporal
-     * @param {number} newValue
-     * @returns {temporal}
+     * @param {!Temporal} temporal the temporal object to adjust.
+     * @param {!number} newValue the new value of the field.
+     * @return {Temporal} the adjusted temporal object.
+     * @throws {DateTimeException} if the field cannot be set.
      */
     adjustInto(temporal, newValue) {
         return temporal.with(this, newValue);
     }
 
     /**
-     * @param {TemporalAccesor} temporal  the temporal object to query, not null
-     * @return {boolean} true if the date-time can be queried for this field, false if not
+     * @param {!TemporalAccesor} temporal the temporal object to query.
+     * @return {boolean} `true` if the date-time can be queried for this field, `false` if not.
      */
     isSupportedBy(temporal) {
         return temporal.isSupported(this);

--- a/packages/core/src/temporal/ChronoField.js
+++ b/packages/core/src/temporal/ChronoField.js
@@ -288,7 +288,7 @@ export class ChronoField extends TemporalField {
      * @returns {number} the value that was passed in.
      */
     checkValidValue(value) {
-        return this.range().checkValidValue(value, this.name());
+        return this.range().checkValidValue(value, this);
     }
 
     /**

--- a/packages/core/src/temporal/ChronoField.js
+++ b/packages/core/src/temporal/ChronoField.js
@@ -92,6 +92,7 @@ export class ChronoField extends TemporalField {
      *
      * @param {String} fieldName
      * @return {ChronoField | null}
+     * @private
      */
     static byName(fieldName) {
         for (const prop in ChronoField) {
@@ -106,8 +107,8 @@ export class ChronoField extends TemporalField {
     /**
      *
      * @param {!string} name
-     * @param {!number} baseUnit
-     * @param {!number} rangeUnit
+     * @param {!TemporalUnit} baseUnit
+     * @param {!TemporalUnit} rangeUnit
      * @param {!ValueRange} range
      * @private
      */
@@ -129,7 +130,7 @@ export class ChronoField extends TemporalField {
 
     /**
      *
-     * @returns {!number}
+     * @returns {!TemporalUnit}
      */
     baseUnit(){
         return this._baseUnit;
@@ -137,7 +138,7 @@ export class ChronoField extends TemporalField {
 
     /**
      *
-     * @returns {!number}
+     * @returns {!TemporalUnit}
      */
     rangeUnit(){
         return this._rangeUnit;
@@ -294,6 +295,24 @@ export class ChronoField extends TemporalField {
     equals(other){
         return this === other;
     }
+
+    /**
+     *
+     * @param {Temporal} temporal
+     * @param {number} newValue
+     * @returns {temporal}
+     */
+    adjustInto(temporal, newValue) {
+        return temporal.with(this, newValue);
+    }
+
+    /**
+     * @param {TemporalAccesor} temporal  the temporal object to query, not null
+     * @return {boolean} true if the date-time can be queried for this field, false if not
+     */
+    isSupportedBy(temporal) {
+        return temporal.isSupported(this);
+    }
 }
 
 export function _init() {
@@ -359,4 +378,3 @@ export function _init() {
     ChronoField.OFFSET_SECONDS = new ChronoField('OffsetSeconds', ChronoUnit.SECONDS, ChronoUnit.FOREVER, ValueRange.of(-18 * 3600, 18 * 3600));
 
 }
-

--- a/packages/core/src/temporal/ChronoUnit.js
+++ b/packages/core/src/temporal/ChronoUnit.js
@@ -21,120 +21,59 @@ import {TemporalUnit} from './TemporalUnit';
  * just with slightly different rules.
  * The documentation of each unit explains how it operates.
  *
- * ### Static properties of Class {@link ChronoUnit}
+ * ### Static properties:
+ * 
+ * - `ChronoUnit.CENTURIES`: Unit that represents the concept of a century. For the ISO calendar
+ * system, it is equal to 100 years.
+ * 
+ * - `ChronoUnit.DAYS`: Unit that represents the concept of a day. For the ISO calendar system, it
+ * is the standard day from midnight to midnight. The estimated duration of a day is 24 Hours.
+ * 
+ * - `ChronoUnit.DECADES`: Unit that represents the concept of a decade. For the ISO calendar system,
+ * it is equal to 10 years.
+ * 
+ * - `ChronoUnit.ERAS`: Unit that represents the concept of an era. The ISO calendar system doesn't
+ * have eras thus it is impossible to add an era to a date or date-time. The estimated duration of the
+ * era is artificially defined as 1,000,000,000 Years.
+ * 
+ * - `ChronoUnit.FOREVER`: Artificial unit that represents the concept of forever. This is primarily
+ * used with {@link TemporalField} to represent unbounded fields such as the year or era. The
+ * estimated duration of the era is artificially defined as the largest duration supported by
+ * {@link Duration}.
+ * 
+ * - `ChronoUnit.HALF_DAYS`: Unit that represents the concept of half a day, as used in AM/PM. For
+ * the ISO calendar system, it is equal to 12 hours.
  *
- * ChronoUnit.NANOS
- *
- * Unit that represents the concept of a nanosecond, the smallest supported unit of time.
- * For the ISO calendar system, it is equal to the 1,000,000,000th part of the second unit.
- *
- * ChronoUnit.MICROS
- *
- * Unit that represents the concept of a microsecond.
- * For the ISO calendar system, it is equal to the 1,000,000th part of the second unit.
- *
- * ChronoUnit.MILLIS
- *
- * Unit that represents the concept of a millisecond.
- * For the ISO calendar system, it is equal to the 1000th part of the second unit.
- *
- * ChronoUnit.SECONDS
- *
- * Unit that represents the concept of a second.
- * For the ISO calendar system, it is equal to the second in the SI system
- * of units, except around a leap-second.
- *
- * ChronoUnit.MINUTES
- *
- * Unit that represents the concept of a minute.
- * For the ISO calendar system, it is equal to 60 seconds.
- *
- * ChronoUnit.HOURS
- *
- * Unit that represents the concept of an hour.
- * For the ISO calendar system, it is equal to 60 minutes.
- *
- * ChronoUnit.HALF_DAYS
- *
- * Unit that represents the concept of half a day, as used in AM/PM.
- * For the ISO calendar system, it is equal to 12 hours.
- *
- * ChronoUnit.DAYS
- *
- * Unit that represents the concept of a day.
- * For the ISO calendar system, it is the standard day from midnight to midnight.
- * The estimated duration of a day is 24 hours.
- *
- * When used with other calendar systems it must correspond to the day defined by
- * the rising and setting of the Sun on Earth. It is not required that days begin
- * at midnight - when converting between calendar systems, the date should be
- * equivalent at midday.
- *
- * ChronoUnit.WEEKS
- *
- * Unit that represents the concept of a week.
- * For the ISO calendar system, it is equal to 7 days.
- *
- * When used with other calendar systems it must correspond to an integral number of days.
- *
- * ChronoUnit.MONTHS
- *
- * Unit that represents the concept of a month.
- * For the ISO calendar system, the length of the month varies by month-of-year.
- * The estimated duration of a month is one twelfth of 365.2425 days.
- *
- * When used with other calendar systems it must correspond to an integral number of days.
- *
- * ChronoUnit.YEARS
- *
- * Unit that represents the concept of a year.
- * For the ISO calendar system, it is equal to 12 months.
- * The estimated duration of a year is 365.2425 days.
- *
- * When used with other calendar systems it must correspond to an integral number of days
- * or months roughly equal to a year defined by the passage of the Earth around the Sun.
- *
- * ChronoUnit.DECADES
- *
- * Unit that represents the concept of a decade.
- * For the ISO calendar system, it is equal to 10 years.
- *
- * When used with other calendar systems it must correspond to an integral number of days
- * and is normally an integral number of years.
- *
- * ChronoUnit.CENTURIES
- *
- * Unit that represents the concept of a century.
- * For the ISO calendar system, it is equal to 100 years.
- *
- * When used with other calendar systems it must correspond to an integral number of days
- * and is normally an integral number of years.
- *
- * ChronoUnit.MILLENNIA
- *
- * Unit that represents the concept of a millennium.
- * For the ISO calendar system, it is equal to 1000 years.
- *
- * When used with other calendar systems it must correspond to an integral number of days
- * and is normally an integral number of years.
- *
- * ChronoUnit.ERAS
- *
- * Unit that represents the concept of an era.
- * The ISO calendar system doesn't have eras thus it is impossible to add
- * an era to a date or date-time.
- * The estimated duration of the era is artificially defined as {Year.MAX_VALUE} + 1.
- *
- * When used with other calendar systems there are no restrictions on the unit.
- *
- * ChronoUnit.FOREVER
- *
- * Artificial unit that represents the concept of forever.
- * This is primarily used with {@link TemporalField} to represent unbounded fields
- * such as the year or era.
- * The estimated duration of the era is artificially defined as the largest duration
- * supported by {@link Duration}.
- *
+ * - `ChronoUnit.HOURS`: Unit that represents the concept of an hour. For the ISO calendar system,
+ * it is equal to 60 minutes.
+ * 
+ * - `ChronoUnit.MICROS`: Unit that represents the concept of a microsecond. For the ISO calendar
+ * system, it is equal to the 1,000,000th part of the second unit.
+ * 
+ * - `ChronoUnit.MILLENNIA`: Unit that represents the concept of a millennium. For the ISO calendar
+ * system, it is equal to 1,000 years.
+ * 
+ * - `ChronoUnit.MILLIS`: Unit that represents the concept of a millisecond. For the ISO calendar
+ * system, it is equal to the 1000th part of the second unit.
+ * 
+ * - `ChronoUnit.MINUTES`: Unit that represents the concept of a minute. For the ISO calendar system,
+ * it is equal to 60 seconds.
+ * 
+ * - `ChronoUnit.MONTHS`: Unit that represents the concept of a month. For the ISO calendar system,
+ * the length of the month varies by month-of-year. The estimated duration of a month is one twelfth
+ * of 365.2425 Days.
+ * 
+ * - `ChronoUnit.NANOS`: Unit that represents the concept of a nanosecond, the smallest supported unit
+ * of time. For the ISO calendar system, it is equal to the 1,000,000,000th part of the second unit.
+ * 
+ * - `ChronoUnit.SECONDS`: Unit that represents the concept of a second. For the ISO calendar system,
+ * it is equal to the second in the SI system of units, except around a leap-second.
+ * 
+ * - `ChronoUnit.WEEKS`: Unit that represents the concept of a week. For the ISO calendar system,
+ * it is equal to 7 Days.
+ * 
+ * - `ChronoUnit.YEARS`: Unit that represents the concept of a year. For the ISO calendar system, it
+ * is equal to 12 months. The estimated duration of a year is 365.2425 Days.
  */
 export class ChronoUnit extends TemporalUnit {
 
@@ -152,27 +91,14 @@ export class ChronoUnit extends TemporalUnit {
 
     //-----------------------------------------------------------------------
     /**
-     * Gets the estimated duration of this unit in the ISO calendar system.
-     *
-     * All of the units in this class have an estimated duration.
-     * Days vary due to daylight saving time, while months have different lengths.
-     *
-     * @return {Duration} the estimated duration of this unit, not null
+     * @return {Duration} the duration of this unit, which may be an estimate.
      */
     duration() {
         return this._duration;
     }
 
     /**
-     * Checks if the duration of the unit is an estimate.
-     *
-     * All time units in this class are considered to be accurate, while all date
-     * units in this class are considered to be estimated.
-     *
-     * This definition ignores leap seconds, but considers that Days vary due to
-     * daylight saving time and months have different lengths.
-     *
-     * @return {boolean} true if the duration is estimated, false if accurate
+     * @return {boolean} `true` if the duration is estimated, `false` if accurate.
      */
     isDurationEstimated() {
         return this.isDateBased() || this === ChronoUnit.FOREVER;
@@ -180,9 +106,7 @@ export class ChronoUnit extends TemporalUnit {
 
     //-----------------------------------------------------------------------
     /**
-     * Checks if this unit is a date unit.
-     *
-     * @return true if a date unit, false if a time unit
+     * @return {boolean} `true` if date unit, `false` if a time unit.
      */
     isDateBased() {
         return this.compareTo(ChronoUnit.DAYS) >= 0 && this !== ChronoUnit.FOREVER;
@@ -191,7 +115,7 @@ export class ChronoUnit extends TemporalUnit {
     /**
      * Checks if this unit is a time unit.
      *
-     * @return true if a time unit, false if a date unit
+     * @return {boolean} `true` if time unit, `false` if a date unit.
      */
     isTimeBased() {
         return this.compareTo(ChronoUnit.DAYS) < 0;
@@ -199,16 +123,8 @@ export class ChronoUnit extends TemporalUnit {
 
     //-----------------------------------------------------------------------
     /**
-     * Checks if this unit is supported by the specified temporal object.
-     *
-     * This checks that the implementing date-time can add/subtract this unit.
-     * This can be used to avoid throwing an exception.
-     *
-     * This default implementation derives the value using
-     * {@link Temporal#plus}.
-     *
-     * @param {Temporal} temporal  the temporal object to check, not null
-     * @return {boolean} true if the unit is supported
+     * @param {!Temporal} temporal the temporal object to check.
+     * @return {boolean} `true` if the unit is supported.
      */
     isSupportedBy(temporal) {
         if (this === ChronoUnit.FOREVER) {
@@ -237,37 +153,10 @@ export class ChronoUnit extends TemporalUnit {
     }
 
     /**
-     * Returns a copy of the specified temporal object with the specified period added.
-     *
-     * The period added is a multiple of this unit. For example, this method
-     * could be used to add "3 days" to a date by calling this method on the
-     * instance representing "days", passing the date and the period "3".
-     * The period to be added may be negative, which is equivalent to subtraction.
-     *
-     * There are two equivalent ways of using this method.
-     * The first is to invoke this method directly.
-     * The second is to use {@link Temporal#plus}:
-     * <pre>
-     *   // these two lines are equivalent, but the second approach is recommended
-     *   temporal = thisUnit.addTo(temporal);
-     *   temporal = temporal.plus(thisUnit);
-     * </pre>
-     * It is recommended to use the second approach, {@link plus},
-     * as it is a lot clearer to read in code.
-     *
-     * Implementations should perform any queries or calculations using the units
-     * available in {@link ChronoUnit} or the fields available in {@link ChronoField}.
-     * If the unit is not supported an {@link UnsupportedTemporalTypeException} must be thrown.
-     *
-     * Implementations must not alter the specified temporal object.
-     * Instead, an adjusted copy of the original must be returned.
-     * This provides equivalent, safe behavior for immutable and mutable implementations.
-     *
-     * @param {Temporal} temporal  the temporal object to adjust, not null
-     * @param {Number} amount  the amount of this unit to add, positive or negative
-     * @return {Temporal} the adjusted temporal object, not null
-     * @throws DateTimeException if the amount cannot be added
-     * @throws UnsupportedTemporalTypeException if the unit is not supported by the temporal
+     * @param {!Temporal} dateTime the temporal object to adjust.
+     * @param {number} periodToAdd the period of this unit to add, positive or negative.
+     * @return {Temporal} the adjusted temporal object.
+     * @throws DateTimeException if the period cannot be added.
      */
     addTo(temporal, amount) {
         return temporal.plus(amount, this);
@@ -275,58 +164,12 @@ export class ChronoUnit extends TemporalUnit {
 
     //-----------------------------------------------------------------------
     /**
-     * Calculates the amount of time between two temporal objects.
-     *
-     * This calculates the amount in terms of this unit. The start and end
-     * points are supplied as temporal objects and must be of compatible types.
-     * The implementation will convert the second type to be an instance of the
-     * first type before the calculating the amount.
-     * The result will be negative if the end is before the start.
-     * For example, the amount in hours between two temporal objects can be
-     * calculated using {@link HOURS.between}.
-     *
-     * The calculation returns a whole number, representing the number of
-     * complete units between the two temporals.
-     * For example, the amount in hours between the times 11:30 and 13:29
-     * will only be one hour as it is one minute short of two hours.
-     *
-     * There are two equivalent ways of using this method.
-     * The first is to invoke this method directly.
-     * The second is to use {@link Temporal#until}:
-     * <pre>
-     *   // these two lines are equivalent
-     *   between = thisUnit.between(start, end);
-     *   between = start.until(end, thisUnit);
-     * </pre>
-     * The choice should be made based on which makes the code more readable.
-     *
-     * For example, this method allows the number of days between two dates to
-     * be calculated:
-     * <pre>
-     *  daysBetween = DAYS.between(start, end);
-     *  // or alternatively
-     *  daysBetween = start.until(end, DAYS);
-     * </pre>
-     *
-     * Implementations should perform any queries or calculations using the units
-     * available in {@link ChronoUnit} or the fields available in {@link ChronoField}.
-     * If the unit is not supported an {@link UnsupportedTemporalTypeException} must be thrown.
-     * Implementations must not alter the specified temporal objects.
-     *
-     * @implSpec
-     * Implementations must begin by checking to if the two temporals have the
-     * same type using `.constructor.name`. If they do not, then the result must be
-     * obtained by calling `temporal1.until`.
-     *
-     * @param {Temporal} temporal1  the base temporal object, not null
-     * @param {Temporal} temporal2  the other temporal object, exclusive, not null
-     * @return {Number} the amount of time between temporal1 and temporal2
-     *  in terms of this unit; positive if temporal2 is later than
-     *  temporal1, negative if earlier
-     * @throws DateTimeException if the amount cannot be calculated, or the end
-     *  temporal cannot be converted to the same type as the start temporal
-     * @throws UnsupportedTemporalTypeException if the unit is not supported by the temporal
-     * @throws ArithmeticException if numeric overflow occurs
+     * @param {!Temporal} temporal1 the base temporal object.
+     * @param {!Temporal} temporal2 the other temporal object.
+     * @return {number} the period between temporal1 and temporal2 in terms of this unit;
+     *  positive if temporal2 is later than temporal1, negative if earlier.
+     * @throws DateTimeException if the period cannot be calculated.
+     * @throws ArithmeticException if numeric overflow occurs.
      */
     between(temporal1, temporal2) {
         return temporal1.until(temporal2, this);
@@ -338,12 +181,12 @@ export class ChronoUnit extends TemporalUnit {
     }
 
     /**
-     * Compares this ChronoUnit to the specified {TemporalUnit}.
+     * Compares this ChronoUnit to the specified {@link TemporalUnit}.
      *
      * The comparison is based on the total length of the durations.
      *
-     * @param {TemporalUnit} other  the other unit to compare to, not null
-     * @return the comparator value, negative if less, positive if greater
+     * @param {!TemporalUnit} other the other unit to compare to.
+     * @return the comparator value, negative if less, positive if greater.
      */
     compareTo(other) {
         return this.duration().compareTo(other.duration());

--- a/packages/core/src/temporal/IsoFields.js
+++ b/packages/core/src/temporal/IsoFields.js
@@ -252,7 +252,7 @@ class Field extends TemporalField{
      *
      * @returns {string}
      */
-    getDisplayName(/*locale*/) {
+    displayName(/*locale*/) {
         return this.toString();
     }
 
@@ -615,7 +615,7 @@ class WEEK_OF_WEEK_BASED_YEAR_FIELD extends Field {
      *
      * @returns {string}
      */
-    getDisplayName() {
+    displayName() {
         return 'Week';
     }
 

--- a/packages/core/src/temporal/IsoFields.js
+++ b/packages/core/src/temporal/IsoFields.js
@@ -138,8 +138,7 @@ import {ResolverStyle} from '../format/ResolverStyle';
  * For the ISO calendar system, it is equal to 3 months.
  * The estimated duration of a quarter-year is one quarter of 365.2425 days.
  */
-export class IsoFields {
-}
+export const IsoFields = {};
 
 //-----------------------------------------------------------------------
 

--- a/packages/core/src/temporal/IsoFields.js
+++ b/packages/core/src/temporal/IsoFields.js
@@ -39,9 +39,9 @@ import {ResolverStyle} from '../format/ResolverStyle';
  *
  * The complete date is expressed using three fields:
  *
- * * {@link DAY_OF_QUARTER} - the day within the quarter, from 1 to 90, 91 or 92
- * * {@link QUARTER_OF_YEAR} - the week within the week-based-year
- * * {@link ChronoField#YEAR} - the standard ISO year
+ * * `IsoFields.DAY_OF_QUARTER` - the day within the quarter, from 1 to 90, 91 or 92
+ * * `QUARTER_OF_YEAR` - the week within the week-based-year
+ * * `ChronoField.YEAR` - the standard ISO year (see {@link ChronoField})
  *
  * ### Week based years
  *
@@ -51,10 +51,10 @@ import {ResolverStyle} from '../format/ResolverStyle';
  *
  * The date is expressed using three fields:
  *
- * * {@link ChronoField#DAY_OF_WEEK} - the standard field defining the
- *   day-of-week from Monday (1) to Sunday (7)
- * * {@link WEEK_OF_WEEK_BASED_YEAR} - the week within the week-based-year
- * * {@link WEEK_BASED_YEAR} - the week-based-year
+ * * `ChronoField.DAY_OF_WEEK` - the standard field defining the
+ *   day-of-week from Monday (1) to Sunday (7) (see {@link ChronoField})
+ * * `WEEK_OF_WEEK_BASED_YEAR` - the week within the week-based-year
+ * * `WEEK_BASED_YEAR` - the week-based-year 
  *
  * The week-based-year itself is defined relative to the standard ISO proleptic year.
  * It differs from the standard year in that it always starts on a Monday.
@@ -81,11 +81,7 @@ import {ResolverStyle} from '../format/ResolverStyle';
  * * Sunday, 2009-01-04: Week 1 of week-based-year 2009
  * * Monday, 2009-01-05: Week 2 of week-based-year 2009
  *
- * ### Static properties of Class {@link IsoFields}
- *
- * IsoFields.DAY_OF_QUARTER
- *
- * The field that represents the day-of-quarter.
+ * @property {TemporalField} DAY_OF_QUARTER The field that represents the day-of-quarter.
  *
  * This field allows the day-of-quarter value to be queried and set.
  * The day-of-quarter has values from 1 to 90 in Q1 of a standard year, from 1 to 91
@@ -98,30 +94,24 @@ import {ResolverStyle} from '../format/ResolverStyle';
  * value from 1 to 92. If the quarter has less than 92 days, then day 92, and
  * potentially day 91, is in the following quarter.
  *
- * IsoFields.QUARTER_OF_YEAR
- *
- * The field that represents the quarter-of-year.
+ * @property {TemporalField} QUARTER_OF_YEAR The field that represents the quarter-of-year.
  *
  * This field allows the quarter-of-year value to be queried and set.
  * The quarter-of-year has values from 1 to 4.
  *
  * The day-of-quarter can only be calculated if the month-of-year is available.
  *
- * IsoFields.WEEK_OF_WEEK_BASED_YEAR
- *
- * The field that represents the week-of-week-based-year.
+ * @property {TemporalField} WEEK_OF_WEEK_BASED_YEAR The field that represents the
+ * week-of-week-based-year.
  *
  * This field allows the week of the week-based-year value to be queried and set.
  *
- * IsoFields.WEEK_BASED_YEAR
- *
- * The field that represents the week-based-year.
+ * @property {TemporalField} WEEK_BASED_YEAR The field that represents the week-based-year.
  *
  * This field allows the week-based-year value to be queried and set.
  *
- * IsoFields.WEEK_BASED_YEARS
- *
- * The unit that represents week-based-years for the purpose of addition and subtraction.
+ * @property {TemporalField} WEEK_BASED_YEARS The unit that represents week-based-years for
+ * the purpose of addition and subtraction.
  *
  * This allows a number of week-based-years to be added to, or subtracted from, a date.
  * The unit is equal to either 52 or 53 weeks.
@@ -132,11 +122,12 @@ import {ResolverStyle} from '../format/ResolverStyle';
  * for the week-based-year field. If the resulting week-based-year only has 52 weeks,
  * then the date will be in week 1 of the following week-based-year.
  *
- * IsoFields.QUARTER_YEARS
- *
- * Unit that represents the concept of a quarter-year.
+ * @property {TemporalField} QUARTER_YEARS Unit that represents the concept of a quarter-year.
  * For the ISO calendar system, it is equal to 3 months.
  * The estimated duration of a quarter-year is one quarter of 365.2425 days.
+ * 
+ * @typedef {Object} IsoFields
+ * @type {Object}
  */
 export const IsoFields = {};
 
@@ -146,6 +137,7 @@ const QUARTER_DAYS = [0, 90, 181, 273, 0, 91, 182, 274];
 
 /**
  * Implementation of the field.
+ * @private
  */
 class Field extends TemporalField{
 
@@ -269,7 +261,9 @@ class Field extends TemporalField{
 
 }
 
-
+/**
+ * @private
+ */
 class DAY_OF_QUARTER_FIELD extends Field {
 
     /**
@@ -406,6 +400,9 @@ class DAY_OF_QUARTER_FIELD extends Field {
     }
 }
 
+/**
+ * @private
+ */
 class QUARTER_OF_YEAR_FIELD extends Field {
 
     /**
@@ -487,6 +484,9 @@ class QUARTER_OF_YEAR_FIELD extends Field {
 
 }
 
+/**
+ * @private
+ */
 class WEEK_OF_WEEK_BASED_YEAR_FIELD extends Field {
 
     /**
@@ -620,6 +620,9 @@ class WEEK_OF_WEEK_BASED_YEAR_FIELD extends Field {
 
 }
 
+/**
+ * @private
+ */
 class WEEK_BASED_YEAR_FIELD extends Field {
 
     /**
@@ -714,6 +717,7 @@ class WEEK_BASED_YEAR_FIELD extends Field {
 //-----------------------------------------------------------------------
 /**
  * Implementation of the period unit.
+ * @private
  */
 class Unit extends TemporalUnit {
 

--- a/packages/core/src/temporal/TemporalField.js
+++ b/packages/core/src/temporal/TemporalField.js
@@ -1,3 +1,5 @@
+import { abstractMethodFail } from '../assert';
+
 /**
  * @copyright (c) 2016, Philipp Thürwächter & Pattrick Hüper
  * @copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos
@@ -21,4 +23,228 @@
  *
  * @interface
  */
-export class TemporalField {}
+export class TemporalField {
+    /**
+     * Checks if this field represents a component of a date.
+     *
+     * @return {boolean} true if it is a component of a date
+     */
+    isDateBased() {
+        abstractMethodFail('isDateBased');
+    }
+
+    /**
+     * Checks if this field represents a component of a time.
+     *
+     * @return {boolean} true if it is a component of a time
+     */
+    isTimeBased() {
+        abstractMethodFail('isTimeBased');
+    }
+
+    /**
+     * Gets the unit that the field is measured in.
+     *
+     * The unit of the field is the period that varies within the range.
+     * For example, in the field 'MonthOfYear', the unit is 'Months'.
+     * See also {@link rangeUnit}.
+     *
+     * @returns {!TemporalUnit}
+     */
+    baseUnit() {
+        abstractMethodFail('baseUnit');
+    }
+
+    /**
+     * Gets the range that the field is bound by.
+     * 
+     * The range of the field is the period that the field varies within.
+     * For example, in the field 'MonthOfYear', the range is 'Years'.
+     * See also {@link baseUnit}.
+     * 
+     * The range is never null. For example, the 'Year' field is shorthand for
+     * 'YearOfForever'. It therefore has a unit of 'Years' and a range of 'Forever'.
+     *
+     * @return {TemporalUnit} the period unit defining the range of the field, not null
+     */
+    rangeUnit() {
+        abstractMethodFail('rangeUnit');
+    }
+
+    /**
+     * Gets the range of valid values for the field.
+     *
+     * All fields can be expressed as an integer.
+     * This method returns an object that describes the valid range for that value.
+     * This method is generally only applicable to the ISO-8601 calendar system.
+     *
+     * Note that the result only describes the minimum and maximum valid values
+     * and it is important not to read too much into them. For example, there
+     * could be values within the range that are invalid for the field.
+     *
+     * @returns {!ValueRange} the range of valid values for the field, not null
+     */
+    range() {
+        abstractMethodFail('range');
+    }
+
+    /**
+     * Get the range of valid values for this field using the temporal object to
+     * refine the result.
+     *
+     * This uses the temporal object to find the range of valid values for the field.
+     * This is similar to {@link range}, however this method refines the result
+     * using the temporal. For example, if the field is {@link DAY_OF_MONTH} the
+     * {@link range} method is not accurate as there are four possible month lengths,
+     * 28, 29, 30 and 31 days. Using this method with a date allows the range to be
+     * accurate, returning just one of those four options.
+     *
+     * There are two equivalent ways of using this method.
+     * The first is to invoke this method directly.
+     * The second is to use {@link TemporalAccessor#range}:
+     * <pre>
+     *   // these two lines are equivalent, but the second approach is recommended
+     *   temporal = thisField.rangeRefinedBy(temporal);
+     *   temporal = temporal.range(thisField);
+     * </pre>
+     * It is recommended to use the second approach, {@link range},
+     * as it is a lot clearer to read in code.
+     *
+     * Implementations should perform any queries or calculations using the fields
+     * available in {@link ChronoField}.
+     * If the field is not supported a {@link DateTimeException} must be thrown.
+     *
+     * @param {!TemporalAccessor} temporal - the temporal object used to refine the result, not null
+     * @return {ValueRange} the range of valid values for this field, not null
+     * @throws {DateTimeException} if the range for the field cannot be obtained
+     */
+    // eslint-disable-next-line no-unused-vars
+    rangeRefinedBy(temporal) {
+        abstractMethodFail('rangeRefinedBy');
+    }
+
+    /**
+     * Gets the value of this field from the specified temporal object.
+     *
+     * This queries the temporal object for the value of this field.
+     *
+     * There are two equivalent ways of using this method.
+     * The first is to invoke this method directly.
+     * The second is to use {@link TemporalAccessor#get}:
+     * <pre>
+     *   // these two lines are equivalent, but the second approach is recommended
+     *   temporal = thisField.getFrom(temporal);
+     *   temporal = temporal.get(thisField);
+     * </pre>
+     * It is recommended to use the second approach, as it is a lot clearer to read in code.
+     *
+     * Implementations should perform any queries or calculations using the fields
+     * available in {@link ChronoField}.
+     * If the field is not supported a {@link DateTimeException} must be thrown.
+     *
+     * @param {TemporalAccesor} temporal the temporal object to query, not null
+     * @return {!number} the value of this field, not null
+     * @throws {DateTimeException} if a value for the field cannot be obtained
+     */
+    // eslint-disable-next-line no-unused-vars
+    getFrom(temporal) {
+        abstractMethodFail('getFrom');
+    }
+
+    /**
+     * Returns a copy of the specified temporal object with the value of this field set.
+     *
+     * This returns a new temporal object based on the specified one with the value for
+     * this field changed. For example, on a {@link LocalDate}, this could be used to
+     * set the year, month or day-of-month.
+     * The returned object has the same observable type as the specified object.
+     *
+     * In some cases, changing a field is not fully defined. For example, if the target object is
+     * a date representing the 31st January, then changing the month to February would be unclear.
+     * In cases like this, the implementation is responsible for resolving the result.
+     * Typically it will choose the previous valid date, which would be the last valid
+     * day of February in this example.
+     *
+     * There are two equivalent ways of using this method.
+     * The first is to invoke this method directly.
+     * The second is to use {@link Temporal#with}:
+     * <pre>
+     *   // these two lines are equivalent, but the second approach is recommended
+     *   temporal = thisField.adjustInto(temporal);
+     *   temporal = temporal.with(thisField);
+     * </pre>
+     * It is recommended to use the second approach, `with(temporal)`,
+     * as it is a lot clearer to read in code.
+     *
+     * Implementations should perform any queries or calculations using the fields
+     * available in {@link ChronoField}.
+     * If the field is not supported a {@link DateTimeException} must be thrown.
+     *
+     * Implementations must not alter the specified temporal object.
+     * Instead, an adjusted copy of the original must be returned.
+     * This provides equivalent, safe behavior for immutable and mutable implementations.
+     *
+     * @param {!Temporal} temporal the temporal object to adjust, not null
+     * @param {!number} newValue the new value of the field
+     * @return {!Temporal} the adjusted temporal object, not null
+     * @throws {DateTimeException} if the field cannot be set
+     */
+    // eslint-disable-next-line no-unused-vars
+    adjustInto(temporal, newValue) {
+        abstractMethodFail('adjustInto');
+    }
+
+    /**
+     * Checks if this field is supported by the temporal object.
+     *
+     * This determines whether the temporal accessor supports this field.
+     * If this returns false, the the temporal cannot be queried for this field.
+     *
+     * There are two equivalent ways of using this method.
+     * The first is to invoke this method directly.
+     * The second is to use {@link TemporalAccessor#isSupported}:
+     * <pre>
+     *   // these two lines are equivalent, but the second approach is recommended
+     *   temporal = thisField.isSupportedBy(temporal);
+     *   temporal = temporal.isSupported(thisField);
+     * </pre>
+     * It is recommended to use the second approach, `isSupported(temporal)`,
+     * as it is a lot clearer to read in code.
+     *
+     * Implementations should determine whether they are supported using the fields
+     * available in {@link ChronoField}.
+     *
+     * @param {TemporalAccesor} temporal  the temporal object to query, not null
+     * @return {boolean} true if the date-time can be queried for this field, false if not
+     */
+    // eslint-disable-next-line no-unused-vars
+    isSupportedBy(temporal) {
+        abstractMethodFail('isSupportedBy');
+    }
+
+    /**
+     *
+     * @returns {string}
+     */
+    displayName(/* TODO: locale */) {
+        abstractMethodFail('displayName');
+    }
+
+    /**
+    *
+    * @param {*} other
+    * @returns {boolean}
+    */
+    // eslint-disable-next-line no-unused-vars
+    equals(other) {
+        abstractMethodFail('equals');
+    }
+
+    /**
+     *
+     * @returns {string}
+     */
+    name() {
+        abstractMethodFail('name');
+    }
+}

--- a/packages/core/src/temporal/TemporalField.js
+++ b/packages/core/src/temporal/TemporalField.js
@@ -27,7 +27,7 @@ export class TemporalField {
     /**
      * Checks if this field represents a component of a date.
      *
-     * @return {boolean} true if it is a component of a date
+     * @return {boolean} `true` if it is a component of a date, `false` otherwise.
      */
     isDateBased() {
         abstractMethodFail('isDateBased');
@@ -36,7 +36,7 @@ export class TemporalField {
     /**
      * Checks if this field represents a component of a time.
      *
-     * @return {boolean} true if it is a component of a time
+     * @return {boolean} `true` if it is a component of a time, `false` otherwise.
      */
     isTimeBased() {
         abstractMethodFail('isTimeBased');
@@ -49,7 +49,7 @@ export class TemporalField {
      * For example, in the field 'MonthOfYear', the unit is 'Months'.
      * See also {@link rangeUnit}.
      *
-     * @returns {!TemporalUnit}
+     * @return {TemporalUnit} the period unit defining the base unit of the field.
      */
     baseUnit() {
         abstractMethodFail('baseUnit');
@@ -65,7 +65,7 @@ export class TemporalField {
      * The range is never null. For example, the 'Year' field is shorthand for
      * 'YearOfForever'. It therefore has a unit of 'Years' and a range of 'Forever'.
      *
-     * @return {TemporalUnit} the period unit defining the range of the field, not null
+     * @return {TemporalUnit} the period unit defining the range of the field.
      */
     rangeUnit() {
         abstractMethodFail('rangeUnit');
@@ -82,7 +82,7 @@ export class TemporalField {
      * and it is important not to read too much into them. For example, there
      * could be values within the range that are invalid for the field.
      *
-     * @returns {!ValueRange} the range of valid values for the field, not null
+     * @return {ValueRange} the range of valid values for the field.
      */
     range() {
         abstractMethodFail('range');
@@ -114,9 +114,10 @@ export class TemporalField {
      * available in {@link ChronoField}.
      * If the field is not supported a {@link DateTimeException} must be thrown.
      *
-     * @param {!TemporalAccessor} temporal - the temporal object used to refine the result, not null
-     * @return {ValueRange} the range of valid values for this field, not null
-     * @throws {DateTimeException} if the range for the field cannot be obtained
+     * @param {!TemporalAccessor} temporal the temporal object used to refine the result.
+     * @return {ValueRange} the range of valid values for this field.
+     * @throws {DateTimeException} if the range for the field cannot be obtained.
+     * 
      */
     // eslint-disable-next-line no-unused-vars
     rangeRefinedBy(temporal) {
@@ -142,9 +143,9 @@ export class TemporalField {
      * available in {@link ChronoField}.
      * If the field is not supported a {@link DateTimeException} must be thrown.
      *
-     * @param {TemporalAccesor} temporal the temporal object to query, not null
-     * @return {!number} the value of this field, not null
-     * @throws {DateTimeException} if a value for the field cannot be obtained
+     * @param {!TemporalAccesor} temporal the temporal object to query.
+     * @return {number} the value of this field.
+     * @throws {DateTimeException} if a value for the field cannot be obtained.
      */
     // eslint-disable-next-line no-unused-vars
     getFrom(temporal) {
@@ -184,10 +185,10 @@ export class TemporalField {
      * Instead, an adjusted copy of the original must be returned.
      * This provides equivalent, safe behavior for immutable and mutable implementations.
      *
-     * @param {!Temporal} temporal the temporal object to adjust, not null
-     * @param {!number} newValue the new value of the field
-     * @return {!Temporal} the adjusted temporal object, not null
-     * @throws {DateTimeException} if the field cannot be set
+     * @param {!Temporal} temporal the temporal object to adjust.
+     * @param {!number} newValue the new value of the field.
+     * @return {Temporal} the adjusted temporal object.
+     * @throws {DateTimeException} if the field cannot be set.
      */
     // eslint-disable-next-line no-unused-vars
     adjustInto(temporal, newValue) {
@@ -214,8 +215,8 @@ export class TemporalField {
      * Implementations should determine whether they are supported using the fields
      * available in {@link ChronoField}.
      *
-     * @param {TemporalAccesor} temporal  the temporal object to query, not null
-     * @return {boolean} true if the date-time can be queried for this field, false if not
+     * @param {!TemporalAccesor} temporal the temporal object to query.
+     * @return {boolean} `true` if the date-time can be queried for this field, `false` if not.
      */
     // eslint-disable-next-line no-unused-vars
     isSupportedBy(temporal) {
@@ -223,15 +224,13 @@ export class TemporalField {
     }
 
     /**
-     *
-     * @returns {string}
+     * @return {string}
      */
     displayName(/* TODO: locale */) {
         abstractMethodFail('displayName');
     }
 
     /**
-    *
     * @param {*} other
     * @returns {boolean}
     */
@@ -241,7 +240,6 @@ export class TemporalField {
     }
 
     /**
-     *
      * @returns {string}
      */
     name() {

--- a/packages/core/src/temporal/TemporalUnit.js
+++ b/packages/core/src/temporal/TemporalUnit.js
@@ -32,14 +32,14 @@ export class TemporalUnit {
      *
      * All units return a duration measured in standard nanoseconds from this method.
      * The duration will be positive and non-zero.
-     * For example, an hour has a duration of `60 * 60 * 1,000,000,000ns`.
+     * For example, an hour has a duration of `60 * 60 * 1,000,000,000 ns`.
      *
      * Some units may return an accurate duration while others return an estimate.
      * For example, days have an estimated duration due to the possibility of
      * daylight saving time changes.
      * To determine if the duration is an estimate, use {@link isDurationEstimated}.
      *
-     * @return {Duration} the duration of this unit, which may be an estimate, not null
+     * @return {Duration} the duration of this unit, which may be an estimate.
      */
     duration() {
         abstractMethodFail('duration');
@@ -54,7 +54,7 @@ export class TemporalUnit {
      * This method returns true if the duration is an estimate and false if it is
      * accurate. Note that accurate/estimated ignores leap seconds.
      *
-     * @return {boolean} true if the duration is estimated, false if accurate
+     * @return {boolean} `true` if the duration is estimated, `false` if accurate.
      */
     isDurationEstimated() {
         abstractMethodFail('isDurationEstimated');
@@ -63,7 +63,7 @@ export class TemporalUnit {
     /**
      * Checks if this unit is date-based.
      *
-     * @return {boolean} true if date-based
+     * @return {boolean} `true` if date unit, `false` if a time unit.
      */
     isDateBased() {
         abstractMethodFail('isDateBased');
@@ -72,7 +72,7 @@ export class TemporalUnit {
     /**
      * Checks if this unit is time-based.
      *
-     * @return {boolean} true if time-based
+     * @return {boolean} `true` if time unit, `false` if a date unit.
      */
     isTimeBased() {
         abstractMethodFail('isTimeBased');
@@ -85,8 +85,8 @@ export class TemporalUnit {
      * This checks that the implementing date-time can add/subtract this unit.
      * This can be used to avoid throwing an exception.
      *
-     * @param {Temporal} temporal  the temporal object to check, not null
-     * @return {boolean} true if the unit is supported
+     * @param {!Temporal} temporal the temporal object to check.
+     * @return {boolean} `true` if the unit is supported.
      */
     // eslint-disable-next-line no-unused-vars
     isSupportedBy(temporal) {
@@ -120,10 +120,10 @@ export class TemporalUnit {
      * Instead, an adjusted copy of the original must be returned.
      * This provides equivalent, safe behavior for immutable and mutable implementations.
      *
-     * @param {Temporal} dateTime  the temporal object to adjust, not null
-     * @param {number} periodToAdd  the period of this unit to add, positive or negative
-     * @return {Temporal} the adjusted temporal object, not null
-     * @throws DateTimeException if the period cannot be added
+     * @param {!Temporal} dateTime the temporal object to adjust.
+     * @param {number} periodToAdd the period of this unit to add, positive or negative.
+     * @return {Temporal} the adjusted temporal object.
+     * @throws DateTimeException if the period cannot be added.
      */
     // eslint-disable-next-line no-unused-vars
     addTo(dateTime, periodToAdd) {
@@ -141,7 +141,7 @@ export class TemporalUnit {
      * using {@link HOURS.between}.
      *
      * The calculation returns a whole number, representing the number of complete units between the two temporals.
-     * For example, the period in hours between the times 11:30 and 13:29 will only b
+     * For example, the period in hours between the times 11:30 and 13:29 will only be
      * one hour as it is one minute short of two hours.
      *
      * There are two equivalent ways of using this method.
@@ -162,19 +162,18 @@ export class TemporalUnit {
      * </pre>
      * Implementations should perform any queries or calculations using the units available in
      * {@link ChronoUnit} or the fields available in {@link ChronoField}.
-     * If the unit is not supported a DateTimeException must be thrown.
+     * If the unit is not supported a {@link DateTimeException} must be thrown.
      * Implementations must not alter the specified temporal objects.
      *
-     * @param {Temporal} temporal1  the base temporal object, not null
-     * @param {Temporal} temporal2  the other temporal object, not null
+     * @param {!Temporal} temporal1 the base temporal object.
+     * @param {!Temporal} temporal2 the other temporal object.
      * @return {number} the period between temporal1 and temporal2 in terms of this unit;
-     *  positive if temporal2 is later than temporal1, negative if earlier
-     * @throws DateTimeException if the period cannot be calculated
-     * @throws ArithmeticException if numeric overflow occurs
+     *  positive if temporal2 is later than temporal1, negative if earlier.
+     * @throws DateTimeException if the period cannot be calculated.
+     * @throws ArithmeticException if numeric overflow occurs.
      */
     // eslint-disable-next-line no-unused-vars
     between(temporal1, temporal2) {
         abstractMethodFail('between');
     }
-
 }

--- a/packages/core/src/temporal/ValueRange.js
+++ b/packages/core/src/temporal/ValueRange.js
@@ -115,6 +115,7 @@ export class ValueRange {
             }
             return assert(false, msg, DateTimeException);
         }
+        return value;
     }
 
     /**

--- a/packages/core/test/DayOfWeekTest.js
+++ b/packages/core/test/DayOfWeekTest.js
@@ -37,11 +37,11 @@ describe('js-joda DayOfWeek', () => {
         });
     });
     
-    describe('getDisplayName', () => {
+    describe('displayName', () => {
         
         it('should throw an IllegalArgumentException', () => {
             expect(() => {
-                DayOfWeek.MONDAY.getDisplayName();
+                DayOfWeek.MONDAY.displayName();
             }).to.throw(IllegalArgumentException);
         });
         

--- a/packages/core/test/reference/DayOfWeekTest.js
+++ b/packages/core/test/reference/DayOfWeekTest.js
@@ -94,23 +94,23 @@ describe('org.threeten.bp.TestDayOfWeek', () => {
     
     });
     
-    describe.skip('getDisplayName()', function () {
+    describe.skip('displayName()', function () {
         // TODO: skipped because it needs locale support
-        it('test_getDisplayName', () => {
+        it('test_displayName', () => {
             // eslint-disable-next-line no-undef
-            assertEquals(DayOfWeek.MONDAY.getDisplayName(TextStyle.SHORT, Locale.US), 'Mon');
+            assertEquals(DayOfWeek.MONDAY.displayName(TextStyle.SHORT, Locale.US), 'Mon');
         });
         
-        it('test_getDisplayName_nullStyle', () => {
+        it('test_displayName_nullStyle', () => {
             expect(() => {
                 // eslint-disable-next-line no-undef
-                DayOfWeek.MONDAY.getDisplayName(null, Locale.US);
+                DayOfWeek.MONDAY.displayName(null, Locale.US);
             }).to.throw(NullPointerException);
         });
         
-        it('test_getDisplayName_nullLocale', () => {
+        it('test_displayName_nullLocale', () => {
             expect(() => {
-                DayOfWeek.MONDAY.getDisplayName(TextStyle.FULL, null);
+                DayOfWeek.MONDAY.displayName(TextStyle.FULL, null);
             }).to.throw(NullPointerException);
         });
     });

--- a/packages/core/test/reference/MonthTest.js
+++ b/packages/core/test/reference/MonthTest.js
@@ -99,20 +99,20 @@ describe('org.threeten.bp.TestMonth', () => {
         });
     });
 
-    describe.skip('getDisplayName()', () => {
-        it('test_ggetDisplayName', () => {
+    describe.skip('displayName()', () => {
+        it('test_displayName', () => {
             //eslint-disable-next-line no-undef
-            expect(Month.JANUARY.getDisplayName(TextStyle.SHORT, Locale.US)).to.eql('Jan');
+            expect(Month.JANUARY.displayName(TextStyle.SHORT, Locale.US)).to.eql('Jan');
         });
-        it('test_getDisplayName_nullStyle', () => {
+        it('test_displayName_nullStyle', () => {
             expect(() => {
                 //eslint-disable-next-line no-undef
-                Month.JANUARY.getDisplayName(null, Locale.US);
+                Month.JANUARY.displayName(null, Locale.US);
             }).to.throw(DateTimeException); //NullPointerException in JDK
         });
-        it('test_getDisplayName_nullLocale', () => {
+        it('test_displayName_nullLocale', () => {
             expect(() => {
-                Month.JANUARY.getDisplayName(TextStyle.FULL, null);
+                Month.JANUARY.displayName(TextStyle.FULL, null);
             }).to.throw(DateTimeException); //NullPointerException in JDK
         });
     });
@@ -391,4 +391,3 @@ describe('org.threeten.bp.TestMonth', () => {
     });                                  
 
 });
-

--- a/packages/core/test/reference/temporal/MockFieldNoValue.js
+++ b/packages/core/test/reference/temporal/MockFieldNoValue.js
@@ -53,7 +53,7 @@ export class MockFieldNoValue extends TemporalField {
         throw new DateTimeException('Mock');
     }
 
-    getDisplayName() {
+    displayName() {
         return 'Mock';
     }
 

--- a/packages/core/test/reference/temporal/MockFieldNoValue.js
+++ b/packages/core/test/reference/temporal/MockFieldNoValue.js
@@ -17,11 +17,11 @@ export class MockFieldNoValue extends TemporalField {
         return null;
     }
 
-    getBaseUnit() {
+    baseUnit() {
         return ChronoUnit.WEEKS;
     }
 
-    getRangeUnit() {
+    rangeUnit() {
         return ChronoUnit.MONTHS;
     }
 

--- a/packages/core/test/temporal/ChronoFieldTest.js
+++ b/packages/core/test/temporal/ChronoFieldTest.js
@@ -29,4 +29,29 @@ describe('js-joda ChronoField', () => {
             expect(ChronoField.INSTANT_SECONDS.isSupportedBy(temporal)).to.equal(false);
         });
     });
+
+    describe('checkValidValue', () => {
+        it('should return the given value if valid', () => {
+            const fields = allChronoFields();
+
+            for (const field of fields) {
+                const value = field.range().largestMinimum();
+
+                expect(field.checkValidValue(value)).to.eq(value);
+            }
+        });
+    });
 });
+
+function allChronoFields() {
+    const fields = [];
+    for (const key in ChronoField) {
+        if (
+            Object.prototype.hasOwnProperty.call(ChronoField, key) &&
+            ChronoField[key] instanceof ChronoField
+        ) {
+            fields.push(ChronoField[key]);
+        }
+    }
+    return fields;
+}

--- a/packages/core/test/temporal/ChronoFieldTest.js
+++ b/packages/core/test/temporal/ChronoFieldTest.js
@@ -1,0 +1,32 @@
+import { expect } from 'chai';
+
+import '../_init';
+
+import {LocalDate} from '../../src/LocalDate';
+import {ChronoField} from '../../src/temporal/ChronoField';
+
+describe('js-joda ChronoField', () => {
+    describe('adjustInto', () => {
+        it('should return a new temporal with the field of this kind set', () => {
+            const temporal = LocalDate.of(2020, 6, 13);
+
+            const result = ChronoField.DAY_OF_MONTH.adjustInto(temporal, 20);
+
+            expect(LocalDate.of(2020, 6, 20).equals(result)).to.equal(true);
+        });
+    });
+
+    describe('isSupportedBy', () => {
+        const temporal = LocalDate.of(2020, 6, 13);
+
+        it('should return true if supported by temporal', () => {
+            expect(ChronoField.DAY_OF_MONTH.isSupportedBy(temporal)).to.equal(true);
+            expect(ChronoField.YEAR.isSupportedBy(temporal)).to.equal(true);
+        });
+
+        it('should return false if unsupported by temporal', () => {
+            expect(ChronoField.HOUR_OF_DAY.isSupportedBy(temporal)).to.equal(false);
+            expect(ChronoField.INSTANT_SECONDS.isSupportedBy(temporal)).to.equal(false);
+        });
+    });
+});

--- a/packages/core/test/typescript_definitions/js-joda-tests.ts
+++ b/packages/core/test/typescript_definitions/js-joda-tests.ts
@@ -37,6 +37,8 @@ import {
     NullPointerException,
     DateTimeException,
     UnsupportedTemporalTypeException,
+    TemporalField,
+    ValueRange
 } from '../../'
 
 // used below
@@ -831,6 +833,19 @@ function test_exceptions() {
     const e2 = new DateTimeParseException('message', 'text', 0, e1);
     new DateTimeException();
     new DateTimeParseException();
+}
+
+function test_TemporalField() {
+    const field: TemporalField = IsoFields.DAY_OF_QUARTER;
+
+    expectType<TemporalUnit>(field.baseUnit());
+    expectType<number>(field.getFrom(LocalTime.now()));
+    expectType<boolean>(field.isDateBased());
+    expectType<boolean>(field.isTimeBased());
+    expectType<ValueRange>(field.range());
+    expectType<ValueRange>(field.rangeRefinedBy(LocalDate.now()));
+    expectType<boolean>(field.isSupportedBy(LocalDate.now()));
+    expectType<LocalDate>(field.adjustInto(LocalDate.now(), 1));
 }
 
 /**

--- a/packages/locale/src/temporal/WeekFields.js
+++ b/packages/locale/src/temporal/WeekFields.js
@@ -470,7 +470,7 @@ export class ComputedDayOfField {
         return ValueRange.of(1, weekIndexOfFirstWeekNextYear - 1);
     }
 
-    getDisplayName(locale) {
+    displayName(locale) {
         requireNonNull(locale, 'locale');
         if (this._rangeUnit === ChronoUnit.YEARS) {  // week-of-year
             return 'Week';

--- a/packages/locale/test/temporal/WeekFieldsTest.js
+++ b/packages/locale/test/temporal/WeekFieldsTest.js
@@ -97,9 +97,9 @@ describe('@js-joda/locale WeekFields', () => {
             }, false);
         });
 
-        it('getDisplayName', () => {
+        it('displayName', () => {
             dataProviderTest(data, (field, baseUnit, rangeUnit, range, isDateBased, isTimeBased, displayName) => {
-                assertEquals(field.getDisplayName(Locale.US), displayName);
+                assertEquals(field.displayName(Locale.US), displayName);
             }, false);
         });
 


### PR DESCRIPTION
This PR makes some cleanups and improvements to temporal fields and units. Some of them were mentioned in #355. In particular:

- The "abstract" class `TemporalField` now contains the relevant methods, all documented.
- `ChronoField` now have methods `isSupportedBy` and `adjustInto` to conform the `TemporalField` interface. The implementation is the same as in threetenbp. I made some basic tests, mostly to prove that the methods exist and work with a particular example; the core of the implementation is already tested in the temporal objects.
- Some methods still named as `getDisplayName` were renamed to `displayName`.
- `IsoFields` is no longer a class, but is now and object to better serve its purpose as an _enum_. The properties are still late-setted in the `_init()` function.
- The ThreeTen indicates that `checkValidValue` in a `ChronoField` should return the given value (or throw), but `ValueRange.prototype.checkValidValue` returned `undefined`. The mentioned function now returns the given value. I tested this from `ChronoField.prototype.checkValidValue` since its more important than `ValueRange` itself.
- The TS declarations were properly updated.
- Since I were already into that, I updated the documentation of `TemporalField`, `ChronoField`, `IsoFields`, `TemporalUnit` and `ChronoUnit`. Some methods had an incorrect signature in the jsdoc. I also added the descriptions for the fields itself.
    I changed the docs for the fields into a list. I think it looks better on the generated page. I also removed the docs in the functions that are inherited from a base class; esdoc copies the documentation, but sadly not the signature, so the signature need to stay.
    Also added some documentation to the TS declarations for the methods and classes I changed in this PR. The documentation is mostly a brief description, but I think it can help developers using an editor/IDE with TS inference. Probably in the future I can improve this a little further.