### PR TITLE
Remove YearMonth#with that takes (number, number)

### DIFF
--- a/packages/core/dist/js-joda.d.ts
+++ b/packages/core/dist/js-joda.d.ts
@@ -861,7 +861,6 @@ export class YearMonth extends Temporal implements TemporalAdjuster {
     plusMonths(monthsToAdd: number): YearMonth;
     with(adjuster: TemporalAdjuster): YearMonth;
     with(field: TemporalField, value: number): YearMonth;
-    withYearMonth(newYear: number, newMonth: number): YearMonth;
     withYear(year: number): YearMonth;
     withMonth(month: number): YearMonth;
     isSupported(fieldOrUnit: TemporalField | TemporalUnit): boolean;

--- a/packages/core/src/YearMonth.js
+++ b/packages/core/src/YearMonth.js
@@ -408,7 +408,7 @@ export class YearMonth extends Temporal {
      * @throws DateTimeException if a value for the field cannot be obtained
      * @throws ArithmeticException if numeric overflow occurs
      */
-    getLong( field) {
+    getLong(field) {
         requireNonNull(field, 'field');
         requireInstance(field, TemporalField, 'field');
         if (field instanceof ChronoField) {
@@ -542,12 +542,13 @@ export class YearMonth extends Temporal {
      * @returns {YearMonth}
      */
     with(adjusterOrFieldOrNumber, value) {
+        if (arguments.length === 2 && typeof adjusterOrFieldOrNumber === 'number') {
+            return this.withYearMonth(adjusterOrFieldOrNumber, value);
+        }
         if (arguments.length === 1) {
             return this.withAdjuster(adjusterOrFieldOrNumber);
-        } else if (arguments.length === 2 && adjusterOrFieldOrNumber instanceof TemporalField){
-            return this.withFieldValue(adjusterOrFieldOrNumber, value);
         } else {
-            return this.withYearMonth(adjusterOrFieldOrNumber, value);
+            return this.withFieldValue(adjusterOrFieldOrNumber, value);
         }
     }
 

--- a/packages/core/src/YearMonth.js
+++ b/packages/core/src/YearMonth.js
@@ -532,41 +532,18 @@ export class YearMonth extends Temporal {
      * function overloading for {@link YearMonth.with}
      *
      * if called with 1 argument, then {@link YearMonth.withAdjuster} is executed,
+     * otherwise {@link YearMonth.withFieldValue} is executed.
      *
-     * if called with 2 arguments and first argument is an instance of TemporalField, then {@link YearMonth.withFieldValue} is executed,
-     *
-     * otherwise {@link YearMonth.withYearMonth} is executed
-     *
-     * @param {!(TemporalAdjuster|TemporalField|Number)} adjusterOrFieldOrNumber
+     * @param {!(TemporalAdjuster|TemporalField)} adjusterOrField
      * @param {?number} value nullable only of first argument is an instance of TemporalAdjuster
      * @returns {YearMonth}
      */
-    with(adjusterOrFieldOrNumber, value) {
-        if (arguments.length === 2 && typeof adjusterOrFieldOrNumber === 'number') {
-            return this.withYearMonth(adjusterOrFieldOrNumber, value);
-        }
+    with(adjusterOrField, value) {
         if (arguments.length === 1) {
-            return this.withAdjuster(adjusterOrFieldOrNumber);
+            return this.withAdjuster(adjusterOrField);
         } else {
-            return this.withFieldValue(adjusterOrFieldOrNumber, value);
+            return this.withFieldValue(adjusterOrField, value);
         }
-    }
-
-    /**
-     * Returns a copy of this year-month with the new year and month, checking
-     * to see if a new object is in fact required.
-     *
-     * @param {number} newYear  the year to represent, validated from MIN_YEAR to MAX_YEAR
-     * @param {number} newMonth  the month-of-year to represent, validated not null
-     * @return the year-month, not null
-     */
-    withYearMonth(newYear, newMonth) {
-        requireNonNull(newYear);
-        requireNonNull(newMonth);
-        if (this._year === newYear && this._month === newMonth) {
-            return this;
-        }
-        return new YearMonth(newYear, newMonth);
     }
 
     /**
@@ -672,7 +649,7 @@ export class YearMonth extends Temporal {
      */
     withYear(year) {
         ChronoField.YEAR.checkValidValue(year);
-        return this.withYearMonth(year, this._month);
+        return new YearMonth(year, this._month);
     }
 
     /**
@@ -686,7 +663,7 @@ export class YearMonth extends Temporal {
      */
     withMonth(month) {
         ChronoField.MONTH_OF_YEAR.checkValidValue(month);
-        return this.withYearMonth(this._year, month);
+        return new YearMonth(this._year, month);
     }
 
     //-----------------------------------------------------------------------
@@ -751,7 +728,7 @@ export class YearMonth extends Temporal {
             return this;
         }
         const newYear = ChronoField.YEAR.checkValidIntValue(this._year + yearsToAdd);  // safe overflow
-        return this.withYearMonth(newYear, this._month);
+        return this.withYear(newYear);
     }
 
     /**
@@ -771,7 +748,7 @@ export class YearMonth extends Temporal {
         const calcMonths = monthCount + monthsToAdd;
         const newYear = ChronoField.YEAR.checkValidIntValue(MathUtil.floorDiv(calcMonths, 12));
         const newMonth = MathUtil.floorMod(calcMonths, 12) + 1;
-        return this.withYearMonth(newYear, newMonth);
+        return new YearMonth(newYear, newMonth);
     }
 
     //-----------------------------------------------------------------------

--- a/packages/core/test/YearMonthTest.js
+++ b/packages/core/test/YearMonthTest.js
@@ -84,33 +84,7 @@ describe('js-joda YearMonth', () => {
         });
         
     });
-    
-    describe('with(Year, Month)', () => {
-        it('should set the given values', () => {
-            const test = YearMonth.of(2015, 12);
-            expect(test.with(2016, 1)).to.eql(YearMonth.of(2016, 1));
-        });
-        
-        it('should return the same object if values are not changed', () => {
-            const test = YearMonth.of(2016, 1);
-            expect(test.with(2016, 1)).to.equal(test);
-        });
-        
-        it('should fail if year is null', () => {
-            expect(() => {
-                const test = YearMonth.of(2016, 1);
-                test.with(null, 1);
-            }).to.throw(NullPointerException);
-        });
-        
-        it('should fail if month is null', () => {
-            expect(() => {
-                const test = YearMonth.of(2016, 1);
-                test.with(2016, null);
-            }).to.throw(NullPointerException);
-        });
-    });
-    
+
     describe('with(TemporalField, value)', () => {
         it('should set the given values', () => {
             const test = YearMonth.of(2015, 12);

--- a/packages/core/test/YearMonthTest.js
+++ b/packages/core/test/YearMonthTest.js
@@ -136,21 +136,21 @@ describe('js-joda YearMonth', () => {
         it('should fail if field is null', () => {
             expect(() => {
                 const test = YearMonth.of(2016, 1);
-                test.withFieldValue(null, 1);
+                test.with(null, 1);
             }).to.throw(NullPointerException);
         });
         
         it('should fail for unsupported ChronoField', () => {
             expect(() => {
                 const test = YearMonth.of(2016, 1);
-                test.withFieldValue(ChronoField.HOUR_OF_DAY, 1);
+                test.with(ChronoField.HOUR_OF_DAY, 1);
             }).to.throw(UnsupportedTemporalTypeException);
         });
         
         it('should fail if field is not a TemporalField', () => {
             expect(() => {
                 const test = YearMonth.of(2016, 1);
-                test.withFieldValue({}, 1);
+                test.with({}, 1);
             }).to.throw(IllegalArgumentException);
         });
         

--- a/packages/core/test/YearTest.js
+++ b/packages/core/test/YearTest.js
@@ -165,19 +165,19 @@ describe('js-joda Year', () => {
         
         it('should fail if field is null', () => {
             expect(() => {
-                testYear.withFieldValue(null, 1);
+                testYear.with(null, 1);
             }).to.throw(NullPointerException);
         });
         
         it('should fail for unsupported ChronoField', () => {
             expect(() => {
-                testYear.withFieldValue(ChronoField.HOUR_OF_DAY, 1);
+                testYear.with(ChronoField.HOUR_OF_DAY, 1);
             }).to.throw(UnsupportedTemporalTypeException);
         });
         
         it('should fail if field is not a TemporalField', () => {
             expect(() => {
-                testYear.withFieldValue({}, 1);
+                testYear.with({}, 1);
             }).to.throw(IllegalArgumentException);
         });
         

--- a/packages/core/test/typescript_definitions/js-joda-tests.ts
+++ b/packages/core/test/typescript_definitions/js-joda-tests.ts
@@ -607,7 +607,6 @@ function test_YearMonth() {
 
     ym.with(TemporalAdjusters.firstDayOfMonth());
     ym.with(ChronoField.YEAR, 2018);
-    ym.withYearMonth(2018, 11);
     ym.withYear(2018);
     ym.withMonth(11);
 


### PR DESCRIPTION
This PR removes `YearMonth.prototype.withYearMonth` and the overload of `YearMonth.prototype.with` that used to take `(number, number)`.

Closes #411 