### PR TITLE
TS types refactor part 1

### DIFF
--- a/packages/core/dist/js-joda.d.ts
+++ b/packages/core/dist/js-joda.d.ts
@@ -85,6 +85,7 @@ export class DayOfWeek extends TemporalAccessor implements TemporalAdjuster {
     name(): string;
     ordinal(): number;
     plus(days: number): DayOfWeek;
+    toJSON(): string;
     toString(): string;
     value(): number;
 }
@@ -207,6 +208,10 @@ export class ResolverStyle {
     static LENIENT: ResolverStyle;
 
     private constructor();
+
+    equals(other: any): boolean;
+    toJSON(): string;
+    toString(): string;
 }
 
 export class SignStyle {
@@ -215,6 +220,12 @@ export class SignStyle {
     static ALWAYS: SignStyle;
     static EXCEEDS_PAD: SignStyle;
     static NOT_NEGATIVE: SignStyle;
+
+    private constructor();
+
+    equals(other: any): boolean;
+    toJSON(): string;
+    toString(): string;
 }
 
 export class DateTimeFormatter {
@@ -329,6 +340,7 @@ export class LocalTime extends Temporal implements TemporalAdjuster {
     plusSeconds(secondstoAdd: number): LocalTime;
     second(): number;
     toJSON(): string;
+    toString(): string;
     toNanoOfDay(): number;
     toSecondOfDay(): number;
     toString(): string;
@@ -378,6 +390,7 @@ export class Month extends TemporalAccessor implements TemporalAdjuster {
     name(): string;
     ordinal(): number;
     plus(months: number): Month;
+    toJSON(): string;
     toString(): string;
     value(): number;
 }
@@ -405,6 +418,7 @@ export class MonthDay extends TemporalAccessor implements TemporalAdjuster {
     isValidYear(year: number): boolean;
     month(): Month;
     monthValue(): number;
+    toJSON(): string;
     toString(): string;
     with(month: Month): MonthDay;
     withDayOfMonth(dayOfMonth: number): MonthDay;
@@ -1174,6 +1188,8 @@ export class Year extends Temporal implements TemporalAdjuster {
     plus(amount: TemporalAmount): Year;
     plus(amountToAdd: number, unit: TemporalUnit): Year;
     plusYears(yearsToAdd: number): Year;
+    toJSON(): string;
+    toString(): string;
     until(endExclusive: Temporal, unit: TemporalUnit): number;
     value(): number;
     with(adjuster: TemporalAdjuster): Year;
@@ -1239,6 +1255,7 @@ export abstract class ZoneId {
     abstract id(): string;
     normalized(): ZoneId;
     abstract rules(): ZoneRules;
+    toJSON(): string;
     toString(): string;
 }
 
@@ -1429,6 +1446,10 @@ export class TextStyle {
     asNormal(): TextStyle;
     asStandalone(): TextStyle;
     isStandalone(): boolean;
+
+    equals(other: any): boolean;
+    toJSON(): string;
+    toString(): string;
 }
 
 export interface Locale {

--- a/packages/core/dist/js-joda.d.ts
+++ b/packages/core/dist/js-joda.d.ts
@@ -25,19 +25,22 @@ export abstract class TemporalQuery<R> {
 
 export abstract class TemporalAccessor {
     get(field: TemporalField): number;
-    query<R>(query: TemporalQuery<R>): R;
+    query<R>(query: TemporalQuery<R>): R | null;
     range(field: TemporalField): ValueRange;
+    abstract getLong(field: TemporalField): number;
+    abstract isSupported(field: TemporalField): boolean;
 }
 
 export abstract class Temporal extends TemporalAccessor {
-    isSupported(unit: TemporalUnit): boolean;
-    minus(amountToSubtract: number, unit: TemporalUnit): Temporal;
-    minus(amount: TemporalAmount): Temporal;
-    plus(amountToAdd: number, unit: TemporalUnit): Temporal;
-    plus(amount: TemporalAmount): Temporal;
-    until(endTemporal: Temporal, unit: TemporalUnit): number;
-    with(adjuster: TemporalAdjuster): Temporal;
-    with(field: TemporalField, newValue: number): Temporal;
+    abstract isSupported(field: TemporalField): boolean;
+    abstract isSupported(unit: TemporalUnit): boolean;
+    abstract minus(amountToSubtract: number, unit: TemporalUnit): Temporal;
+    abstract minus(amount: TemporalAmount): Temporal;
+    abstract plus(amountToAdd: number, unit: TemporalUnit): Temporal;
+    abstract plus(amount: TemporalAmount): Temporal;
+    abstract until(endTemporal: Temporal, unit: TemporalUnit): number;
+    abstract with(adjuster: TemporalAdjuster): Temporal;
+    abstract with(field: TemporalField, newValue: number): Temporal;
 }
 
 export abstract class Clock {
@@ -181,7 +184,6 @@ export class Instant extends Temporal implements TemporalAdjuster {
     compareTo(otherInstant: Instant): number;
     epochSecond(): number;
     equals(other: any): boolean;
-    get(field: TemporalField): number;
     getLong(field: TemporalField): number;
     hashCode(): number;
     isAfter(otherInstant: Instant): boolean;
@@ -198,8 +200,6 @@ export class Instant extends Temporal implements TemporalAdjuster {
     plusMillis(millisToAdd: number): Instant;
     plusNanos(nanosToAdd: number): Instant;
     plusSeconds(secondsToAdd: number): Instant;
-    query<R>(query: TemporalQuery<R>): R;
-    range(field: TemporalField): ValueRange;
     toEpochMilli(): number;
     toJSON(): string;
     toString(): string;
@@ -315,7 +315,6 @@ export class LocalTime extends Temporal implements TemporalAdjuster {
     compareTo(other: LocalTime): number;
     equals(other: any): boolean;
     format(formatter: DateTimeFormatter): string;
-    get(field: ChronoField): number;
     getLong(field: ChronoField): number;
     hashCode(): number;
     hour(): number;
@@ -323,7 +322,7 @@ export class LocalTime extends Temporal implements TemporalAdjuster {
     isBefore(other: LocalTime): boolean;
     isSupported(fieldOrUnit: TemporalField | TemporalUnit): boolean;
     minus(amount: TemporalAmount): LocalTime;
-    minus(amountToSubtract: number, unit: ChronoUnit): LocalTime;
+    minus(amountToSubtract: number, unit: TemporalUnit): LocalTime;
     minusHours(hoursToSubtract: number): LocalTime;
     minusMinutes(minutesToSubtract: number): LocalTime;
     minusNanos(nanosToSubtract: number): LocalTime;
@@ -336,15 +335,13 @@ export class LocalTime extends Temporal implements TemporalAdjuster {
     plusMinutes(minutesToAdd: number): LocalTime;
     plusNanos(nanosToAdd: number): LocalTime;
     plusSeconds(secondstoAdd: number): LocalTime;
-    query<R>(query: TemporalQuery<R>): R;
-    range(field: ChronoField): ValueRange;
     second(): number;
     toJSON(): string;
     toNanoOfDay(): number;
     toSecondOfDay(): number;
     toString(): string;
     truncatedTo(unit: ChronoUnit): LocalTime;
-    until(endExclusive: TemporalAccessor, unit: TemporalUnit): number;
+    until(endExclusive: Temporal, unit: TemporalUnit): number;
     with(adjuster: TemporalAdjuster): LocalTime;
     with(field: TemporalField, newValue: number): LocalTime;
     withHour(hour: number): LocalTime;
@@ -379,7 +376,6 @@ export class Month extends TemporalAccessor implements TemporalAdjuster {
     equals(other: any): boolean;
     firstDayOfYear(leapYear: boolean): number;
     firstMonthOfQuarter(): Month;
-    get(field: TemporalField): number;
     displayName(style: TextStyle, locale: Locale): string;
     getLong(field: TemporalField): number;
     isSupported(field: TemporalField): boolean;
@@ -390,7 +386,6 @@ export class Month extends TemporalAccessor implements TemporalAdjuster {
     name(): string;
     ordinal(): number;
     plus(months: number): Month;
-    query<R>(query: TemporalQuery<R>): R;
     toString(): string;
     value(): number;
 }
@@ -411,7 +406,6 @@ export class MonthDay extends TemporalAccessor implements TemporalAdjuster {
     dayOfMonth(): number;
     equals(other: any): boolean;
     format(formatter: DateTimeFormatter): string;
-    get(field: TemporalField): number;
     getLong(field: TemporalField): number;
     isAfter(other: MonthDay): boolean;
     isBefore(other: MonthDay): boolean;
@@ -419,8 +413,6 @@ export class MonthDay extends TemporalAccessor implements TemporalAdjuster {
     isValidYear(year: number): boolean;
     month(): Month;
     monthValue(): number;
-    query<R>(query: TemporalQuery<R>): R;
-    range(field: TemporalField): ValueRange;
     toString(): string;
     with(month: Month): MonthDay;
     withDayOfMonth(dayOfMonth: number): MonthDay;
@@ -939,15 +931,15 @@ export class LocalDate extends ChronoLocalDate implements TemporalAdjuster {
     dayOfWeek(): DayOfWeek;
     dayOfYear(): number;
     equals(other: any): boolean;
-    get(field: TemporalField): number;
     getLong(field: TemporalField): number;
     hashCode(): number;
     isAfter(other: LocalDate): boolean;
     isBefore(other: LocalDate): boolean;
     isEqual(other: LocalDate): boolean;
     isLeapYear(): boolean;
-    isoWeekOfWeekyear(): number; //implemented in IsoFields.js
-    isoWeekyear(): number; //implemented in IsoFields.js
+    isoWeekOfWeekyear(): number;
+    isoWeekyear(): number;
+    isSupported(fieldOrUnit: TemporalField | TemporalUnit): boolean;
     lengthOfMonth(): number;
     lengthOfYear(): number;
     minus(amount: TemporalAmount): LocalDate;
@@ -964,15 +956,13 @@ export class LocalDate extends ChronoLocalDate implements TemporalAdjuster {
     plusMonths(monthsToAdd: number): LocalDate;
     plusWeeks(weeksToAdd: number): LocalDate;
     plusYears(yearsToAdd: number): LocalDate;
-    query<R>(query: TemporalQuery<R>): R;
-    range(field: TemporalField): ValueRange;
     toEpochDay(): number;
     toJSON(): string;
     toString(): string;
     until(endDate: TemporalAccessor): Period;
-    until(endExclusive: TemporalAccessor, unit: TemporalUnit): number;
-    with(fieldOrAdjuster: TemporalField, newValue: Number): LocalDate;
+    until(endExclusive: Temporal, unit: TemporalUnit): number;
     with(adjuster: TemporalAdjuster): LocalDate;
+    with(field: TemporalField, newValue: number): LocalDate;
     withDayOfMonth(dayOfMonth: number): LocalDate;
     withDayOfYear(dayOfYear: number): LocalDate;
     withMonth(month: Month | number): LocalDate;
@@ -1011,7 +1001,6 @@ export class LocalDateTime extends ChronoLocalDateTime implements TemporalAdjust
     dayOfYear(): number;
     equals(other: any): boolean;
     format(formatter: DateTimeFormatter): string;
-    get(field: TemporalField): number;
     getLong(field: TemporalField): number;
     hashCode(): number;
     hour(): number;
@@ -1027,7 +1016,6 @@ export class LocalDateTime extends ChronoLocalDateTime implements TemporalAdjust
     minusMonths(months: number): LocalDateTime;
     minusNanos(nanos: number): LocalDateTime;
     minusSeconds(seconds: number): LocalDateTime;
-    minusTemporalAmount(amount: TemporalAmount): LocalDateTime;
     minusWeeks(weeks: number): LocalDateTime;
     minusYears(years: number): LocalDateTime;
     minute(): number;
@@ -1042,11 +1030,8 @@ export class LocalDateTime extends ChronoLocalDateTime implements TemporalAdjust
     plusMonths(months: number): LocalDateTime;
     plusNanos(nanos: number): LocalDateTime;
     plusSeconds(seconds: number): LocalDateTime;
-    plusTemporalAmount(amount: TemporalAmount): LocalDateTime;
     plusWeeks(weeks: number): LocalDateTime;
     plusYears(years: number): LocalDateTime;
-    query<R>(query: TemporalQuery<R>): R;
-    range(field: TemporalField): ValueRange;
     second(): number;
     toJSON(): string;
     toLocalDate(): LocalDate;
@@ -1184,17 +1169,20 @@ export class Year extends Temporal implements TemporalAdjuster {
     atMonthDay(monthDay: MonthDay): LocalDate;
     compareTo(other: Year): number;
     equals(other: any): boolean;
+    getLong(field: TemporalField): number;
     isAfter(other: Year): boolean;
     isBefore(other: Year): boolean;
     isLeap(): boolean;
+    isSupported(fieldOrUnit: TemporalField | TemporalUnit): boolean;
     isValidMonthDay(monthDay: MonthDay): boolean;
     length(): number;
-    plus(amount: TemporalAmount): Year;
-    plus(amountToAdd: number, unit: TemporalUnit): Year;
-    plusYears(yearsToAdd: number): Year;
     minus(amount: TemporalAmount): Year;
     minus(amountToSubtract: number, unit: TemporalUnit): Year;
     minusYears(yearsToSubtract: number): Year;
+    plus(amount: TemporalAmount): Year;
+    plus(amountToAdd: number, unit: TemporalUnit): Year;
+    plusYears(yearsToAdd: number): Year;
+    until(endExclusive: Temporal, unit: TemporalUnit): number;
     value(): number;
     with(adjuster: TemporalAdjuster): Year;
     with(field: TemporalField, newValue: number): Year;
@@ -1211,34 +1199,36 @@ export class YearMonth extends Temporal implements TemporalAdjuster {
     private constructor();
 
     adjustInto(temporal: Temporal): Temporal;
-    minus(amount: TemporalAmount): YearMonth;
-    minus(amountToSubtract: number, unit: TemporalUnit): YearMonth;
-    minusYears(yearsToSubtract: number): YearMonth;
-    minusMonths(monthsToSubtract: number): YearMonth;
-    plus(amount: TemporalAmount): YearMonth;
-    plus(amountToAdd: number, unit: TemporalUnit): YearMonth;
-    plusYears(yearsToAdd: number): YearMonth;
-    plusMonths(monthsToAdd: number): YearMonth;
-    with(adjuster: TemporalAdjuster): YearMonth;
-    with(field: TemporalField, value: number): YearMonth;
-    withYear(year: number): YearMonth;
-    withMonth(month: number): YearMonth;
-    isSupported(fieldOrUnit: TemporalField | TemporalUnit): boolean;
-    year(): number;
-    monthValue(): number;
-    month(): Month;
-    isLeapYear(): boolean;
-    isValidDay(): boolean;
-    lengthOfMonth(): number;
-    lengthOfYear(): number;
     atDay(dayOfMonth: number): LocalDate;
     atEndOfMonth(): LocalDate;
     compareTo(other: YearMonth): number;
+    equals(other: any): boolean;
+    format(formatter: DateTimeFormatter): string;
+    getLong(field: TemporalField): number;
     isAfter(other: YearMonth): boolean;
     isBefore(other: YearMonth): boolean;
-    equals(other: any): boolean;
+    isLeapYear(): boolean;
+    isSupported(fieldOrUnit: TemporalField | TemporalUnit): boolean;
+    isValidDay(): boolean;
+    lengthOfMonth(): number;
+    lengthOfYear(): number;
+    minus(amount: TemporalAmount): YearMonth;
+    minus(amountToSubtract: number, unit: TemporalUnit): YearMonth;
+    minusMonths(monthsToSubtract: number): YearMonth;
+    minusYears(yearsToSubtract: number): YearMonth;
+    month(): Month;
+    monthValue(): number;
+    plus(amount: TemporalAmount): YearMonth;
+    plus(amountToAdd: number, unit: TemporalUnit): YearMonth;
+    plusMonths(monthsToAdd: number): YearMonth;
+    plusYears(yearsToAdd: number): YearMonth;
     toJSON(): string;
-    format(formatter: DateTimeFormatter): string;
+    until(endExclusive: Temporal, unit: TemporalUnit): number;
+    with(adjuster: TemporalAdjuster): YearMonth;
+    with(field: TemporalField, newValue: number): YearMonth;
+    withMonth(month: number): YearMonth;
+    withYear(year: number): YearMonth;
+    year(): number;
 }
 
 export abstract class ZoneId {
@@ -1282,7 +1272,6 @@ export class ZoneOffset extends ZoneId implements TemporalAdjuster {
     getLong(field: TemporalField): number;
     hashCode(): number;
     id(): string;
-    query<R>(query: TemporalQuery<R>): R;
     rules(): ZoneRules;
     toString(): string;
     totalSeconds(): number;
@@ -1353,7 +1342,6 @@ export abstract class ChronoZonedDateTime extends Temporal {
     isAfter(other: ChronoZonedDateTime): boolean;
     isBefore(other: ChronoZonedDateTime): boolean;
     isEqual(other: ChronoZonedDateTime): boolean;
-    query<R>(query: TemporalQuery<R>): R;
     toEpochSecond(): number;
     toInstant(): Instant;
 }
@@ -1379,7 +1367,6 @@ export class ZonedDateTime extends ChronoZonedDateTime {
     dayOfYear(): number;
     equals(other: any): boolean;
     format(formatter: DateTimeFormatter): string;
-    get(field: TemporalField): number;
     getLong(field: TemporalField): number;
     hashCode(): number;
     hour(): number;
@@ -1392,8 +1379,6 @@ export class ZonedDateTime extends ChronoZonedDateTime {
     minusMonths(months: number): ZonedDateTime;
     minusNanos(nanos: number): ZonedDateTime;
     minusSeconds(seconds: number): ZonedDateTime;
-    // TODO: Internal. Remove in next major version.
-    minusTemporalAmount(amount: TemporalAmount): ZonedDateTime;
     minusWeeks(weeks: number): ZonedDateTime;
     minusYears(years: number): ZonedDateTime;
     minute(): number;
@@ -1413,7 +1398,6 @@ export class ZonedDateTime extends ChronoZonedDateTime {
     plusTemporalAmount(amount: TemporalAmount): ZonedDateTime;
     plusWeeks(weeks: number): ZonedDateTime;
     plusYears(years: number): ZonedDateTime;
-    query<R>(query: TemporalQuery<R>): R;
     range(field: TemporalField): ValueRange;
     second(): number;
     toJSON(): string;
@@ -1505,7 +1489,6 @@ export class ArithmeticException extends Error {}
 export class IllegalArgumentException extends Error {}
 export class IllegalStateException extends Error {}
 export class NullPointerException extends Error {}
-
 
 export const __esModule: true;
 export as namespace JSJoda;

--- a/packages/core/dist/js-joda.d.ts
+++ b/packages/core/dist/js-joda.d.ts
@@ -122,11 +122,7 @@ export class Duration extends TemporalAmount {
     isZero(): boolean;
     minus(duration: Duration): Duration;
     minus(amount: number, unit: ChronoUnit): Duration;
-    // TODO: Internal. Remove in next major version.
-    minusAmountUnit(amountToSubtract: number, unit: TemporalUnit): Duration;
     minusDays(daysToSubtract: number): Duration;
-    // TODO: Internal. Remove in next major version.
-    minusDuration(duration: Duration): Duration;
     minusHours(hoursToSubtract: number): Duration;
     minusMillis(millisToSubtract: number): Duration;
     minusMinutes(minutesToSubtract: number): Duration;
@@ -137,11 +133,7 @@ export class Duration extends TemporalAmount {
     negated(): Duration;
     plus(duration: Duration): Duration;
     plus(amount: number, unit: ChronoUnit): Duration;
-    // TODO: Internal. Remove in next major version.
-    plusAmountUnit(amountToAdd: number, unit: TemporalUnit): Duration;
     plusDays(daysToAdd: number): Duration;
-    // TODO: Internal. Remove in next major version.
-    plusDuration(duration: Duration): Duration;
     plusHours(hoursToAdd: number): Duration;
     plusMillis(millisToAdd: number): Duration;
     plusMinutes(minutesToAdd: number): Duration;
@@ -1394,8 +1386,6 @@ export class ZonedDateTime extends ChronoZonedDateTime {
     plusMonths(months: number): ZonedDateTime;
     plusNanos(nanos: number): ZonedDateTime;
     plusSeconds(seconds: number): ZonedDateTime;
-    // TODO: Internal. Remove in next major version.
-    plusTemporalAmount(amount: TemporalAmount): ZonedDateTime;
     plusWeeks(weeks: number): ZonedDateTime;
     plusYears(years: number): ZonedDateTime;
     range(field: TemporalField): ValueRange;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,7 @@
     "test-browser": "./node_modules/.bin/karma start --reporters=dots --single-run",
     "test-saucelabs": "./node_modules/.bin/karma start --reporters=\"dots,saucelabs\" --browsers=\"sl_chrome,sl_ie,sl_firefox,sl_ios_simulator\" --single-run=true",
     "test-ci": "npm run build-dist && npm run test && npm run test-browser -- --browsers \"Firefox,PhantomJS\" && npm run test-ts-definitions && npm run test-coverage",
-    "test-ts-definitions": "tsc --noImplicitAny --strict --noEmit --pretty --lib ES6 test/typescript_definitions/js-joda-tests.ts",
+    "test-ts-definitions": "tsc -p test/typescript_definitions/tsconfig.json",
     "build-dist": "npx rollup -c rollup.config.js",
     "build-md-toc": "./node_modules/.bin/markdown-toc -i CheatSheet.md",
     "build-gz-check": "gzip -kf dist/js-joda.min.js && ls -alh ./dist/js-joda.min.js*",

--- a/packages/core/test/typescript_definitions/js-joda-tests.ts
+++ b/packages/core/test/typescript_definitions/js-joda-tests.ts
@@ -86,13 +86,7 @@ function test_LocalDate() {
     d.plusYears(1).isLeapYear();
     d.toEpochDay();
     d.lengthOfMonth();
-    d.range(ChronoField.DAY_OF_MONTH);
     d.lengthOfYear();
-    d.range(ChronoField.DAY_OF_YEAR);
-    d.get(ChronoField.ALIGNED_WEEK_OF_YEAR);
-    d.get(ChronoField.ALIGNED_DAY_OF_WEEK_IN_MONTH);
-    d.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR);
-
     d.isoWeekOfWeekyear();
     d.isoWeekyear();
 
@@ -103,28 +97,31 @@ function test_LocalDate() {
     d.get(IsoFields.DAY_OF_QUARTER);
     d.with(IsoFields.QUARTER_OF_YEAR, 3).with(IsoFields.DAY_OF_QUARTER, 15);
 
+    expectType<boolean>(d.isSupported(ChronoField.DAY_OF_MONTH));
+    expectType<boolean>(d.isSupported(ChronoUnit.DAYS));
+
     d = LocalDate.parse('2016-02-23');
-    d.plusDays(366);
-    d.minusDays(366);
-    d.plusMonths(12);
-    d.minusMonths(12);
-    d.plusWeeks(4);
-    d.minusWeeks(4);
-    d.plusYears(1);
-    d.minusYears(1);
-    d.plus(3, ChronoUnit.DECADES);
-    d.minus(3, ChronoUnit.DECADES);
-    d.plus(Period.ofMonths(3).plusDays(3));
-    d.minus(Period.ofMonths(3).plusDays(3));
+    expectType<LocalDate>(d.plusDays(366));
+    expectType<LocalDate>(d.minusDays(366));
+    expectType<LocalDate>(d.plusMonths(12));
+    expectType<LocalDate>(d.minusMonths(12));
+    expectType<LocalDate>(d.plusWeeks(4));
+    expectType<LocalDate>(d.minusWeeks(4));
+    expectType<LocalDate>(d.plusYears(1));
+    expectType<LocalDate>(d.minusYears(1));
+    expectType<LocalDate>(d.plus(3, ChronoUnit.DECADES));
+    expectType<LocalDate>(d.minus(3, ChronoUnit.DECADES));
+    expectType<LocalDate>(d.plus(Period.ofMonths(3).plusDays(3)));
+    expectType<LocalDate>(d.minus(Period.ofMonths(3).plusDays(3)));
 
     d = LocalDate.parse('2016-12-24');
-    d.withDayOfMonth(1);
-    d.withMonth(1).withDayOfMonth(1);
-    d.withMonth(Month.NOVEMBER).withDayOfMonth(1);
-    d.withYear(1);
+    expectType<LocalDate>(d.withDayOfMonth(1));
+    expectType<LocalDate>(d.withMonth(1).withDayOfMonth(1));
+    expectType<LocalDate>(d.withMonth(Month.NOVEMBER).withDayOfMonth(1));
+    expectType<LocalDate>(d.withYear(1));
+    expectType<LocalDate>(d.withDayOfYear(42));
+    expectType<LocalDate>(d.with(IsoFields.WEEK_OF_WEEK_BASED_YEAR, 52));
     LocalDate.now().plusMonths(1).withDayOfMonth(1).minusDays(1);
-    d.withDayOfYear(42);
-    d.with(IsoFields.WEEK_OF_WEEK_BASED_YEAR, 52);
 
     let d1 = LocalDate.parse('2016-12-24');
     let d2 = d1.plusDays(2);
@@ -163,15 +160,16 @@ function test_LocalDate() {
     d = LocalDate.from(nativeJs(moment()));
 
     d = LocalDate.parse('2016-12-24');
-    d.with(TemporalAdjusters.firstDayOfMonth());
-    d.with(TemporalAdjusters.lastDayOfMonth());
-    d.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
-    d.with(TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY));
-    d.with(TemporalAdjusters.next(DayOfWeek.SATURDAY));
-    d.with(TemporalAdjusters.lastInMonth(DayOfWeek.SATURDAY));
-    d.with(TemporalAdjusters.firstInMonth(DayOfWeek.SATURDAY));
+    expectType<LocalDate>(d.with(TemporalAdjusters.firstDayOfMonth()));
+    expectType<LocalDate>(d.with(TemporalAdjusters.lastDayOfMonth()));
+    expectType<LocalDate>(d.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY)));
+    expectType<LocalDate>(d.with(TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY)));
+    expectType<LocalDate>(d.with(TemporalAdjusters.next(DayOfWeek.SATURDAY)));
+    expectType<LocalDate>(d.with(TemporalAdjusters.lastInMonth(DayOfWeek.SATURDAY)));
+    expectType<LocalDate>(d.with(TemporalAdjusters.firstInMonth(DayOfWeek.SATURDAY)));
 
-    expectType<LocalDate>(d1.query(LocalDate.FROM));
+    expectType<LocalDate | null>(d1.query(LocalDate.FROM));
+    expectType<LocalTime | null>(d1.query(TemporalQueries.localTime()));
 }
 
 function test_Instant() {
@@ -179,6 +177,21 @@ function test_Instant() {
 
     i.toString();
     i.toJSON();
+
+    expectType<number>(i.get(ChronoField.INSTANT_SECONDS));
+    expectType<boolean>(i.isSupported(ChronoField.INSTANT_SECONDS));
+    expectType<boolean>(i.isSupported(ChronoUnit.SECONDS));
+    expectType<ValueRange>(i.range(ChronoField.MICRO_OF_SECOND));
+    expectType<Instant>(i.minus(5, ChronoUnit.DAYS));
+    expectType<Instant>(i.plus(5, ChronoUnit.DAYS));
+    expectType<Instant>(i.minus(Duration.ofHours(3)));
+    expectType<Instant>(i.plus(Duration.ofHours(3)));
+    expectType<Instant>(i.with(Instant.EPOCH));
+    expectType<Instant>(i.with(IsoFields.DAY_OF_QUARTER, 10));
+    expectType<number>(i.until(Instant.now(), ChronoUnit.SECONDS));
+
+    expectType<Instant | null>(i.query(Instant.FROM));
+    expectType<LocalDate | null>(i.query(TemporalQueries.localDate()));
 }
 
 function test_LocalTime() {
@@ -201,24 +214,29 @@ function test_LocalTime() {
     t.minute();
     t.second();
     t.nano();
-    t.get(ChronoField.SECOND_OF_DAY);
-    t.get(ChronoField.MILLI_OF_SECOND);
-    t.get(ChronoField.HOUR_OF_AMPM);
 
     t = LocalTime.parse('11:55:42');
-    t.plusHours(12);
-    t.minusHours(12);
-    t.plusMinutes(30);
-    t.minusMinutes(30);
-    t.plusSeconds(30);
-    t.minusSeconds(30);
-    t.plusNanos(1000000);
-    t.minusNanos(1000000);
-    t.plus(1, ChronoUnit.NANOS);
-    t.plus(1, ChronoUnit.MILLIS);
-    t.plus(1, ChronoUnit.HALF_DAYS);
-    t.plus(Duration.ofMinutes(15));
-    t.minus(Duration.ofMinutes(15));
+    expectType<LocalTime>(t.plusHours(12));
+    expectType<LocalTime>(t.minusHours(12));
+    expectType<LocalTime>(t.plusMinutes(30));
+    expectType<LocalTime>(t.minusMinutes(30));
+    expectType<LocalTime>(t.plusSeconds(30));
+    expectType<LocalTime>(t.minusSeconds(30));
+    expectType<LocalTime>(t.plusNanos(1000000));
+    expectType<LocalTime>(t.minusNanos(1000000));
+
+    expectType<number>(t.get(ChronoField.MINUTE_OF_DAY));
+    expectType<number>(t.get(IsoFields.DAY_OF_QUARTER));
+    expectType<boolean>(t.isSupported(ChronoField.HOUR_OF_DAY));
+    expectType<boolean>(t.isSupported(ChronoUnit.SECONDS));
+    expectType<ValueRange>(t.range(ChronoField.MICRO_OF_SECOND));
+    expectType<LocalTime>(t.minus(5, ChronoUnit.DAYS));
+    expectType<LocalTime>(t.plus(5, ChronoUnit.DAYS));
+    expectType<LocalTime>(t.minus(Duration.ofHours(3)));
+    expectType<LocalTime>(t.plus(Duration.ofHours(3)));
+    expectType<LocalTime>(t.with(LocalTime.MIDNIGHT));
+    expectType<LocalTime>(t.with(IsoFields.DAY_OF_QUARTER, 10));
+    expectType<number>(t.until(LocalTime.now(), ChronoUnit.SECONDS));
 
     t = LocalTime.parse('11:55:42');
     t.withHour(1);
@@ -268,7 +286,8 @@ function test_LocalTime() {
     t = LocalTime.from(nativeJs(new Date()));
     t = LocalTime.from(nativeJs(moment()));
 
-    expectType<LocalTime>(t1.query(LocalTime.FROM));
+    expectType<LocalTime | null>(t1.query(LocalTime.FROM));
+    expectType<LocalDate | null>(t1.query(TemporalQueries.localDate()));
 }
 
 function test_LocalDateTime() {
@@ -306,19 +325,21 @@ function test_LocalDateTime() {
     dt.toLocalDate();
     dt.toLocalTime();
     dt.toLocalDate().lengthOfMonth();
-    dt.range(ChronoField.DAY_OF_MONTH);
-
     dt.toLocalDate().lengthOfYear();
-    dt.range(ChronoField.DAY_OF_YEAR);
-
-    dt.get(ChronoField.ALIGNED_WEEK_OF_YEAR);
-
-    dt.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR);
     dt.toLocalDate().isoWeekOfWeekyear();
-    dt.get(ChronoField.SECOND_OF_DAY);
-    dt.get(ChronoField.MILLI_OF_SECOND);
-    dt.get(ChronoField.HOUR_OF_AMPM);
 
+    expectType<number>(dt.get(ChronoField.HOUR_OF_DAY));
+    expectType<number>(dt.get(IsoFields.DAY_OF_QUARTER));
+    expectType<boolean>(dt.isSupported(ChronoField.HOUR_OF_DAY));
+    expectType<boolean>(dt.isSupported(ChronoUnit.SECONDS));
+    expectType<ValueRange>(dt.range(ChronoField.MICRO_OF_SECOND));
+    expectType<LocalDateTime>(dt.minus(5, ChronoUnit.DAYS));
+    expectType<LocalDateTime>(dt.plus(5, ChronoUnit.DAYS));
+    expectType<LocalDateTime>(dt.minus(Duration.ofHours(3)));
+    expectType<LocalDateTime>(dt.plus(Duration.ofHours(3)));
+    expectType<LocalDateTime>(dt.with(LocalDateTime.MAX));
+    expectType<LocalDateTime>(dt.with(IsoFields.DAY_OF_QUARTER, 10));
+    expectType<number>(dt.until(LocalDateTime.now(), ChronoUnit.SECONDS));
 
     dt = LocalDateTime.parse('2016-02-26T23:55:42.123');
     dt.plusDays(366);
@@ -350,10 +371,6 @@ function test_LocalDateTime() {
 
     dt.plusNanos(1000000);
     dt.minusNanos(1000000);
-
-    dt.plus(1, ChronoUnit.NANOS);
-    dt.plus(1, ChronoUnit.MILLIS);
-    dt.plus(1, ChronoUnit.HALF_DAYS);
 
     dt.plus(Duration.ofHours(30).plusMinutes(45));
     dt.minus(Duration.ofHours(30).plusMinutes(45));
@@ -417,7 +434,8 @@ function test_LocalDateTime() {
     dt = LocalDateTime.from(nativeJs(new Date()));
     dt = LocalDateTime.from(nativeJs(moment()));
 
-    expectType<LocalDateTime>(dt.query(LocalDateTime.FROM));
+    expectType<LocalDateTime | null>(dt.query(LocalDateTime.FROM));
+    expectType<LocalDate | null>(dt.query(TemporalQueries.localDate()));
 }
 
 function test_ZonedDateTime() {
@@ -452,14 +470,25 @@ function test_ZonedDateTime() {
 
     zdt.plusWeeks(2);
     zdt.plusHours(2 * 7 * 24);
-    zdt.plus(Duration.ofDays(1));
-    zdt.minus(Duration.ofDays(1));
-    zdt.minus(5, ChronoUnit.WEEKS);
+
+    expectType<number>(zdt.get(ChronoField.YEAR));
+    expectType<number>(zdt.get(IsoFields.DAY_OF_QUARTER));
+    expectType<boolean>(zdt.isSupported(ChronoField.YEAR));
+    expectType<boolean>(zdt.isSupported(ChronoUnit.SECONDS));
+    expectType<ValueRange>(zdt.range(ChronoField.MICRO_OF_SECOND));
+    expectType<ZonedDateTime>(zdt.minus(5, ChronoUnit.DAYS));
+    expectType<ZonedDateTime>(zdt.plus(5, ChronoUnit.DAYS));
+    expectType<ZonedDateTime>(zdt.minus(Duration.ofHours(3)));
+    expectType<ZonedDateTime>(zdt.plus(Duration.ofHours(3)));
+    expectType<ZonedDateTime>(zdt.with(TemporalAdjusters.firstDayOfMonth()));
+    expectType<ZonedDateTime>(zdt.with(IsoFields.DAY_OF_QUARTER, 10));
+    expectType<number>(zdt.until(ZonedDateTime.now(), ChronoUnit.SECONDS));
 
     expectType<ZonedDateTime>(zdt.withEarlierOffsetAtOverlap());
     expectType<ZonedDateTime>(zdt.withLaterOffsetAtOverlap());
 
-    expectType<ZonedDateTime>(zdt.query(ZonedDateTime.FROM));
+    expectType<ZonedDateTime | null>(zdt.query(ZonedDateTime.FROM));
+    expectType<LocalDate | null>(zdt.query(TemporalQueries.localDate()));
 }
 
 function test_ZoneOffsetTransition() {
@@ -555,6 +584,18 @@ function test_Duration() {
 function test_Year() {
     const year = Year.now();
 
+    expectType<number>(year.get(ChronoField.INSTANT_SECONDS));
+    expectType<boolean>(year.isSupported(ChronoField.INSTANT_SECONDS));
+    expectType<boolean>(year.isSupported(ChronoUnit.SECONDS));
+    expectType<ValueRange>(year.range(ChronoField.MICRO_OF_SECOND));
+    expectType<Year>(year.minus(5, ChronoUnit.DAYS));
+    expectType<Year>(year.plus(5, ChronoUnit.DAYS));
+    expectType<Year>(year.minus(Duration.ofHours(3)));
+    expectType<Year>(year.plus(Duration.ofHours(3)));
+    expectType<Year>(year.with(YearMonth.now()));
+    expectType<Year>(year.with(IsoFields.DAY_OF_QUARTER, 10));
+    expectType<number>(year.until(Year.now(), ChronoUnit.SECONDS));
+
     expectType<LocalDate>(year.atDay(2));
     expectType<YearMonth>(year.atMonth(5));
     expectType<YearMonth>(year.atMonth(Month.DECEMBER));
@@ -565,7 +606,7 @@ function test_Year() {
     expectType<boolean>(year.isLeap());
     expectType<boolean>(year.isValidMonthDay(MonthDay.of(2, 29)));
     expectType<number>(year.compareTo(Year.of(2020)));
-    
+
     expectType<number>(year.length());
 
     year.plus(Period.ofYears(2));
@@ -577,7 +618,8 @@ function test_Year() {
 
     year.with(ChronoField.YEAR, 2015);
 
-    expectType<Year>(year.query(Year.FROM));
+    expectType<Year | null>(year.query(Year.FROM));
+    expectType<LocalDate | null>(year.query(TemporalQueries.localDate()));
 }
 
 function test_YearMonth() {
@@ -597,23 +639,29 @@ function test_YearMonth() {
     var duration = Duration.of(10, ChronoUnit.MONTHS);
     var ym = YearMonth.of(2017, 10);
 
-    ym.minus(duration);
-    ym.minus(10, ChronoUnit.DAYS);
     ym.minusYears(10);
     ym.minusMonths(10);
 
-    ym.plus(duration);
-    ym.plus(10, ChronoUnit.DAYS);
     ym.plusYears(10);
     ym.plusMonths(10);
 
-    ym.with(TemporalAdjusters.firstDayOfMonth());
-    ym.with(ChronoField.YEAR, 2018);
     ym.withYear(2018);
     ym.withMonth(11);
 
     ym.isSupported(ChronoField.YEAR);
     ym.isSupported(ChronoUnit.YEARS);
+
+    expectType<number>(ym.get(ChronoField.INSTANT_SECONDS));
+    expectType<boolean>(ym.isSupported(ChronoField.INSTANT_SECONDS));
+    expectType<boolean>(ym.isSupported(ChronoUnit.SECONDS));
+    expectType<ValueRange>(ym.range(ChronoField.MICRO_OF_SECOND));
+    expectType<YearMonth>(ym.minus(5, ChronoUnit.DAYS));
+    expectType<YearMonth>(ym.plus(5, ChronoUnit.DAYS));
+    expectType<YearMonth>(ym.minus(Duration.ofHours(3)));
+    expectType<YearMonth>(ym.plus(Duration.ofHours(3)));
+    expectType<YearMonth>(ym.with(Year.now()));
+    expectType<YearMonth>(ym.with(IsoFields.DAY_OF_QUARTER, 10));
+    expectType<number>(ym.until(YearMonth.now(), ChronoUnit.SECONDS));
 
     ym.year();
     ym.monthValue();
@@ -633,7 +681,8 @@ function test_YearMonth() {
 
     ym.format(DateTimeFormatter.ofPattern('yyyy-MM'));
 
-    expectType<YearMonth>(ym.query(YearMonth.FROM));
+    expectType<YearMonth | null>(ym.query(YearMonth.FROM));
+    expectType<LocalDate | null>(ym.query(TemporalQueries.localDate()));
 }
 
 function test_DateTimeFormatter() {
@@ -696,6 +745,11 @@ function test_ZoneId() {
 }
 
 function test_DayOfWeek() {
+    const dow = DayOfWeek.SUNDAY;
+    expectType<number>(dow.get(ChronoField.MONTH_OF_YEAR));
+    expectType<boolean>(dow.isSupported(ChronoField.MONTH_OF_YEAR));
+    expectType<ValueRange>(dow.range(ChronoField.MONTH_OF_YEAR));
+
     expectType<number>(DayOfWeek.MONDAY.compareTo(DayOfWeek.WEDNESDAY));
 }
 
@@ -705,13 +759,25 @@ function test_Month() {
     expectType<number>(Month.SEPTEMBER.compareTo(Month.DECEMBER));
     expectType<boolean>(Month.OCTOBER.equals(Month.NOVEMBER));
 
+    const m = Month.DECEMBER;
+    expectType<number>(m.get(ChronoField.MONTH_OF_YEAR));
+    expectType<boolean>(m.isSupported(ChronoField.MONTH_OF_YEAR));
+    expectType<ValueRange>(m.range(ChronoField.MONTH_OF_YEAR));
+
     expectType<Month>(Month.valueOf('FEBRUARY'));
+    expectType<LocalDate | null>(m.query(TemporalQueries.localDate()));
 }
 
 function test_MonthDay() {
     const md = MonthDay.now();
-    
-    expectType<MonthDay>(md.query(MonthDay.FROM));
+
+    expectType<number>(md.get(ChronoField.MONTH_OF_YEAR));
+    expectType<number>(md.get(IsoFields.QUARTER_OF_YEAR));
+    expectType<boolean>(md.isSupported(ChronoField.MONTH_OF_YEAR));
+    expectType<ValueRange>(md.range(ChronoField.MONTH_OF_YEAR));
+
+    expectType<MonthDay | null>(md.query(MonthDay.FROM));
+    expectType<LocalDate | null>(md.query(TemporalQueries.localDate()));
 }
 
 function test_Clock() {
@@ -726,40 +792,40 @@ function test_Clock() {
 }
 
 function test_Temporal() {
-  const temporal: Temporal = Year.now();
+    const temporal: Temporal = Year.now();
 
-  temporal.isSupported(ChronoUnit.YEARS);
+    temporal.isSupported(ChronoUnit.YEARS);
 
-  temporal.minus(4, ChronoUnit.YEARS);
-  temporal.minus(Period.ofYears(4));
+    temporal.minus(4, ChronoUnit.YEARS);
+    temporal.minus(Period.ofYears(4));
 
-  temporal.plus(4, ChronoUnit.YEARS);
-  temporal.plus(Period.ofYears(4));
+    temporal.plus(4, ChronoUnit.YEARS);
+    temporal.plus(Period.ofYears(4));
 
-  temporal.until(Year.of(2020), ChronoUnit.YEARS);
+    temporal.until(Year.of(2020), ChronoUnit.YEARS);
 
-  const nextYear: TemporalAdjuster = {
-    adjustInto(temporal: Temporal): Temporal {
-      if (temporal.isSupported(ChronoUnit.YEARS)) {
-        return temporal.plus(1, ChronoUnit.YEARS);
-      }
-      throw new Error('unsupported')
+    const nextYear: TemporalAdjuster = {
+        adjustInto(temporal: Temporal): Temporal {
+            if (temporal.isSupported(ChronoUnit.YEARS)) {
+                return temporal.plus(1, ChronoUnit.YEARS);
+            }
+            throw new Error('unsupported')
+        }
     }
-  }
 
-  temporal.with(nextYear);
-  temporal.with(ChronoField.YEAR, 2020);
+    temporal.with(nextYear);
+    temporal.with(ChronoField.YEAR, 2020);
 
-  temporal.with(DayOfWeek.MONDAY);
-  temporal.with(Instant.now());
-  temporal.with(LocalDate.now());
-  temporal.with(LocalDateTime.now());
-  temporal.with(LocalTime.now());
-  temporal.with(Month.FEBRUARY);
-  temporal.with(MonthDay.now());
-  temporal.with(Year.now());
-  temporal.with(YearMonth.now());
-  temporal.with(ZoneOffset.ofHours(1));
+    temporal.with(DayOfWeek.MONDAY);
+    temporal.with(Instant.now());
+    temporal.with(LocalDate.now());
+    temporal.with(LocalDateTime.now());
+    temporal.with(LocalTime.now());
+    temporal.with(Month.FEBRUARY);
+    temporal.with(MonthDay.now());
+    temporal.with(Year.now());
+    temporal.with(YearMonth.now());
+    temporal.with(ZoneOffset.ofHours(1));
 }
 
 function test_TemporalQuery() {

--- a/packages/core/test/typescript_definitions/js-joda-tests.ts
+++ b/packages/core/test/typescript_definitions/js-joda-tests.ts
@@ -38,7 +38,9 @@ import {
     DateTimeException,
     UnsupportedTemporalTypeException,
     TemporalField,
-    ValueRange
+    ValueRange,
+    ZoneRegion,
+    TextStyle
 } from '../../'
 
 // used below
@@ -74,7 +76,6 @@ function test_LocalDate() {
 
     let d = LocalDate.parse('2016-12-24');
 
-    d.toString();
     d.dayOfMonth();
     d.month();
     d.monthValue();
@@ -89,6 +90,9 @@ function test_LocalDate() {
     d.lengthOfYear();
     d.isoWeekOfWeekyear();
     d.isoWeekyear();
+
+    expectType<string>(d.toString());
+    expectType<string>(d.toJSON());
 
     LocalDate.of(2017, 1, 1).isoWeekOfWeekyear();
     LocalDate.of(2017, 1, 1).isoWeekyear();
@@ -208,12 +212,13 @@ function test_LocalTime() {
 
     let t = LocalTime.parse('23:55:42.123');
 
-    t.toString();
-
     t.hour();
     t.minute();
     t.second();
     t.nano();
+
+    expectType<string>(t.toString());
+    expectType<string>(t.toJSON());
 
     t = LocalTime.parse('11:55:42');
     expectType<LocalTime>(t.plusHours(12));
@@ -306,8 +311,6 @@ function test_LocalDateTime() {
 
     let dt: LocalDateTime = LocalDateTime.parse('2016-02-26T23:55:42.123');
 
-    dt.toString();
-
     dt.year();
     dt.month();
     dt.monthValue();
@@ -327,6 +330,9 @@ function test_LocalDateTime() {
     dt.toLocalDate().lengthOfMonth();
     dt.toLocalDate().lengthOfYear();
     dt.toLocalDate().isoWeekOfWeekyear();
+
+    expectType<string>(dt.toString());
+    expectType<string>(dt.toJSON());
 
     expectType<number>(dt.get(ChronoField.HOUR_OF_DAY));
     expectType<number>(dt.get(IsoFields.DAY_OF_QUARTER));
@@ -489,6 +495,9 @@ function test_ZonedDateTime() {
 
     expectType<ZonedDateTime | null>(zdt.query(ZonedDateTime.FROM));
     expectType<LocalDate | null>(zdt.query(TemporalQueries.localDate()));
+
+    expectType<string>(zdt.toString());
+    expectType<string>(zdt.toJSON());
 }
 
 function test_ZoneOffsetTransition() {
@@ -554,6 +563,9 @@ function test_Period() {
     LocalDate.parse('2012-01-31').plus(p);
     LocalDateTime.parse('2012-05-31T12:00').plus(p);
 
+    expectType<string>(p.toString());
+    expectType<string>(p.toJSON());
+
     Period.between(LocalDate.parse('2012-06-30'), LocalDate.parse('2012-08-31'));
 }
 
@@ -595,6 +607,9 @@ function test_Year() {
     expectType<Year>(year.with(YearMonth.now()));
     expectType<Year>(year.with(IsoFields.DAY_OF_QUARTER, 10));
     expectType<number>(year.until(Year.now(), ChronoUnit.SECONDS));
+
+    expectType<string>(year.toString());
+    expectType<string>(year.toJSON());
 
     expectType<LocalDate>(year.atDay(2));
     expectType<YearMonth>(year.atMonth(5));
@@ -677,7 +692,8 @@ function test_YearMonth() {
     ym.isBefore(YearMonth.of(2017, 20));
     ym.equals(YearMonth.of(2017, 20));
 
-    ym.toJSON();
+    expectType<string>(ym.toString());
+    expectType<string>(ym.toJSON());
 
     ym.format(DateTimeFormatter.ofPattern('yyyy-MM'));
 
@@ -742,6 +758,27 @@ function test_ZoneId() {
     var zoneId = ZoneId.SYSTEM;
 
     zoneId.id();
+
+    expectType<string>(zoneId.toString());
+    expectType<string>(zoneId.toJSON());
+}
+
+function test_ZoneOffset() {
+    var zoff = ZoneOffset.UTC;
+
+    zoff.id();
+
+    expectType<string>(zoff.toString());
+    expectType<string>(zoff.toJSON());
+}
+
+function test_ZoneRegion() {
+    var zreg = ZoneRegion.UTC;
+
+    zreg.id();
+
+    expectType<string>(zreg.toString());
+    expectType<string>(zreg.toJSON());
 }
 
 function test_DayOfWeek() {
@@ -751,6 +788,9 @@ function test_DayOfWeek() {
     expectType<ValueRange>(dow.range(ChronoField.MONTH_OF_YEAR));
 
     expectType<number>(DayOfWeek.MONDAY.compareTo(DayOfWeek.WEDNESDAY));
+    
+    expectType<string>(DayOfWeek.WEDNESDAY.toString());
+    expectType<string>(DayOfWeek.WEDNESDAY.toJSON());
 }
 
 function test_Month() {
@@ -758,6 +798,9 @@ function test_Month() {
     expectType<string>(Month.MARCH.name());
     expectType<number>(Month.SEPTEMBER.compareTo(Month.DECEMBER));
     expectType<boolean>(Month.OCTOBER.equals(Month.NOVEMBER));
+
+    expectType<string>(Month.JUNE.toString());
+    expectType<string>(Month.JUNE.toJSON());
 
     const m = Month.DECEMBER;
     expectType<number>(m.get(ChronoField.MONTH_OF_YEAR));
@@ -775,6 +818,9 @@ function test_MonthDay() {
     expectType<number>(md.get(IsoFields.QUARTER_OF_YEAR));
     expectType<boolean>(md.isSupported(ChronoField.MONTH_OF_YEAR));
     expectType<ValueRange>(md.range(ChronoField.MONTH_OF_YEAR));
+
+    expectType<string>(md.toString());
+    expectType<string>(md.toJSON());
 
     expectType<MonthDay | null>(md.query(MonthDay.FROM));
     expectType<LocalDate | null>(md.query(TemporalQueries.localDate()));
@@ -911,6 +957,39 @@ function test_TemporalField() {
     expectType<ValueRange>(field.rangeRefinedBy(LocalDate.now()));
     expectType<boolean>(field.isSupportedBy(LocalDate.now()));
     expectType<LocalDate>(field.adjustInto(LocalDate.now(), 1));
+}
+
+function test_ResolverStyle() {
+    const rs = ResolverStyle.STRICT;
+
+    rs.equals(ResolverStyle.LENIENT);
+    
+    expectType<string>(rs.toString());
+    expectType<string>(rs.toJSON());
+    
+}
+
+function test_SignStyle() {
+    const ss = SignStyle.NEVER;
+
+    ss.equals(SignStyle.NOT_NEGATIVE);
+
+    expectType<string>(ss.toString());
+    expectType<string>(ss.toJSON());
+    
+}
+
+function test_TextStyle() {
+    const ts = TextStyle.FULL;
+
+    ts.equals(TextStyle.NARROW);
+
+    expectType<string>(ts.toString());
+    expectType<string>(ts.toJSON());
+    
+    expectType<TextStyle>(ts.asNormal())
+    expectType<TextStyle>(ts.asStandalone())
+    expectType<boolean>(ts.isStandalone())
 }
 
 /**

--- a/packages/core/test/typescript_definitions/tsconfig.json
+++ b/packages/core/test/typescript_definitions/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"target": "ES6",
+		"lib": ["ES2015"],
+		"module": "CommonJS",
+		"pretty": true,
+		"noEmit": true,
+		"strict": true,
+		"noImplicitAny": true,
+		"noImplicitThis": true,
+		"types": [],
+	},
+	"files": ["js-joda-tests.ts"]
+}


### PR DESCRIPTION
This is part 1 of a series of improvements and refactors to TS declarations.

From an user perspective I think the most important changes are:

- Methods of `TemporalAccesor` and `Temporal` was not properly marked as `abstract`. Now all known methods derived from this classes are typed consistently.
- `LocalTime.prototype.get()` took a `ChronoField` instead of a `TemporalField`. Same for `Year`.
- Is expected that a `TemporalQuery` returns `null` but `TemporalAccesor.prototype.query` was not marked as such.
- `LocalTime.prototype.until` now correctly allow only `Temporal` instances while previously accepted `TemporalAccesor`.

Some internal methods were removed:
- `Duration.prototype.`
	- `minusAmountUnit`
	- `minusDuration`
	- `plusAmountUnit`
	- `plusDuration`
- `ZonedDateTime.prototype.plusTemporalAmount`.

I also added types for some methods, like `toJSON` and `equals` to enum-like classes such as `TextStyle`. While I'd like to remove `getLong`, its types were added since is the way js-joda works right now.

I sorted the methods of some classes to facilitate myself catching mistakes, that's why`YearMonth` has a greater diff. Additionally I changed the way `tsc` was invoked from CLI arguments to a `tsconfig.json`, this way is easier to see errors on supported IDEs.

Closes #381