### PR TITLE
Implement OffsetTime and OffsetDateTime

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "prepublish": "npm run build-dist",
-    "test": "NODE_ENV=test ./node_modules/.bin/mocha --timeout 5000 --require @babel/register ./test/*Test.js ./test/**/*Test.js ./test/**/**/*Test.js ./test/*Test_mochaOnly.js",
+    "test": "NODE_ENV=test ./node_modules/.bin/mocha --timeout 5000 --require @babel/register ./test/*Test_mochaOnly.js ./test/*Test.js ./test/**/*Test.js ./test/**/**/*Test.js",
     "test-coverage": "NODE_ENV=test COVERAGE=1 ../../node_modules/.bin/nyc --report-dir=build/coverage --reporter=lcov --reporter html ./node_modules/.bin/mocha --timeout 5000 --require @babel/register --reporter progress ./test/*Test.js ./test/**/*Test.js ./test/**/**/*Test.js",
     "test-browser": "./node_modules/.bin/karma start --reporters=dots --single-run",
     "test-saucelabs": "./node_modules/.bin/karma start --reporters=\"dots,saucelabs\" --browsers=\"sl_chrome,sl_ie,sl_firefox,sl_ios_simulator\" --single-run=true",

--- a/packages/core/src/Instant.js
+++ b/packages/core/src/Instant.js
@@ -11,6 +11,7 @@ import {Clock} from './Clock';
 import {LocalTime} from './LocalTime';
 import {ZonedDateTime} from './ZonedDateTime';
 import {MathUtil} from './MathUtil';
+import {OffsetDateTime} from './OffsetDateTime';
 
 import {Temporal} from './temporal/Temporal';
 import {ChronoField} from './temporal/ChronoField';
@@ -863,9 +864,9 @@ export class Instant extends Temporal {
      * @return {OffsetDateTime} the offset date-time formed from this instant and the specified offset, not null
      * @throws DateTimeException if the result exceeds the supported range
      */
-    //atOffset(offset) {
-    //    return OffsetDateTime.ofInstant(this, offset);
-    //}
+    atOffset(offset) {
+        return OffsetDateTime.ofInstant(this, offset);
+    }
 
     /**
      * Combines this instant with a time-zone to create a {@link ZonedDateTime}.

--- a/packages/core/src/LocalDate.js
+++ b/packages/core/src/LocalDate.js
@@ -20,6 +20,8 @@ import {DateTimeFormatter} from './format/DateTimeFormatter';
 
 import {Clock} from './Clock';
 import {DayOfWeek} from './DayOfWeek';
+import {OffsetDateTime} from './OffsetDateTime';
+import {OffsetTime} from './OffsetTime';
 import {Month} from './Month';
 import {Period} from './Period';
 import {YearConstants} from './YearConstants';
@@ -1316,7 +1318,7 @@ export class LocalDate extends ChronoLocalDate{
      * if called with 1 argument {@link LocalDate.atTime1} is called
      * otherwise {@link LocalDate.atTime4}
      *
-     * @return {LocalDateTime} the local date-time formed from this date and the specified params
+     * @return {LocalDateTime|OffsetDateTime} the local date-time formed from this date and the specified params
      */
     atTime(){
         if(arguments.length===1){
@@ -1333,10 +1335,18 @@ export class LocalDate extends ChronoLocalDate{
      * All possible combinations of date and time are valid.
      *
      * @param {LocalTime} time - the time to combine with, not null
-     * @return {LocalDateTime} the local date-time formed from this date and the specified time, not null
+     * @return {LocalDateTime|OffsetDateTime} the date-time formed from this date and the specified time, not null
      */
     atTime1(time) {
-        return LocalDateTime.of(this, time);
+        requireNonNull(time, 'time');
+        if (time instanceof LocalTime) {
+            return LocalDateTime.of(this, time);
+        } else if (time instanceof OffsetTime) {
+            return this._atTimeOffsetTime(time);
+        } else {
+            throw new IllegalArgumentException('time must be an instance of LocalTime or OffsetTime' +
+                (time && time.constructor && time.constructor.name ? ', but is ' + time.constructor.name : ''));
+        }
     }
 
     /**
@@ -1367,11 +1377,9 @@ export class LocalDate extends ChronoLocalDate{
      * @param {OffsetTime} time - the time to combine with, not null
      * @return {OffsetDateTime} the offset date-time formed from this date and the specified time, not null
      */
-    /*
     _atTimeOffsetTime(time) { // atTime(offsetTime)
-        return OffsetDateTime.of(LocalDateTime.of(this, time.toLocalTime()), time.getOffset());
+        return OffsetDateTime.of(LocalDateTime.of(this, time.toLocalTime()), time.offset());
     }
-*/
 
     /**
      * Combines this date with the time of midnight to create a {@link LocalDateTime}

--- a/packages/core/src/LocalDateTime.js
+++ b/packages/core/src/LocalDateTime.js
@@ -12,6 +12,7 @@ import {Clock} from './Clock';
 import {Instant} from './Instant';
 import {LocalDate} from './LocalDate';
 import {LocalTime} from './LocalTime';
+import {OffsetDateTime} from './OffsetDateTime';
 import {ZonedDateTime} from './ZonedDateTime';
 import {ZoneId} from './ZoneId';
 import {ZoneOffset} from './ZoneOffset';
@@ -1414,11 +1415,9 @@ implements Temporal, TemporalAdjuster, Serializable */ {
      * @param {ZoneOffset} offset  the offset to combine with, not null
      * @return {OffsetDateTime} the offset date-time formed from this date-time and the specified offset, not null
      */
-    /*
     atOffset(offset) {
         return OffsetDateTime.of(this, offset);
     }
-*/
 
     /**
      * Combines this date-time with a time-zone to create a {@link ZonedDateTime}.

--- a/packages/core/src/OffsetDateTime.js
+++ b/packages/core/src/OffsetDateTime.js
@@ -1,0 +1,739 @@
+import {ChronoField} from './temporal/ChronoField';
+import {ChronoUnit} from './temporal/ChronoUnit';
+import {Clock} from './Clock';
+import {DateTimeFormatter} from './format/DateTimeFormatter';
+import {DefaultInterfaceTemporal} from './temporal/DefaultInterfaceTemporal';
+import {Instant} from './Instant';
+import {IsoChronology} from './chrono/IsoChronology';
+import {LocalDateTime} from './LocalDateTime';
+import {LocalDate} from './LocalDate';
+import {LocalTime} from './LocalTime';
+import {MathUtil} from './MathUtil';
+import {OffsetTime} from './OffsetTime';
+import {TemporalQueries} from './temporal/TemporalQueries';
+import {ZonedDateTime} from './ZonedDateTime';
+import {ZoneId} from './ZoneId';
+import {ZoneOffset} from './ZoneOffset';
+import {DateTimeException, IllegalArgumentException} from './errors';
+
+import {createTemporalQuery} from './temporal/TemporalQuery';
+import {requireInstance, requireNonNull} from './assert';
+
+export class OffsetDateTime extends DefaultInterfaceTemporal{
+    /**
+     * @param {TemporaroAccessor} temporal
+     * @return {OffsetDateTime}
+     */
+    static from(temporal) {
+        requireNonNull(temporal, 'temporal');
+        if (temporal instanceof OffsetDateTime) {
+            return temporal;
+        }
+        try {
+            const offset = ZoneOffset.from(temporal);
+            try {
+                const ldt = LocalDateTime.from(temporal);
+                return OffsetDateTime.of(ldt, offset);
+            } catch (_) {
+                const instant = Instant.from(temporal);
+                return OffsetDateTime.ofInstant(instant, offset);
+            }
+        } catch (ex) {
+            throw new DateTimeException(`Unable to obtain OffsetDateTime TemporalAccessor: ${temporal}, type ${temporal.constructor != null ? temporal.constructor.name : ''}`);
+        }
+    }
+
+    /**
+     * @param {Clock|ZoneId|null} clockOrZone
+     * @return {OffsetDateTime}
+     */
+    static now(clockOrZone) {
+        if (arguments.length === 0) {
+            return OffsetDateTime.now(Clock.systemDefaultZone());
+        } else {
+            requireNonNull(clockOrZone, 'clockOrZone');
+            if (clockOrZone instanceof ZoneId) {
+                return OffsetDateTime.now(Clock.system(clockOrZone));
+            } else if (clockOrZone instanceof Clock) {
+                const now = clockOrZone.instant(); // called once
+                return OffsetDateTime.ofInstant(now, clockOrZone.zone().rules().offset(now));
+            } else {
+                throw new IllegalArgumentException('clockOrZone must be an instance of ZoneId or Clock');
+            }
+        }
+    }
+
+    /**
+     * @return {OffsetDateTime}
+     */
+    static of() {
+        if (arguments.length <= 2) {
+            return OffsetDateTime.ofDateTime.apply(this, arguments);
+        } else if (arguments.length === 3) {
+            return OffsetDateTime.ofDateAndTime.apply(this, arguments);
+        } else {
+            return OffsetDateTime.ofNumbers.apply(this, arguments);
+        }
+    }
+
+    static ofDateTime(dateTime, offset) {
+        return new OffsetDateTime(dateTime, offset);
+    }
+
+    static ofDateAndTime(date, time, offset) {
+        const dt = LocalDateTime.of(date, time);
+        return new OffsetDateTime(dt, offset);
+    }
+
+    static ofNumbers(year, month, dayOfMonth, hour=0, minute=0, second=0, nanoOfSecond=0, offset) {
+        const dt = LocalDateTime.of(year, month, dayOfMonth, hour, minute, second, nanoOfSecond);
+        return new OffsetDateTime(dt, offset);
+    }
+
+    /**
+     * @param {Instant} instant
+     * @param {ZoneId} zone
+     * @return {OffsetDateTime}
+     */
+    static ofInstant(instant,  zone){
+        requireNonNull(instant, 'instant');
+        requireNonNull(zone, 'zone');
+        const rules = zone.rules();
+        const offset = rules.offset(instant);
+        const ldt = LocalDateTime.ofEpochSecond(instant.epochSecond(), instant.nano(), offset);
+        return new OffsetDateTime(ldt, offset);
+    }
+
+    /**
+     * @param {string} text
+     * @param {DateTimeFormatter|undefined} formatter
+     * @return {OffsetTime}
+     */
+    static parse(text, formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME){
+        requireNonNull(formatter, 'formatter');
+        return formatter.parse(text, OffsetDateTime.FROM);
+    }
+
+    // TODO: Need java.util.Comparater interface.
+    // static timeLineOrder() {
+    //
+    // }
+
+    //-----------------------------------------------------------------------
+
+
+    /**
+     * @param {LocalDateTime} dateTime
+     * @param {ZoneOffset} offset
+     * @private
+     */
+    constructor(dateTime, offset) {
+        super();
+        requireNonNull(dateTime, 'dateTime');
+        requireInstance(dateTime, LocalDateTime, 'dateTime');
+        requireNonNull(offset, 'offset');
+        requireInstance(offset, ZoneOffset, 'offset');
+        this._dateTime = dateTime;
+        this._offset = offset;
+    }
+
+    /**
+     *
+     * @param {Temporal} temporal
+     * @return {Temporal}
+     */
+    adjustInto(temporal) {
+        return temporal
+            .with(ChronoField.EPOCH_DAY, this.toLocalDate().toEpochDay())
+            .with(ChronoField.NANO_OF_DAY, this.toLocalTime().toNanoOfDay())
+            .with(ChronoField.OFFSET_SECONDS, this.offset().totalSeconds());
+    }
+
+    until(endExclusive, unit) {
+        let end = OffsetDateTime.from(endExclusive);
+        if (unit instanceof ChronoUnit) {
+            end = end.withOffsetSameInstant(this._offset);
+            return this._dateTime.until(end._dateTime, unit);
+        }
+        return unit.between(this, end);
+    }
+
+    /**
+     * @param {ZoneId}zone
+     * @return {ZonedDateTime}
+     */
+    atZoneSameInstant(zone) {
+        return ZonedDateTime.ofInstant(this._dateTime, this._offset, zone);
+    }
+
+    /**
+     * @param {ZoneId} zone
+     * @return {ZonedDateTime}
+     */
+    atZoneSimilarLocal(zone) {
+        return ZonedDateTime.ofLocal(this._dateTime, zone, this._offset);
+    }
+
+    query(query) {
+        requireNonNull(query, 'query');
+        if (query === TemporalQueries.chronology()) {
+            return IsoChronology.INSTANCE;
+        } else if (query === TemporalQueries.precision()) {
+            return ChronoUnit.NANOS;
+        } else if (query === TemporalQueries.offset() || query === TemporalQueries.zone()) {
+            return this.offset();
+        } else if (query === TemporalQueries.localDate()) {
+            return this.toLocalDate();
+        } else if (query === TemporalQueries.localTime()) {
+            return this.toLocalTime();
+        } else if (query === TemporalQueries.zoneId()) {
+            return null;
+        }
+        return super.query(query);
+    }
+
+    get(field) {
+        if (field instanceof ChronoField) {
+            switch (field) {
+                case ChronoField.INSTANT_SECONDS: throw new DateTimeException('Field too large for an int: ' + field);
+                case ChronoField.OFFSET_SECONDS: return this.offset().totalSeconds();
+            }
+            return this._dateTime.get(field);
+        }
+        return super.get(field);
+    }
+
+    getLong(field) {
+        if (field instanceof ChronoField) {
+            switch (field) {
+                case ChronoField.INSTANT_SECONDS: return this.toEpochSecond();
+                case ChronoField.OFFSET_SECONDS: return this.offset().totalSeconds();
+            }
+            return this._dateTime.getLong(field);
+        }
+        return field.getFrom(this);
+    }
+
+    /**
+     * @return {ZoneOffset}
+     */
+    offset() {
+        return this._offset;
+    }
+
+    /**
+     * @return {number} the year, from MIN_YEAR to MAX_YEAR
+     */
+    year() {
+        return this._dateTime.year();
+    }
+
+    /**
+     * @return {number} the month-of-year, from 1 to 12
+     * @see #month()
+     */
+    monthValue() {
+        return this._dateTime.monthValue();
+    }
+
+    /**
+     * @return {{number} }the month-of-year, not null
+     * @see #monthValue()
+     */
+    month() {
+        return this._dateTime.month();
+    }
+
+    /**
+     * @return {number} the day-of-month, from 1 to 31
+     */
+    dayOfMonth() {
+        return this._dateTime.dayOfMonth();
+    }
+
+    /**
+     * @return {number} the day-of-year, from 1 to 365, or 366 in a leap year
+     */
+    dayOfYear() {
+        return this._dateTime.dayOfYear();
+    }
+
+    /**
+     * @return {number} the day-of-week, not null
+     */
+    dayOfWeek() {
+        return this._dateTime.dayOfWeek();
+    }
+
+    /**
+     * @return {number} the hour-of-day, from 0 to 23
+     */
+    hour() {
+        return this._dateTime.hour();
+    }
+
+    /**
+     * @return {number} the minute-of-hour, from 0 to 59
+     */
+    minute() {
+        return this._dateTime.minute();
+    }
+
+    /**
+     * @return {number} the second-of-minute, from 0 to 59
+     */
+    second() {
+        return this._dateTime.second();
+    }
+
+    /**
+     * @return {number} the nano-of-second, from 0 to 999,999,999
+     */
+    nano() {
+        return this._dateTime.nano();
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * @return {LocalDateTime}the local date-time part of this date-time, not null
+     */
+    toLocalDateTime() {
+        return this._dateTime;
+    }
+
+    /**
+     * @return {LocalDate} the date part of this date-time, not null
+     */
+    toLocalDate() {
+        return this._dateTime.toLocalDate();
+    }
+
+    /**
+     * @return {LocalTime} the time part of this date-time, not null
+     */
+    toLocalTime() {
+        return this._dateTime.toLocalTime();
+    }
+
+    /**
+     * @return {OffsetTime} an OffsetTime representing the time and offset, not null
+     */
+    toOffsetTime() {
+        return OffsetTime.of(this._dateTime.toLocalTime(), this._offset);
+    }
+
+    /**
+     * @return {ZonedDateTime}a zoned date-time representing the same local date-time and offset, not null
+     */
+    toZonedDateTime() {
+        return ZonedDateTime.of(this._dateTime, this._offset);
+    }
+
+    /**
+     * @return {Instant} an {@code Instant} representing the same instant, not null
+     */
+    toInstant() {
+        return this._dateTime.toInstant(this._offset);
+    }
+
+    /**
+     * @return {number} the number of seconds from the epoch of 1970-01-01T00:00:00Z
+     */
+    toEpochSecond() {
+        return this._dateTime.toEpochSecond(this._offset);
+    }
+
+    isSupported(fieldOrUnit) {
+        if (fieldOrUnit instanceof ChronoField) {
+            return fieldOrUnit.isDateBased() || fieldOrUnit.isTimeBased();
+        }
+        if (fieldOrUnit instanceof ChronoUnit) {
+            return fieldOrUnit.isDateBased() || fieldOrUnit.isTimeBased();
+        }
+        return fieldOrUnit != null && fieldOrUnit.isSupportedBy(this);
+    }
+
+    range(field) {
+        if (field instanceof ChronoField) {
+            if (field === ChronoField.INSTANT_SECONDS || field === ChronoField.OFFSET_SECONDS) {
+                return field.range();
+            }
+            return this._dateTime.range(field);
+        }
+        return field.rangeRefinedBy(this);
+    }
+
+    withAdjuster(adjuster) {
+        requireNonNull(adjuster);
+        // optimizations
+        if (adjuster instanceof LocalDate || adjuster instanceof LocalTime || adjuster instanceof LocalDateTime) {
+            return this._withDateTimeOffset(this._dateTime.with(adjuster), this._offset);
+        } else if (adjuster instanceof Instant) {
+            return OffsetDateTime.ofInstant(adjuster, this._offset);
+        } else if (adjuster instanceof ZoneOffset) {
+            return this._withDateTimeOffset(this._dateTime, adjuster);
+        } else if (adjuster instanceof OffsetDateTime) {
+            return adjuster;
+        }
+        return adjuster.adjustInto(this);
+    }
+
+    withFieldValue(field, newValue) {
+        requireNonNull(field);
+        if (field instanceof ChronoField) {
+            const f = field;
+            switch (f) {
+                case ChronoField.INSTANT_SECONDS: return OffsetDateTime.ofInstant(Instant.ofEpochSecond(newValue, this.nano()), this._offset);
+                case ChronoField.OFFSET_SECONDS: {
+                    return this._withDateTimeOffset(this._dateTime, ZoneOffset.ofTotalSeconds(f.checkValidIntValue(newValue)));
+                }
+            }
+            return this._withDateTimeOffset(this._dateTime.with(field, newValue), this._offset);
+        }
+        return field.adjustInto(this, newValue);
+    }
+
+    _withDateTimeOffset(dateTime, offset) {
+        if (this._dateTime === dateTime && this._offset.equals(offset)) {
+            return this;
+        }
+        return new OffsetDateTime(dateTime, offset);
+    }
+
+    /**
+     * @param {int} year
+     * @return {OffsetDateTime}
+     */
+    withYear(year) {
+        return this._withDateTimeOffset(this._dateTime.withYear(year), this._offset);
+    }
+
+    /**
+     * @param {int} month
+     * @return {OffsetDateTime}
+     */
+    withMonth(month) {
+        return this._withDateTimeOffset(this._dateTime.withMonth(month), this._offset);
+    }
+
+    /**
+     * @param {int} dayOfMonth
+     * @return {OffsetDateTime}
+     */
+    withDayOfMonth(dayOfMonth) {
+        return this._withDateTimeOffset(this._dateTime.withDayOfMonth(dayOfMonth), this._offset);
+    }
+
+    /**
+     * @param {int} dayOfYear
+     * @return {OffsetDateTime}
+     */
+    withDayOfYear(dayOfYear) {
+        return this._withDateTimeOffset(this._dateTime.withDayOfYear(dayOfYear), this._offset);
+    }
+
+    /**
+     * @param {int} hour
+     * @return {OffsetDateTime}
+     */
+    withHour(hour) {
+        return this._withDateTimeOffset(this._dateTime.withHour(hour), this._offset);
+    }
+
+    /**
+     * @param {int} minute
+     * @return {OffsetDateTime}
+     */
+    withMinute(minute) {
+        return this._withDateTimeOffset(this._dateTime.withMinute(minute), this._offset);
+    }
+
+    /**
+     * @param {int} second
+     * @return {OffsetDateTime}
+     */
+    withSecond(second) {
+        return this._withDateTimeOffset(this._dateTime.withSecond(second), this._offset);
+    }
+
+    /**
+     * @param {int} nanoOfSecond
+     * @return {OffsetDateTime}
+     */
+    withNano(nanoOfSecond) {
+        return this._withDateTimeOffset(this._dateTime.withNano(nanoOfSecond), this._offset);
+    }
+
+    /**
+     * @param {ZoneOffset} offset
+     * @return {OffsetDateTime}
+     */
+    withOffsetSameLocal(offset) {
+        requireNonNull(offset, 'offset');
+        return this._withDateTimeOffset(this._dateTime, offset);
+    }
+
+    /**
+     * @param {ZoneOffset} offset
+     * @return {OffsetDateTime}
+     */
+    withOffsetSameInstant(offset) {
+        requireNonNull(offset, 'offset');
+        if (offset.equals(this._offset)) {
+            return this;
+        }
+        const difference = offset.totalSeconds() - this._offset.totalSeconds();
+        const adjusted = this._dateTime.plusSeconds(difference);
+        return new OffsetDateTime(adjusted, offset);
+    }
+
+    /**
+     * @param {TemporalUnit} unit
+     * @return {OffsetDateTime}
+     */
+    truncatedTo(unit) {
+        return this._withDateTimeOffset(this._dateTime.truncatedTo(unit), this._offset);
+    }
+
+    plusAmount(amount) {
+        requireNonNull(amount, 'amount');
+        return amount.addTo(this);
+    }
+
+    plusAmountUnit(amountToAdd, unit) {
+        if (unit instanceof ChronoUnit) {
+            return this._withDateTimeOffset(this._dateTime.plus(amountToAdd, unit), this._offset);
+        }
+        return unit.addTo(this, amountToAdd);
+    }
+
+    /**
+     * @param {int} years
+     * @return {OffsetTime}
+     */
+    plusYears(years) {
+        return this._withDateTimeOffset(this._dateTime.plusYears(years), this._offset);
+    }
+
+    /**
+     * @param {int} months
+     * @return {OffsetTime}
+     */
+    plusMonths(months) {
+        return this._withDateTimeOffset(this._dateTime.plusMonths(months), this._offset);
+    }
+
+    /**
+     * @param {int} weeks
+     * @return {OffsetTime}
+     */
+    plusWeeks(weeks) {
+        return this._withDateTimeOffset(this._dateTime.plusWeeks(weeks), this._offset);
+    }
+
+    /**
+     * @param {int} days
+     * @return {OffsetTime}
+     */
+    plusDays(days) {
+        return this._withDateTimeOffset(this._dateTime.plusDays(days), this._offset);
+    }
+
+    /**
+     * @param {int} hours
+     * @return {OffsetTime}
+     */
+    plusHours(hours) {
+        return this._withDateTimeOffset(this._dateTime.plusHours(hours), this._offset);
+    }
+
+    /**
+     * @param {int} minutes
+     * @return {OffsetTime}
+     */
+    plusMinutes(minutes) {
+        return this._withDateTimeOffset(this._dateTime.plusMinutes(minutes), this._offset);
+    }
+
+    /**
+     * @param {int} seconds
+     * @return {OffsetTime}
+     */
+    plusSeconds(seconds) {
+        return this._withDateTimeOffset(this._dateTime.plusSeconds(seconds), this._offset);
+    }
+
+    /**
+     * @param {int} nanos
+     * @return {OffsetTime}
+     */
+    plusNanos(nanos) {
+        return this._withDateTimeOffset(this._dateTime.plusNanos(nanos), this._offset);
+    }
+
+    minusAmount(amount) {
+        requireNonNull(amount);
+        return amount.subtractFrom(this);
+    }
+
+    minusAmountUnit(amountToSubtract, unit) {
+        return this.plus(-1 * amountToSubtract, unit);
+    }
+
+    /**
+     * @param {int} years
+     * @return {OffsetTime}
+     */
+    minusYears(years) {
+        return this._withDateTimeOffset(this._dateTime.minusYears(years), this._offset);
+    }
+
+    /**
+     * @param {int} months
+     * @return {OffsetTime}
+     */
+    minusMonths(months) {
+        return this._withDateTimeOffset(this._dateTime.minusMonths(months), this._offset);
+    }
+
+    /**
+     * @param {int} weeks
+     * @return {OffsetTime}
+     */
+    minusWeeks(weeks) {
+        return this._withDateTimeOffset(this._dateTime.minusWeeks(weeks), this._offset);
+    }
+
+    /**
+     * @param {int} days
+     * @return {OffsetTime}
+     */
+    minusDays(days) {
+        return this._withDateTimeOffset(this._dateTime.minusDays(days), this._offset);
+    }
+
+    /**
+     * @param {int} hours
+     * @return {OffsetTime}
+     */
+    minusHours(hours) {
+        return this._withDateTimeOffset(this._dateTime.minusHours(hours), this._offset);
+    }
+
+    /**
+     * @param {int} minutes
+     * @return {OffsetTime}
+     */
+    minusMinutes(minutes) {
+        return this._withDateTimeOffset(this._dateTime.minusMinutes(minutes), this._offset);
+    }
+
+    /**
+     * @param {int} seconds
+     * @return {OffsetTime}
+     */
+    minusSeconds(seconds) {
+        return this._withDateTimeOffset(this._dateTime.minusSeconds(seconds), this._offset);
+    }
+
+    /**
+     * @param {int} nanos
+     * @return {OffsetTime}
+     */
+    minusNanos(nanos) {
+        return this._withDateTimeOffset(this._dateTime.minusNanos(nanos), this._offset);
+    }
+
+    compareTo(other) {
+        requireNonNull(other, 'other');
+        requireInstance(other, OffsetDateTime, 'other');
+        if (this.offset().equals(other.offset())) {
+            return this.toLocalDateTime().compareTo(other.toLocalDateTime());
+        }
+        let cmp = MathUtil.compareNumbers(this.toEpochSecond(), other.toEpochSecond());
+        if (cmp === 0) {
+            cmp = this.toLocalTime().nano() - other.toLocalTime().nano();
+            if (cmp === 0) {
+                cmp = this.toLocalDateTime().compareTo(other.toLocalDateTime());
+            }
+        }
+        return cmp;
+    }
+
+    /**
+     * @param {OffsetDateTime} other
+     * @return {boolean}
+     */
+    isAfter(other) {
+        requireNonNull(other, 'other');
+        const thisEpochSec = this.toEpochSecond();
+        const otherEpochSec = other.toEpochSecond();
+        return thisEpochSec > otherEpochSec || (thisEpochSec === otherEpochSec && this.toLocalTime().nano() > other.toLocalTime().nano());
+    }
+
+    /**
+     * @param {OffsetDateTime} other
+     * @return {boolean}
+     */
+    isBefore(other) {
+        requireNonNull(other, 'other');
+        const thisEpochSec = this.toEpochSecond();
+        const otherEpochSec = other.toEpochSecond();
+        return thisEpochSec < otherEpochSec || (thisEpochSec === otherEpochSec && this.toLocalTime().nano() < other.toLocalTime().nano());
+    }
+
+    /**
+     * @param {OffsetDateTime} other
+     * @return {boolean}
+     */
+    isEqual(other) {
+        requireNonNull(other, 'other');
+        return this.toEpochSecond() === other.toEpochSecond() && this.toLocalTime().nano() === other.toLocalTime().nano();
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * @param other
+     * @return {boolean}
+     */
+    equals(other) {
+        if (this === other) {
+            return true;
+        }
+        if (other instanceof OffsetDateTime) {
+            return this._dateTime.equals(other._dateTime) && this._offset.equals(other._offset);
+        }
+        return false;
+    }
+
+    /**
+     * @return {number}
+     */
+    hashCode() {
+        return this._dateTime.hashCode() ^ this._offset.hashCode();
+    }
+
+    toString() {
+        return this._dateTime.toString() + this._offset.toString();
+    }
+
+    /**
+     * @param {DateTimeFormatter} formatter
+     * @return {string}
+     */
+    format(formatter) {
+        requireNonNull(formatter, 'formatter');
+        return formatter.format(this);
+    }
+}
+
+
+export function _init() {
+    OffsetDateTime.MIN = LocalDateTime.MIN.atOffset(ZoneOffset.MAX);
+
+    OffsetDateTime.MAX = LocalDateTime.MAX.atOffset(ZoneOffset.MIN);
+
+    OffsetDateTime.FROM = createTemporalQuery('OffsetDateTime.FROM', (temporal) => {
+        return OffsetDateTime.from(temporal);
+    });
+}

--- a/packages/core/src/OffsetTime.js
+++ b/packages/core/src/OffsetTime.js
@@ -1,0 +1,604 @@
+import {ChronoField} from './temporal/ChronoField';
+import {ChronoUnit} from './temporal/ChronoUnit';
+import {Clock} from './Clock';
+import {DateTimeException, UnsupportedTemporalTypeException} from './errors';
+import {DateTimeFormatter} from './format/DateTimeFormatter';
+import {DefaultInterfaceTemporal} from './temporal/DefaultInterfaceTemporal';
+import {Instant, LocalTime} from './js-joda';
+import {MathUtil} from './MathUtil';
+import {OffsetDateTime} from './OffsetDateTime';
+import {TemporalQueries} from './temporal/TemporalQueries';
+import {ZoneId} from './ZoneId';
+import {ZoneOffset} from './ZoneOffset';
+
+import {createTemporalQuery} from './temporal/TemporalQuery';
+import {requireInstance, requireNonNull} from './assert';
+
+export class OffsetTime extends DefaultInterfaceTemporal {
+    /**
+     * @param {!TemporalAccessor} temporal
+     * @return {OffsetTime}
+     */
+    static from(temporal) {
+        requireNonNull(temporal, 'temporal');
+        if (temporal instanceof OffsetTime) {
+            return temporal;
+        } else if (temporal instanceof OffsetDateTime) {
+            return temporal.toOffsetTime();
+        }
+        try {
+            const time = LocalTime.from(temporal);
+            const offset = ZoneOffset.from(temporal);
+            return new OffsetTime(time, offset);
+        } catch(ex) {
+            throw new DateTimeException(`Unable to obtain OffsetTime TemporalAccessor: ${temporal}, type ${temporal.constructor != null ? temporal.constructor.name : ''}`);
+        }
+    }
+
+    /**
+     * @param {Clock|ZoneId} clockOrZone
+     * @return {OffsetTime}
+     */
+    static now(clockOrZone) {
+        if (arguments.length === 0){
+            return OffsetTime._now(Clock.systemDefaultZone());
+        } else if (clockOrZone instanceof Clock){
+            return OffsetTime._now(clockOrZone);
+        } else {
+            return OffsetTime._now(Clock.system(clockOrZone));
+        }
+    }
+
+    /**
+     * @param {Clock} clock - the clock to use, defaults to Clock.systemDefaultZone()
+     * @return {OffsetTime} the current offset date-time, not null
+     */
+    static _now(clock) {
+        requireNonNull(clock, 'clock');
+        const now = clock.instant();
+        return OffsetTime.ofInstant(now, clock.zone().rules().offset(now));
+    }
+
+    /**
+     * @return {OffsetTime}
+     */
+    static of(){
+        if (arguments.length <= 2) {
+            return OffsetTime.ofTimeAndOffset.apply(this, arguments);
+        } else {
+            return OffsetTime.ofNumbers.apply(this, arguments);
+        }
+    }
+
+    /**
+     * @param {int}hour
+     * @param {int}minute
+     * @param {int}second
+     * @param {int}nanoOfSecond
+     * @param {ZoneOffset}offset
+     * @return {OffsetTime}
+     */
+    static ofNumbers(hour, minute, second, nanoOfSecond, offset) {
+        const time = LocalTime.of(hour, minute, second, nanoOfSecond);
+        return new OffsetTime(time, offset);
+    }
+
+    /**
+     * @param {LocalTime}time
+     * @param {ZoneOffset}offset
+     * @return {OffsetTime}
+     */
+    static ofTimeAndOffset(time, offset) {
+        return new OffsetTime(time, offset);
+    }
+
+    /**
+     * @param {!Instant} instant
+     * @param {!ZoneId} zone
+     * @return {!OffsetTime}
+     */
+    static ofInstant( instant,  zone){
+        requireNonNull(instant, 'instant');
+        requireInstance(instant, Instant, 'instant');
+        requireNonNull(zone, 'zone');
+        requireInstance(zone, ZoneId, 'zone');
+
+        const rules = zone.rules();
+        const offset = rules.offset(instant);
+        let secsOfDay = instant.epochSecond() % LocalTime.SECONDS_PER_DAY;
+        secsOfDay = (secsOfDay + offset.totalSeconds()) % LocalTime.SECONDS_PER_DAY;
+        if (secsOfDay < 0) {
+            secsOfDay += LocalTime.SECONDS_PER_DAY;
+        }
+        const time = LocalTime.ofSecondOfDay(secsOfDay, instant.nano());
+        return new OffsetTime(time, offset);
+    }
+
+    /**
+     * @param {string} text
+     * @param {DateTimeFormatter} formatter
+     * @return {OffsetTime}
+     */
+    static parse(text, formatter= DateTimeFormatter.ISO_OFFSET_TIME) {
+        requireNonNull(formatter, 'formatter');
+        return formatter.parse(text, OffsetTime.FROM);
+    }
+    //-----------------------------------------------------------------------
+
+    /**
+     * @param {LocalTime} time
+     * @param {ZoneOffset} offset
+     * @private
+     */
+    constructor(time, offset) {
+        super();
+        requireNonNull(time, 'time');
+        requireInstance(time, LocalTime, 'time');
+        requireNonNull(offset, 'offset');
+        requireInstance(offset, ZoneOffset, 'offset');
+        this._time = time;
+        this._offset = offset;
+    }
+
+
+    /**
+     * @param {TemporalAdjuster} temporal - the target object to be adjusted, not null
+     * @return {Temporal} the adjusted object, not null
+     * @throws {DateTimeException} if unable to make the adjustment
+     * @throws {ArithmeticException} if numeric overflow occurs
+     */
+    adjustInto(temporal) {
+        return temporal
+            .with(ChronoField.NANO_OF_DAY, this._time.toNanoOfDay())
+            .with(ChronoField.OFFSET_SECONDS, this.offset().totalSeconds());
+    }
+
+    /**
+     * @param {LocalDate} date - the date to combine with, not null
+     * @return {OffsetDateTime} the offset date-time formed from this time and the specified date, not null
+     */
+    atDate(date) {
+        return OffsetDateTime.of(date, this._time, this._offset);
+    }
+
+    /**
+     * @param {DateTimeFormatter} formatter - the formatter to use, not null
+     * @return {string} the formatted time string, not null
+     * @throws {DateTimeException} if an error occurs during printing
+     */
+    format(formatter) {
+        requireNonNull(formatter, 'formatter');
+        return formatter.format(this, OffsetTime.FROM);
+    }
+
+
+    /**
+     * @param {TemporalField} field - the field to get, not null
+     * @return {number} the value for the field
+     * @throws {DateTimeException} if a value for the field cannot be obtained
+     * @throws {ArithmeticException} if numeric overflow occurs
+     */
+    get(field) {
+        return super.get(field);
+    }
+
+    /**
+     * @param {TemporalField} field - the field to get, not null
+     * @return {number} the value for the field
+     * @throws {DateTimeException} if a value for the field cannot be obtained
+     * @trhows {UnsupportedTemporalTypeException}
+     * @throws {ArithmeticException} if numeric overflow occurs
+     */
+    getLong(field) {
+        if (field instanceof ChronoField) {
+            if (field === ChronoField.OFFSET_SECONDS) {
+                return this._offset.totalSeconds();
+            }
+            return this._time.getLong(field);
+        }
+        return field.getFrom(this);
+    }
+
+    /**
+     * @return {int}
+     */
+    hour() {
+        return this._time.hour();
+    }
+
+    /**
+     * @return {int}
+     */
+    minute() {
+        return this._time.minute();
+    }
+
+    /**
+     * @return {int}
+     */
+    second() {
+        return this._time.second();
+    }
+
+    /**
+     * @return {int}
+     */
+    nano() {
+        return this._time.nano();
+    }
+
+    /**
+     * @return {ZoneOffset}
+     */
+    offset() {
+        return this._offset;
+    }
+
+    /**
+     * @param {OffsetTime} other - the other time to compare to, not null
+     * @return {boolean} true if this is after the specified time
+     * @throws {NullPointerException} if `other` is null
+     */
+    isAfter(other) {
+        requireNonNull(other, 'other');
+        return this._toEpochNano() > other._toEpochNano();
+    }
+
+    /**
+     * @param {OffsetTime} other - the other time to compare to, not null
+     * @return {boolean} true if this point is before the specified time
+     * @throws {NullPointerException} if `other` is null
+     */
+    isBefore(other) {
+        requireNonNull(other, 'other');
+        return this._toEpochNano() < other._toEpochNano();
+    }
+
+    /**
+     * @param {OffsetTime} other - the other time to compare to, not null
+     * @return {boolean}
+     * @throws {NullPointerException} if `other` is null
+     */
+    isEqual(other) {
+        requireNonNull(other, 'other');
+        return this._toEpochNano() === other._toEpochNano();
+    }
+
+    /**
+     * @param {TemporalField|TemporalUnit} fieldOrUnit - the field to check, null returns false
+     * @return {boolean} true if the field is supported on this time, false if not
+     */
+    isSupported(fieldOrUnit) {
+        if (fieldOrUnit instanceof ChronoField) {
+            return fieldOrUnit.isTimeBased() || fieldOrUnit === ChronoField.OFFSET_SECONDS;
+        } else if (fieldOrUnit instanceof ChronoUnit) {
+            return fieldOrUnit.isTimeBased();
+        }
+        return fieldOrUnit != null && fieldOrUnit.isSupportedBy(this);
+    }
+
+    /**
+     * @param {number} hours
+     * @return {OffsetTime}
+     */
+    minusHours(hours) {
+        return this._withLocalTimeOffset(this._time.minusHours(hours), this._offset);
+    }
+
+    /**
+     * @param {number} minutes
+     * @return {OffsetTime}
+     */
+    minusMinutes(minutes) {
+        return this._withLocalTimeOffset(this._time.minusMinutes(minutes), this._offset);
+    }
+
+    /**
+     * @param {number} seconds
+     * @return {OffsetTime}
+     */
+    minusSeconds(seconds) {
+        return this._withLocalTimeOffset(this._time.minusSeconds(seconds), this._offset);
+    }
+
+    /**
+     * @param {number} nanos
+     * @return {OffsetTime}
+     */
+    minusNanos(nanos) {
+        return this._withLocalTimeOffset(this._time.minusNanos(nanos), this._offset);
+    }
+
+    minusAmount(amount) {
+        requireNonNull(amount);
+        return amount.subtractFrom(this);
+    }
+
+    minusAmountUnit(amountToSubtract, unit) {
+        return this.plus(-1 * amountToSubtract, unit);
+    }
+
+    plusAmount(amount) {
+        requireNonNull(amount);
+        return amount.addTo(this);
+    }
+
+    /**
+     *
+     * @param amountToAdd
+     * @param unit
+     * @return {Temporal}
+     */
+    plusAmountUnit(amountToAdd, unit) {
+        if (unit instanceof ChronoUnit) {
+            return this._withLocalTimeOffset(this._time.plus(amountToAdd, unit), this._offset);
+        }
+        return unit.addTo(this, amountToAdd);
+    }
+
+    /**
+     * @param {int} hours
+     * @return {OffsetTime}
+     */
+    plusHours(hours) {
+        return this._withLocalTimeOffset(this._time.plusHours(hours), this._offset);
+    }
+
+    /**
+     * @param {int} minutes
+     * @return {OffsetTime}
+     */
+    plusMinutes(minutes) {
+        return this._withLocalTimeOffset(this._time.plusMinutes(minutes), this._offset);
+    }
+
+    /**
+     * @param {int} seconds
+     * @return {OffsetTime}
+     */
+    plusSeconds(seconds) {
+        return this._withLocalTimeOffset(this._time.plusSeconds(seconds), this._offset);
+    }
+
+    /**
+     * @param {int} nanos
+     * @return {OffsetTime}
+     */
+    plusNanos(nanos) {
+        return this._withLocalTimeOffset(this._time.plusNanos(nanos), this._offset);
+    }
+
+    /**
+     * @param {TemporalQuery} query - the query to invoke, not null
+     * @return {*} the query result, null may be returned (defined by the query)
+     * @throws {DateTimeException} if unable to query (defined by the query)
+     * @throws {ArithmeticException} if numeric overflow occurs (defined by the query)
+     */
+    query(query) {
+        requireNonNull(query, 'query');
+        if (query === TemporalQueries.precision()) {
+            return ChronoUnit.NANOS;
+        } else if (query === TemporalQueries.offset() || query === TemporalQueries.zone()) {
+            return this.offset();
+        } else if (query === TemporalQueries.localTime()) {
+            return this._time;
+        } else if (query === TemporalQueries.chronology() || query === TemporalQueries.localDate() || query === TemporalQueries.zoneId()) {
+            return null;
+        }
+        return super.query(query);
+    }
+
+    /**
+     * @param {TemporalField} field - the field to query the range for, not null
+     * @return {ValueRange} the range of valid values for the field, not null
+     * @throws {DateTimeException} if the range for the field cannot be obtained
+     */
+    range(field) {
+        if (field instanceof ChronoField) {
+            if (field === ChronoField.OFFSET_SECONDS) {
+                return field.range();
+            }
+            return this._time.range(field);
+        }
+        return field.rangeRefinedBy(this);
+    }
+
+    /**
+     * @return {LocalTime}
+     */
+    toLocalTime() {
+        return this._time;
+    }
+
+    /**
+     * @param {TemporalUnit} unit - the unit to truncate to, not null
+     * @return {OffsetTime} a {@link LocalTime} based on this time with the time truncated, not null
+     * @throws {DateTimeException} if unable to truncate
+     */
+    truncatedTo(unit) {
+        return this._withLocalTimeOffset(this._time.truncatedTo(unit), this._offset);
+    }
+
+    /**
+    * @param {Temporal} endExclusive - the end time, which is converted to a {@link LocalTime}, not null
+    * @param {TemporalUnit} unit - the unit to measure the period in, not null
+    * @return {number} the amount of the period between this time and the end time
+    * @throws {DateTimeException} if the period cannot be calculated
+    * @throws {ArithmeticException} if numeric overflow occurs
+    */
+    until(endExclusive, unit) {
+        requireNonNull(endExclusive, 'endExclusive');
+        requireNonNull(unit, 'unit');
+        const end = OffsetTime.from(endExclusive);
+        if (unit instanceof ChronoUnit) {
+            const nanosUntil = end._toEpochNano() - this._toEpochNano(); // no overflow
+            switch (unit) {
+                case ChronoUnit.NANOS: return nanosUntil;
+                case ChronoUnit.MICROS: return Math.floor(nanosUntil / 1000);
+                case ChronoUnit.MILLIS: return Math.floor(nanosUntil / 1000000);
+                case ChronoUnit.SECONDS: return Math.floor(nanosUntil / LocalTime.NANOS_PER_SECOND);
+                case ChronoUnit.MINUTES: return Math.floor(nanosUntil / LocalTime.NANOS_PER_MINUTE);
+                case ChronoUnit.HOURS: return Math.floor(nanosUntil / LocalTime.NANOS_PER_HOUR);
+                case ChronoUnit.HALF_DAYS: return Math.floor(nanosUntil / (12 * LocalTime.NANOS_PER_HOUR));
+            }
+            throw new UnsupportedTemporalTypeException('Unsupported unit: ' + unit);
+        }
+        return unit.between(this, end);
+    }
+
+    /**
+     * @param {int} hour
+     * @return {OffsetTime}
+     */
+    withHour(hour) {
+        return this._withLocalTimeOffset(this._time.withHour(hour), this._offset);
+    }
+
+    /**
+     * @param {int} minute
+     * @return {OffsetTime}
+     */
+    withMinute(minute) {
+        return this._withLocalTimeOffset(this._time.withMinute(minute), this._offset);
+    }
+
+    /**
+     * @param {int} second
+     * @return {OffsetTime}
+     */
+    withSecond(second) {
+        return this._withLocalTimeOffset(this._time.withSecond(second), this._offset);
+    }
+
+    /**
+     * @param {int} nano
+     * @return {OffsetTime}
+     */
+    withNano(nano) {
+        return this._withLocalTimeOffset(this._time.withNano(nano), this._offset);
+    }
+
+    /**
+     * @param {ZoneOffset} offset
+     * @return {OffsetTime}
+     */
+    withOffsetSameInstant(offset) {
+        requireNonNull(offset, 'offset');
+        if (offset.equals(this._offset)) {
+            return this;
+        }
+        const difference = offset.totalSeconds() - this._offset.totalSeconds();
+        const adjusted = this._time.plusSeconds(difference);
+        return new OffsetTime(adjusted, offset);
+    }
+
+    /**
+     * @param {ZoneOffset} offset
+     * @return {OffsetTime}
+     */
+    withOffsetSameLocal(offset) {
+        return offset != null && offset.equals(this._offset) ? this : new OffsetTime(this._time, offset);
+    }
+
+    _toEpochNano() {
+        const nod = this._time.toNanoOfDay();
+        const offsetNanos = this._offset.totalSeconds() * LocalTime.NANOS_PER_SECOND;
+        return nod - offsetNanos;
+    }
+
+    withAdjuster(adjuster) {
+        requireNonNull(adjuster, 'adjuster');
+        // optimizations
+        if (adjuster instanceof LocalTime) {
+            return this._withLocalTimeOffset(adjuster, this._offset);
+        } else if (adjuster instanceof ZoneOffset) {
+            return this._withLocalTimeOffset(this._time, adjuster);
+        } else if (adjuster instanceof OffsetTime) {
+            return adjuster;
+        }
+        return adjuster.adjustInto(this);
+    }
+
+    withFieldValue(field, newValue) {
+        requireNonNull(field, 'field');
+        if (field instanceof ChronoField) {
+            if (field === ChronoField.OFFSET_SECONDS) {
+                return this._withLocalTimeOffset(this._time, ZoneOffset.ofTotalSeconds(field.checkValidIntValue(newValue)));
+            }
+            return this._withLocalTimeOffset(this._time.with(field, newValue), this._offset);
+        }
+        return field.adjustInto(this, newValue);
+    }
+
+    /**
+     * @private
+     * @param {LocalTime}time
+     * @param {ZoneOffset}offset
+     * @return {OffsetTime}
+     */
+    _withLocalTimeOffset(time, offset) {
+        if (this._time === time && this._offset.equals(offset)) {
+            return this;
+        }
+        return new OffsetTime(time, offset);
+    }
+
+    //---------------------------------
+
+    /**
+     * @param {OffsetTime} other - the other time to compare to, not null
+     * @return {int} the comparator value, negative if less, positive if greater
+     * @throws {NullPointerException} if `other` is null
+     */
+    compareTo(other) {
+        requireNonNull(other, 'other');
+        requireInstance(other, OffsetTime, 'other');
+        if (this._offset.equals(other._offset)) {
+            return this._time.compareTo(other._time);
+        }
+        const compare = MathUtil.compareNumbers(this._toEpochNano(), other._toEpochNano());
+        if (compare === 0) {
+            return this._time.compareTo(other._time);
+        }
+        return compare;
+    }
+
+    /**
+     * @param {*} other - the object to check, null returns false
+     * @return {boolean} true if this is equal to the other time
+     */
+    equals(other) {
+        if (this === other) {
+            return true;
+        }
+        if (other instanceof OffsetTime) {
+            return this._time.equals(other._time) && this._offset.equals(other._offset);
+        }
+        return false;
+    }
+
+    /**
+     * @return {number}
+     */
+    hashCode() {
+        return this._time.hashCode() ^ this._offset.hashCode();
+    }
+
+    /**
+     * @return {string}
+     */
+    toString() {
+        return this._time.toString() + this._offset.toString();
+    }
+}
+
+
+export function _init() {
+    OffsetTime.MIN = OffsetTime.ofNumbers(0, 0, 0,0, ZoneOffset.MAX);
+
+    OffsetTime.MAX = OffsetTime.ofNumbers(23, 59, 59,999999999, ZoneOffset.MIN);
+
+    OffsetTime.FROM = createTemporalQuery('OffsetTime.FROM', (temporal) => {
+        return OffsetTime.from(temporal);
+    });
+}

--- a/packages/core/src/_init.js
+++ b/packages/core/src/_init.js
@@ -12,6 +12,8 @@ import {_init as LocalTimeInit} from './LocalTime';
 import {_init as LocalDateTimeInit} from './LocalDateTime';
 import {_init as MonthInit} from './Month';
 import {_init as MonthDayInit} from './MonthDay';
+import {_init as OffsetDateTimeInit} from './OffsetDateTime';
+import {_init as OffsetTimeInit} from './OffsetTime';
 import {_init as PeriodInit} from './Period';
 import {_init as YearInit} from './Year';
 import {_init as YearConstantsInit} from './YearConstants';
@@ -59,6 +61,8 @@ function init() {
     IsoChronologyInit();
     DateTimeFormatterInit();
     DateTimeFormatterBuilderInit();
+    OffsetDateTimeInit();
+    OffsetTimeInit();
 }
 
 init();

--- a/packages/core/src/js-joda.js
+++ b/packages/core/src/js-joda.js
@@ -22,6 +22,8 @@ import { LocalTime } from './LocalTime';
 import { LocalDateTime } from './LocalDateTime';
 import { Month } from './Month';
 import { MonthDay } from './MonthDay';
+import { OffsetDateTime } from './OffsetDateTime';
+import { OffsetTime } from './OffsetTime';
 import { Period } from './Period';
 import { Year } from './Year';
 import { YearConstants } from './YearConstants';
@@ -105,6 +107,8 @@ const jsJodaExports = {
     LocalDate,
     LocalTime,
     LocalDateTime,
+    OffsetTime,
+    OffsetDateTime,
     Month,
     MonthDay,
     Period,
@@ -167,6 +171,8 @@ export {
     LocalDateTime,
     Month,
     MonthDay,
+    OffsetTime,
+    OffsetDateTime,
     Period,
     Year,
     YearConstants,

--- a/packages/core/test/InstantTest.js
+++ b/packages/core/test/InstantTest.js
@@ -13,10 +13,12 @@ import {ChronoUnit} from '../src/temporal/ChronoUnit';
 import {Instant} from '../src/Instant';
 import {LocalTime} from '../src/LocalTime';
 import {MathUtil} from '../src/MathUtil';
+import {OffsetDateTime} from '../src/OffsetDateTime';
 import {TemporalAccessor} from '../src/temporal/TemporalAccessor';
 import {TemporalField} from '../src/temporal/TemporalField';
 import {TemporalQuery} from '../src/temporal/TemporalQuery';
 import {TemporalUnit} from '../src/temporal/TemporalUnit';
+import {ZoneOffset} from '../src/ZoneOffset';
 import {DateTimeException, NullPointerException, UnsupportedTemporalTypeException} from '../src/errors';
 
 /* these are not covered by the threetenbp ported tests */
@@ -256,6 +258,11 @@ describe('js-joda Instant', () => {
             }).to.throw(UnsupportedTemporalTypeException);
         });
     });
-    
-    
+
+    describe('atOffset', () => {
+        it('normal', () => {
+            assertEquals(testInstant.atOffset(ZoneOffset.ofHours(1)), OffsetDateTime.parse('1970-01-01T01:02:03.000000456+01:00'));
+            assertEquals(testInstant.atOffset(ZoneOffset.ofHours(5)), OffsetDateTime.parse('1970-01-01T05:02:03.000000456+05:00'));
+        });
+    });
 });

--- a/packages/core/test/OffsetDateTimeTest.js
+++ b/packages/core/test/OffsetDateTimeTest.js
@@ -1,0 +1,270 @@
+/*
+ * @copyright (c) 2016, Philipp Thürwächter & Pattrick Hüper
+ * @license BSD-3-Clause (see LICENSE.md in the root directory of this source tree)
+ */
+
+import {expect} from 'chai';
+
+import {ChronoField} from '../src/temporal/ChronoField';
+import {ChronoUnit} from '../src/temporal/ChronoUnit';
+import {createTemporalQuery} from '../src/temporal/TemporalQuery';
+import {DateTimeFormatter} from '../src/format/DateTimeFormatter';
+import {Instant} from '../src/Instant';
+import {IsoFields} from '../src/temporal/IsoFields';
+import {LocalDateTime} from '../src/LocalDateTime';
+import {LocalTime} from '../src/LocalTime';
+import {OffsetDateTime} from '../src/OffsetDateTime';
+import {TemporalField} from '../src/temporal/TemporalField';
+import {TemporalUnit} from '../src/temporal/TemporalUnit';
+import {Temporal} from '../src/temporal/Temporal';
+import {ZonedDateTime} from '../src/ZonedDateTime';
+import {ZoneId} from '../src/ZoneId';
+import {ZoneOffset} from '../src/ZoneOffset';
+import {
+    DateTimeException,
+    IllegalArgumentException,
+    NullPointerException
+} from '../src/errors';
+
+import './_init';
+
+/* these are not covered by the threetenbp ported tests */
+describe('js-joda OffsetDateTime', () => {
+    const odtNow = OffsetDateTime.now();
+
+    describe('from', () => {
+        it('should return value even if temporal fails on LocalDatetime.from', () => {
+            class CustomTemporal extends Temporal {
+                getLong() {
+                    return 123;
+                }
+                get() {
+                    return 456;
+                }
+                query() {
+                    return ZoneOffset.UTC;
+                }
+            }
+            const odt = OffsetDateTime.from(new CustomTemporal());
+            expect(odt).to.be.an.instanceOf(OffsetDateTime);
+        });
+
+        it('should throw if failed to obtain OffsetDateTime TemporarlAccessor', () => {
+            expect(() => {
+                OffsetDateTime.from('fail !!');
+            }).to.throw(DateTimeException);
+        });
+    });
+
+    describe('now', () => {
+        it('should optimize if ZoneId', () => {
+            const odt = OffsetDateTime.now(ZoneId.systemDefault());
+            expect(odt).to.be.an.instanceOf(OffsetDateTime);
+        });
+
+        it('should fail if illegal', () => {
+            expect(() => {
+                OffsetDateTime.now('zone id !!');
+            }).to.throw(IllegalArgumentException);
+        });
+    });
+
+    describe('adjustInto', () => {
+        it('should work', () => {
+            const odt = OffsetDateTime.parse('2025-01-03T03:04:06.7+08:00');
+            expect(odt.adjustInto(odtNow)).to.eql(odt);
+        });
+    });
+
+    describe('until', () => {
+        const odt = OffsetDateTime.parse('2025-01-03T03:04:06.7+08:00');
+        const other = OffsetDateTime.parse('2030-01-03T03:04:06.7+08:00');
+
+        it('should optimize if ChronoUnit', () => {
+            expect(odt.until(other, ChronoUnit.YEARS)).to.equal(5);
+        });
+
+        it('should support non-ChronoUnit', () => {
+            class CustomUnit extends TemporalUnit {
+                between() {
+                    return 42;
+                }
+            }
+            expect(odt.until(other, new CustomUnit())).to.equal(42);
+        });
+    });
+
+    describe('query', () => {
+        it('should work on custom query', () => {
+            const customQuery = createTemporalQuery('custom', (temporal) => {
+                return LocalTime.from(temporal);
+            });
+            expect(odtNow.query(customQuery)).to.be.an.instanceOf(LocalTime);
+        });
+    });
+
+    describe('get', () => {
+        it('should fail-fast on INSTANT_SECONDS', () => {
+            expect(() => {
+                odtNow.get(ChronoField.INSTANT_SECONDS);
+            }).to.throw(DateTimeException);
+        });
+
+        it('should support non-ChronoField', () => {
+            expect(typeof odtNow.get(IsoFields.DAY_OF_QUARTER)).to.equal('number');
+        });
+    });
+
+    describe('getLong', () => {
+        it('should support non-ChronoField', () => {
+            expect(typeof odtNow.getLong(IsoFields.DAY_OF_QUARTER)).to.equal('number');
+        });
+    });
+
+    describe('monthValue', () => {
+        it('should work', () => {
+            const odt = OffsetDateTime.parse('2025-01-03T03:04:06.7+08:00');
+            expect(odt.monthValue()).to.equal(1);
+        });
+    });
+
+    describe('toZonedDateTime', () => {
+        it('should work', () => {
+            const odt = OffsetDateTime.parse('2025-01-03T03:04:06.7+08:00');
+            expect(odt.toZonedDateTime()).to.eql(ZonedDateTime.of(
+                LocalDateTime.parse('2025-01-03T03:04:06.7'),
+                ZoneId.of('+8')
+            ));
+        });
+    });
+
+    describe('isSupported', () => {
+        it('should support date-based ChronoField', () => {
+            expect(odtNow.isSupported(ChronoField.DAY_OF_YEAR)).to.equal(true);
+        });
+
+        it('should support time-based ChronoField', () => {
+            expect(odtNow.isSupported(ChronoField.HOUR_OF_DAY)).to.equal(true);
+        });
+
+        it('should support date-based ChronoUnit', () => {
+            expect(odtNow.isSupported(ChronoUnit.DAYS)).to.equal(true);
+        });
+
+        it('should support time-based ChronoUnit', () => {
+            expect(odtNow.isSupported(ChronoUnit.HOURS)).to.equal(true);
+        });
+    });
+
+    describe('range', () => {
+        it('should optimize if ChronoField', () => {
+            expect(odtNow.range(ChronoField.INSTANT_SECONDS).isIntValue()).to.equal(true);
+            expect(odtNow.range(ChronoField.OFFSET_SECONDS).maximum()).to.equal(64800);
+            expect(odtNow.range(ChronoField.HOUR_OF_AMPM).maximum()).to.equal(11);
+        });
+    });
+
+    describe('with', () => {
+        describe('withAdjuster', () => {
+            it('should support Instant', () => {
+                expect(odtNow.with(Instant.now())).to.be.an.instanceOf(OffsetDateTime);
+            });
+        });
+
+        describe('withFieldValue', () => {
+            it('should support custom field', () => {
+                class CustomField extends TemporalField {
+                    adjustInto(temporal, newValue) {
+                        return temporal.withYear(newValue);
+                    }
+                }
+                expect(odtNow.with(new CustomField(), 10).year()).to.equal(10);
+            });
+        });
+    });
+
+    describe('withOffsetSameLocal', () => {
+        it('should work', () => {
+            const odt = OffsetDateTime.parse('2025-01-03T03:04:06.7+08:00');
+            expect(odt.withOffsetSameLocal(ZoneOffset.UTC).toLocalTime()).to.eql(odt.toLocalTime());
+        });
+    });
+
+    describe('plusAmountUnit', () => {
+        it('should support custom unit', () => {
+            class CustomUnit extends TemporalUnit {
+                addTo(dateTime, periodToAdd) {
+                    return dateTime.plusDays(periodToAdd);
+                }
+            }
+            const odt = OffsetDateTime.parse('2025-01-02T03:04:06.7+08:00');
+            expect(odt.plusAmountUnit(1, new CustomUnit()).dayOfMonth()).to.equal(3);
+        });
+    });
+
+    describe('isAfter/isBefore/isEqual', () => {
+        it('should throw if null', () => {
+            expect(() => {
+                odtNow.isAfter(null);
+            }).to.throw(NullPointerException);
+            expect(() => {
+                odtNow.isBefore(null);
+            }).to.throw(NullPointerException);
+            expect(() => {
+                odtNow.isEqual(null);
+            }).to.throw(NullPointerException);
+        });
+
+        it('exact same instance', () => {
+            expect(odtNow.isAfter(odtNow)).to.equal(false);
+            expect(odtNow.isBefore(odtNow)).to.equal(false);
+            expect(odtNow.isEqual(odtNow)).to.equal(true);
+        });
+
+        it('different epoch second', () => {
+            const a = OffsetDateTime.parse('2020-01-01T01:01:01.001Z');
+            const b = OffsetDateTime.parse('9020-01-01T01:01:01.001Z');
+            expect(a.isAfter(b)).to.equal(false);
+            expect(b.isAfter(a)).to.equal(true);
+
+            expect(a.isBefore(b)).to.equal(true);
+            expect(b.isBefore(a)).to.equal(false);
+
+            expect(a.isEqual(b)).to.equal(false);
+            expect(b.isEqual(a)).to.equal(false);
+        });
+
+        it('same epoch second, but diffrent nano', () => {
+            const a = OffsetDateTime.parse('2020-01-01T01:01:01.001Z');
+            const b = OffsetDateTime.parse('2020-01-01T01:01:01.999Z');
+            expect(a.isAfter(b)).to.equal(false);
+            expect(b.isAfter(a)).to.equal(true);
+
+            expect(a.isBefore(b)).to.equal(true);
+            expect(b.isBefore(a)).to.equal(false);
+
+            expect(a.isEqual(b)).to.equal(false);
+            expect(b.isEqual(a)).to.equal(false);
+        });
+    });
+
+    describe('equals', () => {
+        it('should return on incompatible type', () => {
+            expect(odtNow.equals('string')).to.equal(false);
+        });
+    });
+
+    describe('format', () => {
+        it('should throw if null', () => {
+            expect(() => {
+                odtNow.format(null);
+            }).to.throw(NullPointerException);
+        });
+
+        it('should work', () => {
+            const odt = OffsetDateTime.parse('2020-01-02T03:04:05.000000006+07:00');
+            const f = DateTimeFormatter.ofPattern('y M d H m s n X');
+            expect(odt.format(f)).to.equal('2020 1 2 3 4 5 6 +07');
+        });
+    });
+});

--- a/packages/core/test/OffsetTimeTest.js
+++ b/packages/core/test/OffsetTimeTest.js
@@ -1,0 +1,169 @@
+/*
+ * @copyright (c) 2016, Philipp Thürwächter & Pattrick Hüper
+ * @license BSD-3-Clause (see LICENSE.md in the root directory of this source tree)
+ */
+
+import {expect} from 'chai';
+
+import {ChronoField} from '../src/temporal/ChronoField';
+import {ChronoUnit} from '../src/temporal/ChronoUnit';
+import {DateTimeException,NullPointerException, UnsupportedTemporalTypeException} from '../src/errors';
+import {IsoFields} from '../src/temporal/IsoFields';
+import {LocalDate} from '../src/LocalDate';
+import {LocalTime} from '../src/LocalTime';
+import {OffsetDateTime} from '../src/OffsetDateTime';
+import {OffsetTime} from '../src/OffsetTime';
+import {TemporalField} from '../src/js-joda';
+import {TemporalUnit} from '../src/temporal/TemporalUnit';
+import {ZoneOffset} from '../src/ZoneOffset';
+
+import {createTemporalQuery} from '../src/temporal/TemporalQuery';
+import './_init';
+
+/* these are not covered by the threetenbp ported tests */
+describe('js-joda OffsetTime', () => {
+    describe('from', () => {
+        it('should optimize if OffsetDateTime given', () => {
+            const odt = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30), ZoneOffset.ofHours(1));
+            const ot = OffsetTime.from(odt);
+            expect(ot).to.eql(OffsetTime.parse('11:30+01:00'));
+        });
+
+        it('should throw if illegal type given given', () => {
+            expect(() => {
+                OffsetTime.from('11:30+01:00');
+            }).to.throw(DateTimeException);
+        });
+    });
+
+    describe('atDate', () => {
+        it('should create OffsetDateTime', () => {
+            const ot = OffsetTime.parse('11:30+01:00');
+            const odt = ot.atDate(LocalDate.parse('2020-07-13'));
+            expect(odt).to.eql(OffsetDateTime.parse('2020-07-13T11:30+01:00'));
+        });
+    });
+
+    describe('getLong', () => {
+        it('should work if IsoField (non-ChronoField) given', () => {
+            expect(() => {
+                const ot = OffsetTime.parse('11:30+01:00');
+                ot.getLong(IsoFields.DAY_OF_QUARTER);
+            }).to.throw(UnsupportedTemporalTypeException);
+        });
+    });
+
+    describe('isSupported', () => {
+        it('should support time-based field', () => {
+            const ot = OffsetTime.parse('11:30+01:00');
+            expect(ot.isSupported(ChronoField.HOUR_OF_AMPM)).to.equal(true);
+            expect(ot.isSupported(ChronoField.DAY_OF_MONTH)).to.equal(false);
+            expect(ot.isSupported(IsoFields.HOUR_OF_AMPM)).to.equal(false);
+        });
+
+        it('should support time-based unit', () => {
+            const ot = OffsetTime.parse('11:30+01:00');
+            expect(ot.isSupported(ChronoUnit.HOURS)).to.equal(true);
+            expect(ot.isSupported(ChronoUnit.DAYS)).to.equal(false);
+        });
+
+        it('should return false if null', () => {
+            const ot = OffsetTime.parse('11:30+01:00');
+            expect(ot.isSupported(null)).to.equal(false);
+        });
+    });
+
+    describe('plusAmountUnit', () => {
+        it('should support custom unit', () => {
+            class CustomUnit extends TemporalUnit{
+                isSupportedBy(){
+                    return true;
+                }
+                addTo(dateTime, periodToAdd) {
+                    return dateTime.plusSeconds(periodToAdd);
+                }
+            }
+            const ot = OffsetTime.parse('11:30+01:00');
+            expect(ot.plus(1, new CustomUnit())).to.eql(ot.plusSeconds(1));
+        });
+    });
+
+    describe('query', () => {
+        it('should support custom query', () => {
+            const ot = OffsetTime.parse('11:30+01:00');
+            const customQuery = createTemporalQuery('custom', (temporal) => {
+                return LocalTime.from(temporal);
+            });
+            expect(ot.query(customQuery)).to.be.an.instanceOf(LocalTime);
+        });
+    });
+
+    describe('range', () => {
+        it('should work if non-ChronoField field', () => {
+            expect(() => {
+                const ot = OffsetTime.parse('11:30+01:00');
+                expect(ot.range(IsoFields.DAY_OF_QUARTER)).to.be.an.instanceOf(LocalTime);
+            }).to.throw(UnsupportedTemporalTypeException);
+        });
+    });
+
+    describe('until', () => {
+        const ot = OffsetTime.parse('11:30+01:00');
+        const odt = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(20, 12, 34, 56), ZoneOffset.ofHours(3));
+
+        it('should throw if null endExclusive', () => {
+            expect(() => {
+                ot.until(null, ChronoUnit.NANOS);
+            }).to.throw(NullPointerException);
+        });
+
+        it('should throw if null unit', () => {
+            expect(() => {
+                ot.until(ot, null);
+            }).to.throw(NullPointerException);
+        });
+
+        it('should support if time-based ChronoUnit', () => {
+            expect(ot.until(odt, ChronoUnit.NANOS)).to.equal(24154000000056);
+            expect(ot.until(odt, ChronoUnit.MICROS)).to.equal(24154000000);
+            expect(ot.until(odt, ChronoUnit.MILLIS)).to.equal(24154000);
+            expect(ot.until(odt, ChronoUnit.SECONDS)).to.equal(24154);
+            expect(ot.until(odt, ChronoUnit.MINUTES)).to.equal(402);
+            expect(ot.until(odt, ChronoUnit.MINUTES)).to.equal(402);
+            expect(ot.until(odt, ChronoUnit.HOURS)).to.equal(6);
+            expect(ot.until(odt, ChronoUnit.HALF_DAYS)).to.equal(0);
+        });
+
+        it('should thow if not-time-based ChronoUnit', () => {
+            expect(() => {
+                ot.until(odt, ChronoUnit.YEARS);
+            }).to.throw(UnsupportedTemporalTypeException);
+        });
+
+        it('should support custom unit', () => {
+            class CustomUnit extends TemporalUnit{
+                isSupportedBy(){
+                    return true;
+                }
+                between() {
+                    return 42;
+                }
+            }
+            expect(ot.until(odt, new CustomUnit())).to.equal(42);
+        });
+    });
+
+    describe('with', () => {
+        describe('with(field, value)', () => {
+            it('should support non-ChronoField', () => {
+                class CustomField extends TemporalField {
+                    adjustInto(temporal, newValue) {
+                        return temporal.withSecond(newValue);
+                    }
+                }
+                const ot = OffsetTime.parse('11:30+01:00');
+                expect(ot.with(new CustomField(), 12)).to.eql(OffsetTime.parse('11:30:12+01:00'));
+            });
+        });
+    });
+});

--- a/packages/core/test/reference/InstantTest.js
+++ b/packages/core/test/reference/InstantTest.js
@@ -18,11 +18,14 @@ import {Duration} from '../../src/Duration';
 import {Instant} from '../../src/Instant';
 import {LocalDateTime} from '../../src/LocalDateTime';
 import {MathUtil} from '../../src/MathUtil';
+import {OffsetDateTime} from '../../src/OffsetDateTime';
 import {ZoneOffset} from '../../src/ZoneOffset';
+import {ZonedDateTime} from '../../src/ZonedDateTime';
 
 import {ChronoField} from '../../src/temporal/ChronoField';
 import {ChronoUnit} from '../../src/temporal/ChronoUnit';
 import {TemporalQueries} from '../../src/temporal/TemporalQueries';
+import {CurrentStandardZoneEuropeParis} from '../zone/CurrentStandardZone';
 
 const MIN_SECOND = Instant.MIN.epochSecond();
 const MAX_SECOND = Instant.MAX.epochSecond();
@@ -30,6 +33,8 @@ const MAX_SECOND = Instant.MAX.epochSecond();
 describe('org.threeten.bp.TestInstant', () => {
 
     const TEST_12345_123456789 = Instant.ofEpochSecond(12345, 123456789);
+    const OFFSET_PTWO = ZoneOffset.ofHours(2);
+    const ZONE_PARIS = new CurrentStandardZoneEuropeParis();
 
     function check(instant, epochSecs, nos) {
         expect(instant.epochSecond()).to.equal(epochSecs);
@@ -318,9 +323,9 @@ describe('org.threeten.bp.TestInstant', () => {
                 [Instant.ofEpochSecond(10), Instant.MAX, Instant.ofEpochSecond(10), null],
 
                 [Instant.ofEpochSecond(10, 200), LocalDateTime.of(1970, 1, 1, 0, 0, 20).toInstant(ZoneOffset.UTC), Instant.ofEpochSecond(10, 200), null],
-                //[Instant.ofEpochSecond(10, 200), OffsetDateTime.of(1970, 1, 1, 0, 0, 20, 10, ZoneOffset.UTC), OffsetDateTime.of(1970, 1, 1, 0, 0, 10, 200, ZoneOffset.UTC), null],
-                //[Instant.ofEpochSecond(10, 200), OffsetDateTime.of(1970, 1, 1, 0, 0, 20, 10, OFFSET_PTWO), OffsetDateTime.of(1970, 1, 1, 2, 0, 10, 200, OFFSET_PTWO), null],
-                //[Instant.ofEpochSecond(10, 200), ZonedDateTime.of(1970, 1, 1, 0, 0, 20, 10, ZONE_PARIS), ZonedDateTime.of(1970, 1, 1, 1, 0, 10, 200, ZONE_PARIS), null],
+                [Instant.ofEpochSecond(10, 200), OffsetDateTime.of(1970, 1, 1, 0, 0, 20, 10, ZoneOffset.UTC), OffsetDateTime.of(1970, 1, 1, 0, 0, 10, 200, ZoneOffset.UTC), null],
+                [Instant.ofEpochSecond(10, 200), OffsetDateTime.of(1970, 1, 1, 0, 0, 20, 10, OFFSET_PTWO), OffsetDateTime.of(1970, 1, 1, 2, 0, 10, 200, OFFSET_PTWO), null],
+                [Instant.ofEpochSecond(10, 200), ZonedDateTime.of(1970, 1, 1, 0, 0, 20, 10, ZONE_PARIS), ZonedDateTime.of(1970, 1, 1, 1, 0, 10, 200, ZONE_PARIS), null],
 
                 [Instant.ofEpochSecond(10, 200), LocalDateTime.of(1970, 1, 1, 0, 0, 20), null, DateTimeException],
                 [Instant.ofEpochSecond(10, 200), null, null, NullPointerException]

--- a/packages/core/test/reference/LocalDateTest.js
+++ b/packages/core/test/reference/LocalDateTest.js
@@ -24,6 +24,8 @@ import {LocalDate} from '../../src/LocalDate';
 import {LocalTime} from '../../src/LocalTime';
 import {LocalDateTime} from '../../src/LocalDateTime';
 import {Month} from '../../src/Month';
+import {OffsetDateTime} from '../../src/OffsetDateTime';
+import {OffsetTime} from '../../src/OffsetTime';
 import {Period} from '../../src/Period';
 import {Year} from '../../src/Year';
 import {ZoneOffset} from '../../src/ZoneOffset';
@@ -1601,6 +1603,19 @@ describe('org.threeten.bp.TestLocalDate', () => {
                 const t = LocalDate.of(2008, 6, 30);
                 t.atTime(null);
             }).to.throw(NullPointerException);
+        });
+
+        it('test_atTime_OffsetTime', () => {
+            const t = LocalDate.of(2008, 6, 30);
+            const ot = OffsetTime.of(12, 34, 56, 789, ZoneOffset.ofHours(3));
+            assertEquals(t.atTime(ot), OffsetDateTime.of(2008, 6, 30, 12, 34, 56, 789, ZoneOffset.ofHours(3)));
+        });
+
+        it('test_atTime_illegal', () => {
+            expect(() => {
+                const t = LocalDate.of(2008, 6, 30);
+                t.atTime('string');
+            }).to.throw(IllegalArgumentException);
         });
 
         it('test_atTime_int_int', () => {

--- a/packages/core/test/reference/LocalDateTimeTest.js
+++ b/packages/core/test/reference/LocalDateTimeTest.js
@@ -28,6 +28,7 @@ import {ChronoUnit} from '../../src/temporal/ChronoUnit';
 import {TemporalQueries} from '../../src/temporal/TemporalQueries';
 import {ZoneId} from '../../src/ZoneId';
 import {ZonedDateTime} from '../../src/ZonedDateTime';
+import {OffsetDateTime} from '../../src/OffsetDateTime';
 
 import {MockSimplePeriod} from './MockSimplePeriod';
 import {MockFieldNoValue} from './temporal/MockFieldNoValue';
@@ -137,6 +138,20 @@ describe('org.threeten.bp.TestLocalDateTime', () => {
     function createDateMidnight(year, month, day) {
         return LocalDateTime.of(year, month, day, 0, 0);
     }
+
+    describe('atOffset', () => {
+        it('normal', () => {
+            const t = createDateMidnight(2020, 7, 1);
+            assertEquals(t.atOffset(ZoneOffset.UTC), OffsetDateTime.of(2020, 7, 1, 0, 0, 0, 0, ZoneOffset.UTC));
+        });
+
+        it('null', () => {
+            expect(() => {
+                const t = createDateMidnight(2020, 7, 1);
+                t.atOffset(null);
+            }).to.throw(NullPointerException);
+        });
+    });
 
     describe('now()', () => {
 

--- a/packages/core/test/reference/OffsetDateTimeTest.js
+++ b/packages/core/test/reference/OffsetDateTimeTest.js
@@ -1,0 +1,950 @@
+/*
+ * @copyright (c) 2016, Philipp Thürwächter & Pattrick Hüper
+ * @copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos
+ * @license BSD-3-Clause (see LICENSE in the root directory of this source tree)
+ */
+
+import {expect} from 'chai';
+
+import {ChronoField} from '../../src/temporal/ChronoField';
+import {ChronoUnit} from '../../src/temporal/ChronoUnit';
+import {Clock} from '../../src/Clock';
+import {DateTimeFormatter} from '../../src/format/DateTimeFormatter';
+import {Duration} from '../../src/Duration';
+import {Instant} from '../../src/Instant';
+import {IsoChronology} from '../../src/chrono/IsoChronology';
+import {LocalDateTime} from '../../src/LocalDateTime';
+import {LocalDate} from '../../src/LocalDate';
+import {LocalTime} from '../../src/LocalTime';
+import {Month} from '../../src/Month';
+import {OffsetDateTime} from '../../src/OffsetDateTime';
+import {OffsetTime} from '../../src/OffsetTime';
+import {TemporalAdjuster} from '../../src/temporal/TemporalAdjuster';
+import {TemporalQueries} from '../../src/temporal/TemporalQueries';
+import {Year} from '../../src/Year';
+import {ZonedDateTime} from '../../src/ZonedDateTime';
+import {ZoneOffset} from '../../src/ZoneOffset';
+import {
+    DateTimeException,
+    DateTimeParseException,
+    IllegalArgumentException,
+    NullPointerException
+} from '../../src/errors';
+
+import {MockSimplePeriod} from './MockSimplePeriod';
+import {dataProviderTest, assertTrue, assertEquals} from '../testUtils';
+import {CurrentStandardZoneAsiaGaza, CurrentStandardZoneEuropeParis} from '../zone/CurrentStandardZone';
+
+import '../_init';
+
+describe('org.threeten.bp.TestOffsetDateTime', () => {
+    const ZONE_PARIS = new CurrentStandardZoneEuropeParis();
+    const ZONE_GAZA = new CurrentStandardZoneAsiaGaza();
+    const OFFSET_PONE = ZoneOffset.ofHours(1);
+    const OFFSET_PTWO = ZoneOffset.ofHours(2);
+    const OFFSET_MONE = ZoneOffset.ofHours(-1);
+    const OFFSET_MTWO = ZoneOffset.ofHours(-2);
+    const sampleToString = [
+        [2008, 6, 30, 11, 30, 59, 0, 'Z', '2008-06-30T11:30:59Z'],
+        [2008, 6, 30, 11, 30, 59, 0, '+01:00', '2008-06-30T11:30:59+01:00'],
+        [2008, 6, 30, 11, 30, 59, 999000000, 'Z', '2008-06-30T11:30:59.999Z'],
+        [2008, 6, 30, 11, 30, 59, 999000000, '+01:00', '2008-06-30T11:30:59.999+01:00'],
+        [2008, 6, 30, 11, 30, 59, 999000, 'Z', '2008-06-30T11:30:59.000999Z'],
+        [2008, 6, 30, 11, 30, 59, 999000, '+01:00', '2008-06-30T11:30:59.000999+01:00'],
+        [2008, 6, 30, 11, 30, 59, 999, 'Z', '2008-06-30T11:30:59.000000999Z'],
+        [2008, 6, 30, 11, 30, 59, 999, '+01:00', '2008-06-30T11:30:59.000000999+01:00'],
+    ];
+    const sampleTimes = [
+        [2008, 6, 30, 11, 30, 20, 500, OFFSET_PONE],
+        [2008, 6, 30, 11, 0, 0, 0, OFFSET_PONE],
+        [2008, 6, 30, 23, 59, 59, 999999999, OFFSET_PONE],
+        [-1, 1, 1, 0, 0, 0, 0, OFFSET_PONE],
+    ];
+    
+    let TEST_2008_6_30_11_30_59_000000500;
+
+    beforeEach(() => {
+        TEST_2008_6_30_11_30_59_000000500 = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 59, 500), OFFSET_PONE);
+    });
+
+    /**
+     * @param {OffsetDateTime} test
+     * @param {int} y
+     * @param {int} mo
+     * @param {int} d
+     * @param {int} h
+     * @param {int} m
+     * @param {int} s
+     * @param {int} n
+     * @param {ZoneOffset }offset
+     */
+    function check(test, y,mo,d, h, m,  s,  n,  offset) {
+        assertEquals(test.year(), y);
+        assertEquals(test.month().value(), mo);
+        assertEquals(test.dayOfMonth(), d);
+        assertEquals(test.hour(), h);
+        assertEquals(test.minute(), m);
+        assertEquals(test.second(), s);
+        assertEquals(test.nano(), n);
+        assertEquals(test.offset(), offset);
+        assertEquals(test, test);
+        assertEquals(test.hashCode(), test.hashCode());
+        assertEquals(OffsetDateTime.of(LocalDateTime.of(y, mo, d, h, m, s, n), offset), test);
+    }
+
+    describe('now', () => {
+        let expected = OffsetDateTime.now(Clock.systemDefaultZone());
+        let test = OffsetDateTime.now();
+        let diff = Math.abs(test.toLocalTime().toNanoOfDay() - expected.toLocalTime().toNanoOfDay());
+        if (diff >= 100000000) {
+            // may be date change
+            expected = OffsetDateTime.now(Clock.systemDefaultZone());
+            test = OffsetDateTime.now();
+            diff = Math.abs(test.toLocalTime().toNanoOfDay() - expected.toLocalTime().toNanoOfDay());
+        }
+        assertTrue(diff < 100000000);  // less than 0.1 secs
+    });
+
+    describe('now(Clock)', () => {
+        it('allSecsInDay_utc', () => {
+            for (let i = 0; i < (2 * 24 * 60 * 60); i += 100) {
+                const instant = Instant.ofEpochSecond(i).plusNanos(123456789);
+                const clock = Clock.fixed(instant, ZoneOffset.UTC);
+                const test = OffsetDateTime.now(clock);
+                assertEquals(test.year(), 1970);
+                assertEquals(test.month(), Month.JANUARY);
+                assertEquals(test.dayOfMonth(), (i < 24 * 60 * 60 ? 1 : 2));
+                assertEquals(test.hour(), Math.floor(i / (60 * 60)) % 24);
+                assertEquals(test.minute(), Math.floor(i / 60) % 60);
+                assertEquals(test.second(), i % 60);
+                assertEquals(test.nano(), 123456789);
+                assertEquals(test.offset(), ZoneOffset.UTC);
+            }
+        });
+
+        it('allSecsInDay_offset', () => {
+            for (let i = 0; i < (2 * 24 * 60 * 60); i += 100) {
+                const instant = Instant.ofEpochSecond(i).plusNanos(123456789);
+                const clock = Clock.fixed(instant.minusSeconds(OFFSET_PONE.totalSeconds()), OFFSET_PONE);
+                const test = OffsetDateTime.now(clock);
+                assertEquals(test.year(), 1970);
+                assertEquals(test.month(), Month.JANUARY);
+                assertEquals(test.dayOfMonth(), (i < 24 * 60 * 60) ? 1 : 2);
+                assertEquals(test.hour(), Math.floor(i / (60 * 60)) % 24);
+                assertEquals(test.minute(), Math.floor(i / 60) % 60);
+                assertEquals(test.second(), i % 60);
+                assertEquals(test.nano(), 123456789);
+                assertEquals(test.offset(), OFFSET_PONE);
+            }
+        });
+
+        it('allSecsInDay_beforeEpoch', () => {
+            let expected = LocalTime.MIDNIGHT.plusNanos(123456789).plusSeconds(100 - 1);
+            for (let i = -1; i >= -(24 * 60 * 60); i -= 100) {
+                const instant = Instant.ofEpochSecond(i).plusNanos(123456789);
+                const clock = Clock.fixed(instant, ZoneOffset.UTC);
+                const test = OffsetDateTime.now(clock);
+                assertEquals(test.year(), 1969);
+                assertEquals(test.month(), Month.DECEMBER);
+                assertEquals(test.dayOfMonth(), 31);
+                expected = expected.minusSeconds(100);
+                assertEquals(test.toLocalTime(), expected);
+                assertEquals(test.offset(), ZoneOffset.UTC);
+            }
+        });
+
+        it('offsets', () => {
+            const base = OffsetDateTime.of(LocalDate.of(1970, 1, 1), LocalTime.of(12, 0), ZoneOffset.UTC);
+            for (let i = -9; i < 15; i++) {
+                const offset = ZoneOffset.ofHours(i);
+                const clock = Clock.fixed(base.toInstant(), offset);
+                const test = OffsetDateTime.now(clock);
+                assertEquals(test.hour(), (12 + i) % 24);
+                assertEquals(test.minute(), 0);
+                assertEquals(test.second(), 0);
+                assertEquals(test.nano(), 0);
+                assertEquals(test.offset(), offset);
+            }
+        });
+
+        it('nullZoneID or nullClock', () => {
+            expect(() => {
+                OffsetDateTime.now( null);
+            }).to.throw(NullPointerException);
+        });
+    });
+
+    describe('of', () => {
+        it('intMonthIntHM', () => {
+            const test = OffsetDateTime.of(LocalDate.of(2008, Month.JUNE, 30),
+                LocalTime.of(11, 30), OFFSET_PONE);
+            check(test, 2008, 6, 30, 11, 30, 0, 0, OFFSET_PONE);
+        });
+
+        it('intMonthIntHMS', () => {
+            const test = OffsetDateTime.of(LocalDate.of(2008, Month.JUNE, 30),
+                LocalTime.of(11, 30, 10), OFFSET_PONE);
+            check(test, 2008, 6, 30, 11, 30, 10, 0, OFFSET_PONE);
+
+        });
+
+        it('intMonthIntHMSN', () => {
+            const test = OffsetDateTime.of(LocalDate.of(2008, Month.JUNE, 30),
+                LocalTime.of(11, 30, 10, 500), OFFSET_PONE);
+            check(test, 2008, 6, 30, 11, 30, 10, 500, OFFSET_PONE);
+        });
+
+        it('intsHM', () => {
+            const test = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30), OFFSET_PONE);
+            check(test, 2008, 6, 30, 11, 30, 0, 0, OFFSET_PONE);
+        });
+
+        it('intsHMS', () => {
+            const test = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 10), OFFSET_PONE);
+            check(test, 2008, 6, 30, 11, 30, 10, 0, OFFSET_PONE);
+        });
+
+        it('intsHMSN', () => {
+            const test = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 10, 500), OFFSET_PONE);
+            check(test, 2008, 6, 30, 11, 30, 10, 500, OFFSET_PONE);
+        });
+
+        it('LocalDateLocalTimeZoneOffset', () => {
+            const date = LocalDate.of(2008, 6, 30);
+            const time = LocalTime.of(11, 30, 10, 500);
+            const test = OffsetDateTime.of(date, time, OFFSET_PONE);
+            check(test, 2008, 6, 30, 11, 30, 10, 500, OFFSET_PONE);
+        });
+
+        it('nullLocalDate', () => {
+            expect(() => {
+                const time = LocalTime.of(11, 30, 10, 500);
+                OffsetDateTime.of(null, time, OFFSET_PONE);
+            }).to.throw(NullPointerException);
+        });
+
+        it('nullLocalTime', () => {
+            expect(() => {
+                const date = LocalDate.of(2008, 6, 30);
+                OffsetDateTime.of(date, null, OFFSET_PONE);
+            }).to.throw(NullPointerException);
+        });
+
+        it('nullOffset', () => {
+            expect(() => {
+                const date = LocalDate.of(2008, 6, 30);
+                const time = LocalTime.of(11, 30, 10, 500);
+                OffsetDateTime.of(date, time, null);
+            }).to.throw(NullPointerException);
+        });
+
+        it('LocalDateTimeZoneOffset', () => {
+            const dt = LocalDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 10, 500));
+            const test = OffsetDateTime.of(dt, OFFSET_PONE);
+            check(test, 2008, 6, 30, 11, 30, 10, 500, OFFSET_PONE);
+        });
+
+        it('LocalDateTimeZoneOffset_nullProvider', () => {
+            expect(() => {
+                OffsetDateTime.of(null, OFFSET_PONE);
+            }).to.throw(NullPointerException);
+        });
+
+        it('LocalDateTimeZoneOffset_nullOffset', () => {
+            expect(() => {
+                const dt = LocalDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 10, 500));
+                OffsetDateTime.of(dt, null);
+            }).to.throw(NullPointerException);
+        });
+    });
+
+    describe('from', () => {
+        it('CalendricalObject', () => {
+            assertEquals(OffsetDateTime.from(
+                OffsetDateTime.of(LocalDate.of(2007, 7, 15), LocalTime.of(17, 30), OFFSET_PONE)),
+            OffsetDateTime.of(LocalDate.of(2007, 7, 15), LocalTime.of(17, 30), OFFSET_PONE));
+        });
+
+        it('invalid_noDrive', () => {
+            expect(() => {
+                OffsetDateTime.from(LocalTime.of(12, 30));
+            }).to.throw(DateTimeException);
+        });
+
+        it('null', () => {
+            expect(() => {
+                OffsetDateTime.from(null);
+            }).to.throw(NullPointerException);
+        });
+    });
+
+    describe('parse(text)', () => {
+        it('parse', () => {
+            dataProviderTest(sampleToString, (y, month, d, h, m, s, n, offsetId, text) => {
+                const t = OffsetDateTime.parse(text);
+                assertEquals(t.year(), y);
+                assertEquals(t.month().value(), month);
+                assertEquals(t.dayOfMonth(), d);
+                assertEquals(t.hour(), h);
+                assertEquals(t.minute(), m);
+                assertEquals(t.second(), s);
+                assertEquals(t.nano(), n);
+                assertEquals(t.offset().id(), offsetId);
+            });
+        });
+
+        it('illegalValue', () => {
+            expect(() => {
+                OffsetDateTime.parse('2008-06-32T11:15+01:00');
+            }).to.throw(DateTimeParseException);
+        });
+
+        it('invalidValue', () => {
+            expect(() => {
+                OffsetDateTime.parse('2008-06-31T11:15+01:00');
+            }).to.throw(DateTimeParseException);
+        });
+
+        it('nullText', () => {
+            expect(() => {
+                OffsetDateTime.parse(null);
+            }).to.throw(NullPointerException);
+        });
+    });
+
+    describe('parse(DateTimeFormatter)', () => {
+        it('formatter', () => {
+            const f = DateTimeFormatter.ofPattern('u M d H m s XXX');
+            const test = OffsetDateTime.parse('2010 12 3 11 30 0 +01:00', f);
+            assertEquals(test, OffsetDateTime.of(LocalDate.of(2010, 12, 3), LocalTime.of(11, 30), ZoneOffset.ofHours(1)));
+        });
+
+        it('nullText', () => {
+            expect(() => {
+                const f = DateTimeFormatter.ofPattern('u M d H m s');
+                OffsetDateTime.parse(null, f);
+            }).to.throw(NullPointerException);
+        });
+
+        it('nullFormatter', () => {
+            expect(() => {
+                OffsetDateTime.parse('ANY', null);
+            }).to.throw(NullPointerException);
+        });
+    });
+
+    describe('constructor', () => {
+        it('nullTime', () => {
+            expect(() => {
+                new OffsetDateTime(null, OFFSET_PONE);
+            }).to.throw(NullPointerException);
+        });
+
+        it('nullOffset', () => {
+            expect(() => {
+                new OffsetDateTime(LocalDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30)), null);
+            }).to.throw(NullPointerException);
+        });
+    });
+
+    describe('basics', () => {
+        dataProviderTest(sampleTimes, (y, o, d, h, m, s, n, offset) => {
+            const localDate = LocalDate.of(y, o, d);
+            const localTime = LocalTime.of(h, m, s, n);
+            const localDateTime = LocalDateTime.of(localDate, localTime);
+            const a = OffsetDateTime.of(localDateTime, offset);
+
+            assertEquals(a.year(), localDate.year());
+            assertEquals(a.month(), localDate.month());
+            assertEquals(a.dayOfMonth(), localDate.dayOfMonth());
+            assertEquals(a.dayOfYear(), localDate.dayOfYear());
+            assertEquals(a.dayOfWeek(), localDate.dayOfWeek());
+
+            assertEquals(a.hour(), localDateTime.hour());
+            assertEquals(a.minute(), localDateTime.minute());
+            assertEquals(a.second(), localDateTime.second());
+            assertEquals(a.nano(), localDateTime.nano());
+
+            assertEquals(a.toOffsetTime(), OffsetTime.of(localTime, offset));
+            assertEquals(a.toString(), localDateTime.toString() + offset.toString());
+        });
+    });
+
+    describe('get', () => {
+        it('get(TemporalField)', () => {
+            const test = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(12, 30, 40, 987654321), OFFSET_PONE);
+            assertEquals(test.get(ChronoField.YEAR), 2008);
+            assertEquals(test.get(ChronoField.MONTH_OF_YEAR), 6);
+            assertEquals(test.get(ChronoField.DAY_OF_MONTH), 30);
+            assertEquals(test.get(ChronoField.DAY_OF_WEEK), 1);
+            assertEquals(test.get(ChronoField.DAY_OF_YEAR), 182);
+
+            assertEquals(test.get(ChronoField.HOUR_OF_DAY), 12);
+            assertEquals(test.get(ChronoField.MINUTE_OF_HOUR), 30);
+            assertEquals(test.get(ChronoField.SECOND_OF_MINUTE), 40);
+            assertEquals(test.get(ChronoField.NANO_OF_SECOND), 987654321);
+            assertEquals(test.get(ChronoField.HOUR_OF_AMPM), 0);
+            assertEquals(test.get(ChronoField.AMPM_OF_DAY), 1);
+
+            assertEquals(test.get(ChronoField.OFFSET_SECONDS), 3600);
+        });
+
+        it('getLong(TemporalField)', () => {
+            const test = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(12, 30, 40, 987654321), OFFSET_PONE);
+            assertEquals(test.getLong(ChronoField.YEAR), 2008);
+            assertEquals(test.getLong(ChronoField.MONTH_OF_YEAR), 6);
+            assertEquals(test.getLong(ChronoField.DAY_OF_MONTH), 30);
+            assertEquals(test.getLong(ChronoField.DAY_OF_WEEK), 1);
+            assertEquals(test.getLong(ChronoField.DAY_OF_YEAR), 182);
+
+            assertEquals(test.getLong(ChronoField.HOUR_OF_DAY), 12);
+            assertEquals(test.getLong(ChronoField.MINUTE_OF_HOUR), 30);
+            assertEquals(test.getLong(ChronoField.SECOND_OF_MINUTE), 40);
+            assertEquals(test.getLong(ChronoField.NANO_OF_SECOND), 987654321);
+            assertEquals(test.getLong(ChronoField.HOUR_OF_AMPM), 0);
+            assertEquals(test.getLong(ChronoField.AMPM_OF_DAY), 1);
+
+            assertEquals(test.getLong(ChronoField.INSTANT_SECONDS), test.toEpochSecond());
+            assertEquals(test.getLong(ChronoField.OFFSET_SECONDS), 3600);
+        });
+    });
+
+    describe('query(TemporalQuery)', () => {
+        it('query', () => {
+            assertEquals(TEST_2008_6_30_11_30_59_000000500.query(TemporalQueries.chronology()), IsoChronology.INSTANCE);
+            assertEquals(TEST_2008_6_30_11_30_59_000000500.query(TemporalQueries.localDate()), TEST_2008_6_30_11_30_59_000000500.toLocalDate());
+            assertEquals(TEST_2008_6_30_11_30_59_000000500.query(TemporalQueries.localTime()), TEST_2008_6_30_11_30_59_000000500.toLocalTime());
+            assertEquals(TEST_2008_6_30_11_30_59_000000500.query(TemporalQueries.offset()), TEST_2008_6_30_11_30_59_000000500.offset());
+            assertEquals(TEST_2008_6_30_11_30_59_000000500.query(TemporalQueries.precision()), ChronoUnit.NANOS);
+            assertEquals(TEST_2008_6_30_11_30_59_000000500.query(TemporalQueries.zone()), TEST_2008_6_30_11_30_59_000000500.offset());
+            assertEquals(TEST_2008_6_30_11_30_59_000000500.query(TemporalQueries.zoneId()), null);
+        });
+
+        it('null', () => {
+            expect(() => {
+                TEST_2008_6_30_11_30_59_000000500.query(null);
+            }).to.throw(NullPointerException);
+        });
+    });
+
+    describe('with(WithAdjuster)', () => {
+        it('adjustment', () => {
+            const sample = OffsetDateTime.of(LocalDate.of(2012, 3, 4), LocalTime.of(23, 5), OFFSET_PONE);
+            const adjuster = new TemporalAdjuster();
+            adjuster.adjustInto = () => sample;
+            assertEquals(TEST_2008_6_30_11_30_59_000000500.with(adjuster), sample);
+        });
+
+        it('adjustment_LocalDate', () => {
+            const test = TEST_2008_6_30_11_30_59_000000500.with(LocalDate.of(2012, 9, 3));
+            assertEquals(test, OffsetDateTime.of(LocalDate.of(2012, 9, 3), LocalTime.of(11, 30, 59, 500), OFFSET_PONE));
+        });
+
+        it('adjustment_LocalTime', () => {
+            const test = TEST_2008_6_30_11_30_59_000000500.with(LocalTime.of(19, 15));
+            assertEquals(test, OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(19, 15), OFFSET_PONE));
+        });
+
+        it('adjustment_LocalDateTime', () => {
+            const test = TEST_2008_6_30_11_30_59_000000500.with(LocalDateTime.of(LocalDate.of(2012, 9, 3), LocalTime.of(19, 15)));
+            assertEquals(test, OffsetDateTime.of(LocalDate.of(2012, 9, 3), LocalTime.of(19, 15), OFFSET_PONE));
+        });
+
+        it('adjustment_OffsetTime', () => {
+            const test = TEST_2008_6_30_11_30_59_000000500.with(OffsetTime.of(LocalTime.of(19, 15), OFFSET_PTWO));
+            assertEquals(test, OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(19, 15), OFFSET_PTWO));
+        });
+
+        it('adjustment_OffsetDateTime', () => {
+            const test = TEST_2008_6_30_11_30_59_000000500.with(OffsetDateTime.of(LocalDate.of(2012, 9, 3), LocalTime.of(19, 15), OFFSET_PTWO));
+            assertEquals(test, OffsetDateTime.of(LocalDate.of(2012, 9, 3), LocalTime.of(19, 15), OFFSET_PTWO));
+        });
+
+        it('adjustment_Month', () => {
+            const test = TEST_2008_6_30_11_30_59_000000500.with(Month.DECEMBER);
+            assertEquals(test, OffsetDateTime.of(LocalDate.of(2008, 12, 30),LocalTime.of(11, 30, 59, 500), OFFSET_PONE));
+        });
+
+        it('adjustment_ZoneOFfset', () => {
+            const test = TEST_2008_6_30_11_30_59_000000500.with(OFFSET_PTWO);
+            assertEquals(test, OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 59, 500), OFFSET_PTWO));
+        });
+
+        it('null', () => {
+            expect(() => {
+                TEST_2008_6_30_11_30_59_000000500.with(null);
+            }).to.throw(NullPointerException);
+        });
+    });
+
+    describe('withOffsetSameLocal', () => {
+        it('withOffsetSameLocal null', () => {
+            expect(() => {
+                const base = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 59), OFFSET_PONE);
+                base.withOffsetSameLocal(null);
+            }).to.throw(NullPointerException);
+        });
+    });
+
+    describe('withOffsetSameInstant', () => {
+        it('normal', () => {
+            const base = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.withOffsetSameInstant(OFFSET_PTWO);
+            const expected = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(12, 30, 59), OFFSET_PTWO);
+            assertEquals(test, expected);
+        });
+
+        it('null', () => {
+            expect(() => {
+                const base = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 59), OFFSET_PONE);
+                base.withOffsetSameInstant(null);
+            }).to.throw(NullPointerException);
+        });
+    });
+
+    describe('withMonth', () => {
+        it('normal', () => {
+            const base = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.withMonth(1);
+            assertEquals(test, OffsetDateTime.of(LocalDate.of(2008, 1, 30), LocalTime.of(11, 30, 59), OFFSET_PONE));
+        });
+    });
+
+    describe('withDayOfMonth', () => {
+        const base = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 59), OFFSET_PONE);
+        const test = base.withDayOfMonth(15);
+        assertEquals(test, OffsetDateTime.of(LocalDate.of(2008, 6, 15), LocalTime.of(11, 30, 59), OFFSET_PONE));
+    });
+
+    describe('withDayOfYear', () => {
+        it('normal', () => {
+            const t = TEST_2008_6_30_11_30_59_000000500.withDayOfYear(33);
+            assertEquals(t, OffsetDateTime.of(LocalDate.of(2008, 2, 2), LocalTime.of(11, 30, 59, 500), OFFSET_PONE));
+        });
+
+        it('illegal', () => {
+            expect(() => {
+                TEST_2008_6_30_11_30_59_000000500.withDayOfYear(367);
+            }).to.throw(DateTimeException);
+        });
+
+        it('invalid', () => {
+            expect(() => {
+                OffsetDateTime.of(LocalDate.of(2007, 2, 2), LocalTime.of(11, 30), OFFSET_PONE).withDayOfYear(366);
+            }).to.throw(DateTimeException);
+        });
+    });
+
+    describe('withHour', () => {
+        it('normal', () => {
+            const base = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.withHour(15);
+            assertEquals(test, OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(15, 30, 59), OFFSET_PONE));
+        });
+    });
+
+    describe('withMinute', () => {
+        it('normal', () => {
+            const base = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.withMinute(15);
+            assertEquals(test, OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 15, 59), OFFSET_PONE));
+        });
+    });
+
+    describe('withSecond', () => {
+        it('normal', () => {
+            const base = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.withSecond(15);
+            assertEquals(test, OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 15), OFFSET_PONE));
+        });
+    });
+
+    describe('withNanoOfSecond', () => {
+        it('normal', () => {
+            const base = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 59, 1), OFFSET_PONE);
+            const test = base.withNano(15);
+            assertEquals(test, OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 59, 15), OFFSET_PONE));
+        });
+    });
+
+    describe('truncatedTo(TemporalUnit)', () => {
+        it('normal', () => {
+            assertEquals(TEST_2008_6_30_11_30_59_000000500.truncatedTo(ChronoUnit.NANOS), TEST_2008_6_30_11_30_59_000000500);
+            assertEquals(TEST_2008_6_30_11_30_59_000000500.truncatedTo(ChronoUnit.SECONDS), TEST_2008_6_30_11_30_59_000000500.withNano(0));
+            assertEquals(TEST_2008_6_30_11_30_59_000000500.truncatedTo(ChronoUnit.DAYS), TEST_2008_6_30_11_30_59_000000500.with(LocalTime.MIDNIGHT));
+        });
+
+        it('null', () => {
+            expect(() => {
+                TEST_2008_6_30_11_30_59_000000500.truncatedTo(null);
+            }).to.throw(NullPointerException);
+        });
+    });
+
+    describe('plus(Period)', () => {
+        it('normal', () => {
+            const period = MockSimplePeriod.of(7, ChronoUnit.MONTHS);
+            const t = TEST_2008_6_30_11_30_59_000000500.plus(period);
+            assertEquals(t, OffsetDateTime.of(LocalDate.of(2009, 1, 30), LocalTime.of(11, 30, 59, 500), OFFSET_PONE));
+        });
+    });
+
+    describe('plus(Duration)', () => {
+        it('normal', () => {
+            const dur = Duration.ofSeconds(62, 3);
+            const t = TEST_2008_6_30_11_30_59_000000500.plus(dur);
+            assertEquals(t, OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 32, 1, 503), OFFSET_PONE));
+        });
+
+        it('zero', () => {
+            const t = TEST_2008_6_30_11_30_59_000000500.plus(Duration.ZERO);
+            assertEquals(t, TEST_2008_6_30_11_30_59_000000500);
+        });
+
+        it('null', () => {
+            expect(() => {
+                TEST_2008_6_30_11_30_59_000000500.plus(null);
+            }).to.throw(NullPointerException);
+        });
+    });
+
+    describe('plusYears', () => {
+        it('normal', () => {
+            const base = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.plusYears(1);
+            assertEquals(test, OffsetDateTime.of(LocalDate.of(2009, 6, 30), LocalTime.of(11, 30, 59), OFFSET_PONE));
+        });
+    });
+
+    describe('plusMonths', () => {
+        it('normal', () => {
+            const base = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.plusMonths(1);
+            assertEquals(test, OffsetDateTime.of(LocalDate.of(2008, 7, 30), LocalTime.of(11, 30, 59), OFFSET_PONE));
+        });
+    });
+
+    describe('plusWeeks', () => {
+        it('normal', () => {
+            const base = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.plusWeeks(1);
+            assertEquals(test, OffsetDateTime.of(LocalDate.of(2008, 7, 7), LocalTime.of(11, 30, 59), OFFSET_PONE));
+        });
+    });
+
+    describe('plusDays', () => {
+        it('normal', () => {
+            const base = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.plusDays(1);
+            assertEquals(test, OffsetDateTime.of(LocalDate.of(2008, 7, 1), LocalTime.of(11, 30, 59), OFFSET_PONE));
+        });
+    });
+
+    describe('plusHours', () => {
+        it('normal', () => {
+            const base = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.plusHours(13);
+            assertEquals(test, OffsetDateTime.of(LocalDate.of(2008, 7, 1), LocalTime.of(0, 30, 59), OFFSET_PONE));
+        });
+    });
+
+    describe('plusMinutes', () => {
+        it('normal', () => {
+            const base = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.plusMinutes(30);
+            assertEquals(test, OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(12, 0, 59), OFFSET_PONE));
+        });
+    });
+
+    describe('plusSeconds', () => {
+        it('normal', () => {
+            const base = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.plusSeconds(1);
+            assertEquals(test, OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 31, 0), OFFSET_PONE));
+        });
+    });
+
+    describe('plusNanos', () => {
+        it('normal', () => {
+            const base = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 59, 0), OFFSET_PONE);
+            const test = base.plusNanos(1);
+            assertEquals(test, OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 59, 1), OFFSET_PONE));
+        });
+    });
+
+    describe('mius(Period)', () => {
+        it('normal', () => {
+            const period = MockSimplePeriod.of(7, ChronoUnit.MONTHS);
+            const t = TEST_2008_6_30_11_30_59_000000500.minus(period);
+            assertEquals(t, OffsetDateTime.of(LocalDate.of(2007, 11, 30), LocalTime.of(11, 30, 59, 500), OFFSET_PONE));
+        });
+    });
+
+    describe('minus(Duration)', () => {
+        it('normal', () => {
+            const dur = Duration.ofSeconds(62, 3);
+            const t = TEST_2008_6_30_11_30_59_000000500.minus(dur);
+            assertEquals(t, OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 29, 57, 497), OFFSET_PONE));
+        });
+
+        it('zero', () => {
+            const t = TEST_2008_6_30_11_30_59_000000500.minus(Duration.ZERO);
+            assertEquals(t, TEST_2008_6_30_11_30_59_000000500);
+        });
+
+        it('null', () => {
+            expect(() => {
+                TEST_2008_6_30_11_30_59_000000500.minus(null);
+            }).to.throw(NullPointerException);
+        });
+    });
+
+    describe('minusYears', () => {
+        it('normal', () => {
+            const base = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.minusYears(1);
+            assertEquals(test, OffsetDateTime.of(LocalDate.of(2007, 6, 30), LocalTime.of(11, 30, 59), OFFSET_PONE));
+        });
+    });
+
+    describe('minusMonths', () => {
+        it('normal', () => {
+            const base = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.minusMonths(1);
+            assertEquals(test, OffsetDateTime.of(LocalDate.of(2008, 5, 30), LocalTime.of(11, 30, 59), OFFSET_PONE));
+        });
+    });
+
+    describe('minusWeeks', () => {
+        it('normal', () => {
+            const base = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.minusWeeks(1);
+            assertEquals(test, OffsetDateTime.of(LocalDate.of(2008, 6, 23), LocalTime.of(11, 30, 59), OFFSET_PONE));
+        });
+    });
+
+    describe('minusDays', () => {
+        it('normal', () => {
+            const base = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.minusDays(1);
+            assertEquals(test, OffsetDateTime.of(LocalDate.of(2008, 6, 29), LocalTime.of(11, 30, 59), OFFSET_PONE));
+        });
+    });
+
+    describe('minusHours', () => {
+        it('normal' +
+            '', () => {
+            const base = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.minusHours(13);
+            assertEquals(test, OffsetDateTime.of(LocalDate.of(2008, 6, 29), LocalTime.of(22, 30, 59), OFFSET_PONE));
+        });
+    });
+
+    describe('miusMinutes', () => {
+        it('normal', () => {
+            const base = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.minusMinutes(30);
+            assertEquals(test, OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 0, 59), OFFSET_PONE));
+        });
+    });
+
+    describe('minusSeconds', () => {
+        it('normal', () => {
+            const base = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.minusSeconds(1);
+            assertEquals(test, OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 58), OFFSET_PONE));
+        });
+    });
+
+    describe('minusNanos', () => {
+        it('normal', () => {
+            const base = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 59, 0), OFFSET_PONE);
+            const test = base.minusNanos(1);
+            assertEquals(test, OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 58, 999999999), OFFSET_PONE));
+        });
+    });
+
+    describe('atZoneSameInstant', () => {
+        it('atZone', () => {
+            const t = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30), OFFSET_MTWO);
+            assertEquals(t.atZoneSameInstant(ZONE_PARIS),
+                ZonedDateTime.of(LocalDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(15, 30)), ZONE_PARIS));
+        });
+
+        it('nullTimeZone', () => {
+            expect(() => {
+                const t = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30), OFFSET_PTWO);
+                t.atZoneSameInstant(null);
+            }).to.throw(NullPointerException);
+        });
+    });
+
+    describe('atZoneSimilarLocal', () => {
+        it('normal', () => {
+            const t = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30), OFFSET_MTWO);
+            assertEquals(t.atZoneSimilarLocal(ZONE_PARIS),
+                ZonedDateTime.of(LocalDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30)), ZONE_PARIS));
+        });
+
+        it('dstGap', () => {
+            const t = OffsetDateTime.of(LocalDate.of(2007, 4, 1), LocalTime.of(0, 0), OFFSET_MTWO);
+            assertEquals(t.atZoneSimilarLocal(ZONE_GAZA),
+                ZonedDateTime.of(LocalDateTime.of(LocalDate.of(2007, 4, 1), LocalTime.of(1, 0)), ZONE_GAZA));
+        });
+
+        it('dstOverlapSummer', () => {
+            const t = OffsetDateTime.of(LocalDate.of(2007, 10, 28), LocalTime.of(2, 30), OFFSET_PTWO);
+            assertEquals(t.atZoneSimilarLocal(ZONE_PARIS).toLocalDateTime(), t.toLocalDateTime());
+            assertEquals(t.atZoneSimilarLocal(ZONE_PARIS).offset(), OFFSET_PTWO);
+            assertEquals(t.atZoneSimilarLocal(ZONE_PARIS).zone(), ZONE_PARIS);
+        });
+
+        it('dstOverlapWinter', () => {
+            const t = OffsetDateTime.of(LocalDate.of(2007, 10, 28), LocalTime.of(2, 30), OFFSET_PONE);
+            assertEquals(t.atZoneSimilarLocal(ZONE_PARIS).toLocalDateTime(), t.toLocalDateTime());
+            assertEquals(t.atZoneSimilarLocal(ZONE_PARIS).offset(), OFFSET_PONE);
+            assertEquals(t.atZoneSimilarLocal(ZONE_PARIS).zone(), ZONE_PARIS);
+        });
+
+        it('nullTimeZone', () => {
+            expect(() => {
+                const t = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30), OFFSET_PTWO);
+                t.atZoneSimilarLocal(null);
+            }).to.throw(NullPointerException);
+        });
+    });
+
+    describe('toEpochSecond', () => {
+        it('afterEpoch', function() {
+            for (let i = 0; i < 100000; i += 100) {
+                const a = OffsetDateTime.of(LocalDate.of(1970, 1, 1), LocalTime.of(0, 0), ZoneOffset.UTC).plusSeconds(i);
+                assertEquals(a.toEpochSecond(), i);
+            }
+        });
+
+        it('beforeEpoch', () => {
+            // +0 !== -0 in JS
+            const b = OffsetDateTime.of(LocalDate.of(1970, 1, 1), LocalTime.of(0, 0), ZoneOffset.UTC).minusSeconds(0);
+            assertEquals(b.toEpochSecond(), 0);
+
+            for (let i = 1; i < 100000; i += 100) {
+                const a = OffsetDateTime.of(LocalDate.of(1970, 1, 1), LocalTime.of(0, 0), ZoneOffset.UTC).minusSeconds(i);
+                assertEquals(a.toEpochSecond(), -i);
+            }
+        });
+    });
+
+    describe('compareTo', () => {
+        it('timeMins', () => {
+            const a = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 29, 3), OFFSET_PONE);
+            const b = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 2), OFFSET_PONE);  // a is before b due to time
+            assertEquals(a.compareTo(b) < 0, true);
+            assertEquals(b.compareTo(a) > 0, true);
+            assertEquals(a.compareTo(a) === 0, true);
+            assertEquals(b.compareTo(b) === 0, true);
+            assertEquals(a.toInstant().compareTo(b.toInstant()) < 0, true);
+        });
+
+        it('timeSecs', () => {
+            const a = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 29, 2), OFFSET_PONE);
+            const b = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 29, 3), OFFSET_PONE);  // a is before b due to time
+            assertEquals(a.compareTo(b) < 0, true);
+            assertEquals(b.compareTo(a) > 0, true);
+            assertEquals(a.compareTo(a) === 0, true);
+            assertEquals(b.compareTo(b) === 0, true);
+            assertEquals(a.toInstant().compareTo(b.toInstant()) < 0, true);
+        });
+
+        it('timeNanos', () => {
+            const a = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 29, 40, 4), OFFSET_PONE);
+            const b = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 29, 40, 5), OFFSET_PONE);  // a is before b due to time
+            assertEquals(a.compareTo(b) < 0, true);
+            assertEquals(b.compareTo(a) > 0, true);
+            assertEquals(a.compareTo(a) === 0, true);
+            assertEquals(b.compareTo(b) === 0, true);
+            assertEquals(a.toInstant().compareTo(b.toInstant()) < 0, true);
+        });
+
+        it('offset', () => {
+            const a = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30), OFFSET_PTWO);
+            const b = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30), OFFSET_PONE);  // a is before b due to offset
+            assertEquals(a.compareTo(b) < 0, true);
+            assertEquals(b.compareTo(a) > 0, true);
+            assertEquals(a.compareTo(a) === 0, true);
+            assertEquals(b.compareTo(b) === 0, true);
+            assertEquals(a.toInstant().compareTo(b.toInstant()) < 0, true);
+        });
+
+        it('offsetNanos', () => {
+            const a = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 40, 6), OFFSET_PTWO);
+            const b = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 40, 5), OFFSET_PONE);  // a is before b due to offset
+            assertEquals(a.compareTo(b) < 0, true);
+            assertEquals(b.compareTo(a) > 0, true);
+            assertEquals(a.compareTo(a) === 0, true);
+            assertEquals(b.compareTo(b) === 0, true);
+            assertEquals(a.toInstant().compareTo(b.toInstant()) < 0, true);
+        });
+
+        it('both', () => {
+            const a = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 50), OFFSET_PTWO);
+            const b = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 20), OFFSET_PONE);  // a is before b on instant scale
+            assertEquals(a.compareTo(b) < 0, true);
+            assertEquals(b.compareTo(a) > 0, true);
+            assertEquals(a.compareTo(a) === 0, true);
+            assertEquals(b.compareTo(b) === 0, true);
+            assertEquals(a.toInstant().compareTo(b.toInstant()) < 0, true);
+        });
+
+        it('bothNanos', () => {
+            const a = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 20, 40, 4), OFFSET_PTWO);
+            const b = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(10, 20, 40, 5), OFFSET_PONE);  // a is before b on instant scale
+            assertEquals(a.compareTo(b) < 0, true);
+            assertEquals(b.compareTo(a) > 0, true);
+            assertEquals(a.compareTo(a) === 0, true);
+            assertEquals(b.compareTo(b) === 0, true);
+            assertEquals(a.toInstant().compareTo(b.toInstant()) < 0, true);
+        });
+
+        it('hourDifference', () => {
+            const a = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(10, 0), OFFSET_PONE);
+            const b = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 0), OFFSET_PTWO);  // a is before b despite being same time-line time
+            assertEquals(a.compareTo(b) < 0, true);
+            assertEquals(b.compareTo(a) > 0, true);
+            assertEquals(a.compareTo(a) === 0, true);
+            assertEquals(b.compareTo(b) === 0, true);
+            assertEquals(a.toInstant().compareTo(b.toInstant()) === 0, true);
+        });
+
+        it('max', () => {
+            const a = OffsetDateTime.of(LocalDate.of(Year.MAX_VALUE, 12, 31), LocalTime.of(23, 59), OFFSET_MONE);
+            const b = OffsetDateTime.of(LocalDate.of(Year.MAX_VALUE, 12, 31), LocalTime.of(23, 59), OFFSET_MTWO);  // a is before b due to offset
+            assertEquals(a.compareTo(b) < 0, true);
+            assertEquals(b.compareTo(a) > 0, true);
+            assertEquals(a.compareTo(a) === 0, true);
+            assertEquals(b.compareTo(b) === 0, true);
+        });
+
+        it('min', () => {
+            const a = OffsetDateTime.of(LocalDate.of(Year.MIN_VALUE, 1, 1), LocalTime.of(0, 0), OFFSET_PTWO);
+            const b = OffsetDateTime.of(LocalDate.of(Year.MIN_VALUE, 1, 1), LocalTime.of(0, 0), OFFSET_PONE);  // a is before b due to offset
+            assertEquals(a.compareTo(b) < 0, true);
+            assertEquals(b.compareTo(a) > 0, true);
+            assertEquals(a.compareTo(a) === 0, true);
+            assertEquals(b.compareTo(b) === 0, true);
+        });
+
+        it('null', () => {
+            expect(() => {
+                const a = OffsetDateTime.of(LocalDate.of(2008, 6, 30), LocalTime.of(11, 30, 59), OFFSET_PONE);
+                a.compareTo(null);
+            }).to.throw(NullPointerException);
+        });
+
+        it('NonOffsetDateTime', () => {
+            expect(() => {
+                const c = TEST_2008_6_30_11_30_59_000000500;
+                c.compareTo(new Object());
+            }).to.throw(IllegalArgumentException);
+        });
+    });
+});

--- a/packages/core/test/reference/OffsetTimeTest.js
+++ b/packages/core/test/reference/OffsetTimeTest.js
@@ -1,0 +1,1048 @@
+/*
+ * @copyright (c) 2016, Philipp Thürwächter & Pattrick Hüper
+ * @copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos
+ * @license BSD-3-Clause (see LICENSE in the root directory of this source tree)
+ */
+
+import {expect} from 'chai';
+
+import {Clock} from '../../src/Clock';
+import {Instant} from '../../src/Instant';
+import {ChronoField} from '../../src/temporal/ChronoField';
+import {TemporalAdjuster} from '../../src/temporal/TemporalAdjuster';
+import {ChronoUnit} from '../../src/temporal/ChronoUnit';
+import {TemporalQueries} from '../../src/temporal/TemporalQueries';
+import {LocalTime} from '../../src/LocalTime';
+import {LocalDate} from '../../src/LocalDate';
+import {Period} from '../../src/Period';
+import {LocalDateTime} from '../../src/LocalDateTime';
+import {DateTimeFormatter} from '../../src/format/DateTimeFormatter';
+import {ZoneOffset} from '../../src/ZoneOffset';
+import {OffsetTime} from '../../src/OffsetTime';
+import {ZonedDateTime} from '../../src/ZonedDateTime';
+import {
+    DateTimeException,
+    DateTimeParseException,
+    IllegalArgumentException,
+    NullPointerException
+} from '../../src/errors';
+
+import {MockSimplePeriod} from './MockSimplePeriod';
+import {dataProviderTest, assertNotNull, assertEquals} from '../testUtils';
+
+import '../_init';
+
+describe('org.threeten.bp.TestOffsetTime', () => {
+    const OFFSET_PONE = ZoneOffset.ofHours(1);
+    const OFFSET_PTWO = ZoneOffset.ofHours(2);
+    const DATE = LocalDate.of(2008, 12, 3);
+    const sampleTimes = [
+        [11, 30, 20, 500, OFFSET_PONE],
+        [11, 0, 0, 0, OFFSET_PONE],
+        [23, 59, 59, 999999999, OFFSET_PONE],
+    ];
+    const sampleToString = [
+        [11, 30, 59, 0, 'Z', '11:30:59Z'],
+        [11, 30, 59, 0, '+01:00', '11:30:59+01:00'],
+        [11, 30, 59, 999000000, 'Z', '11:30:59.999Z'],
+        [11, 30, 59, 999000000, '+01:00', '11:30:59.999+01:00'],
+        [11, 30, 59, 999000, 'Z', '11:30:59.000999Z'],
+        [11, 30, 59, 999000, '+01:00', '11:30:59.000999+01:00'],
+        [11, 30, 59, 999, 'Z', '11:30:59.000000999Z'],
+        [11, 30, 59, 999, '+01:00', '11:30:59.000000999+01:00'],
+    ];
+
+    let TEST_11_30_59_500_PONE;
+
+    beforeEach(() => {
+        TEST_11_30_59_500_PONE = OffsetTime.of(LocalTime.of(11, 30, 59, 500), OFFSET_PONE);
+    });
+
+    /**
+     * @param {OffsetTime} test
+     * @param {int} h
+     * @param {int} m
+     * @param {int} s
+     * @param {int} n
+     * @param {ZoneOffset }offset
+     */
+    function check( test,  h, m,  s,  n,  offset) {
+        expect(test.toLocalTime()).to.eql(LocalTime.of(h, m, s, n));
+        expect(test.offset()).to.eql(offset);
+
+        expect(test.hour()).to.equal(h);
+        expect(test.minute()).to.equal(m);
+        expect(test.second()).to.equal(s);
+        expect(test.nano()).to.equal(n);
+
+        expect(test).to.equal(test);
+        expect(test.hashCode()).to.equal(test.hashCode());
+        expect(OffsetTime.of(LocalTime.of(h, m, s, n), offset)).to.eql(test);
+    }
+
+    describe('constants', () => {
+        it('MIN', () => {
+            check(OffsetTime.MIN, 0, 0, 0, 0, ZoneOffset.MAX);
+        });
+        it('MAX', () => {
+            check(OffsetTime.MAX, 23, 59, 59, 999999999, ZoneOffset.MIN);
+        });
+    });
+
+    describe('now', () => {
+        it('now()', () => {
+            const nowDT = ZonedDateTime.now();
+
+            const expected = OffsetTime.now(Clock.systemDefaultZone());
+            const test = OffsetTime.now();
+            const diff = Math.abs(test.toLocalTime().toNanoOfDay() - expected.toLocalTime().toNanoOfDay());
+            expect(diff).to.be.lessThan(100000000);
+            expect(test.offset()).to.be.eql(nowDT.offset());
+        });
+
+        describe('now(Clock)', () => {
+            it('allSecsInDay', () => {
+                for (let i = 0; i < (2 * 24 * 60 * 60); i += 100) {
+                    const instant = Instant.ofEpochSecond(i, 8);
+                    const clock = Clock.fixed(instant, ZoneOffset.UTC);
+                    const test = OffsetTime.now(clock);
+                    expect(test.hour()).to.be.equal(Math.floor(i / (60 * 60)) % 24);
+                    expect(test.minute()).to.be.equal(Math.floor(i / 60) % 60);
+                    expect(test.second()).to.be.equal(i % 60);
+                    expect(test.nano()).to.be.equal(8);
+                    expect(test.offset()).to.be.eql(ZoneOffset.UTC);
+                }
+            });
+
+            it('beforeEpoch', () => {
+                for (let i =-1; i >= -(24 * 60 * 60); i -= 100) {
+                    const instant = Instant.ofEpochSecond(i, 8);
+                    const clock = Clock.fixed(instant, ZoneOffset.UTC);
+                    const test = OffsetTime.now(clock);
+                    expect(test.hour()).to.be.equal(Math.floor((i + 24 * 60 * 60) / (60 * 60)) % 24);
+                    expect(test.minute()).to.be.equal(Math.floor((i + 24 * 60 * 60) / 60) % 60);
+                    expect(test.second()).to.be.equal(Math.floor(i + 24 * 60 * 60) % 60);
+                    expect(test.nano()).to.be.equal(8);
+                    expect(test.offset()).to.be.eql(ZoneOffset.UTC);
+                }
+            });
+
+            it('offsets', () =>{
+                const base = LocalDateTime.of(1970, 1, 1, 12, 0).toInstant(ZoneOffset.UTC);
+                for (let i = -9; i < 15; i++) {
+                    const offset = ZoneOffset.ofHours(i);
+                    const clock = Clock.fixed(base, offset);
+                    const test = OffsetTime.now(clock);
+                    expect(test.hour()).to.be.equal((12 + i) % 24);
+                    expect(test.minute()).to.be.equal( 0);
+                    expect(test.second()).to.be.equal( 0);
+                    expect(test.nano()).to.be.equal( 0);
+                    expect(test.offset()).to.be.eql(offset);
+                }
+            });
+
+            it('null', () => {
+                expect(() => {
+                    OffsetTime.now( null);
+                }).to.throw(NullPointerException);
+            });
+        });
+    });
+
+    describe('factories', () => {
+        describe('of', () => {
+            it('intsHM', () => {
+                const test = OffsetTime.of(LocalTime.of(11, 30), OFFSET_PONE);
+                check(test, 11, 30, 0, 0, OFFSET_PONE);
+            });
+
+            it('intsHMS', () => {
+                const test = OffsetTime.of(LocalTime.of(11, 30, 10), OFFSET_PONE);
+                check(test, 11, 30, 10, 0, OFFSET_PONE);
+            });
+
+            it('intsHMSN', () => {
+                const test = OffsetTime.of(LocalTime.of(11, 30, 10, 500), OFFSET_PONE);
+                check(test, 11, 30, 10, 500, OFFSET_PONE);
+            });
+
+            it('LocalTimeZoneOffset', () => {
+                const localTime = LocalTime.of(11, 30, 10, 500);
+                const test = OffsetTime.of(localTime, OFFSET_PONE);
+                check(test, 11, 30, 10, 500, OFFSET_PONE);
+            });
+
+            it('LocalTimeZoneOffset_nullTime', () => {
+                expect(() => {
+                    OffsetTime.of(null, OFFSET_PONE);
+                }).to.throw(NullPointerException);
+            });
+
+            it('LocalTimeZoneOffset_nullOffset', () => {
+                expect(() => {
+                    const localTime = LocalTime.of(11, 30, 10, 500);
+                    OffsetTime.of(localTime, null);
+                }).to.throw(NullPointerException);
+            });
+        });
+
+        describe('ofInstant', () => {
+            it('nullInstant', () => {
+                expect(() => {
+                    OffsetTime.ofInstant(null, ZoneOffset.UTC);
+                }).to.throw(NullPointerException);
+            });
+
+            it('nullOffset', () => {
+                expect(() => {
+                    const instant = Instant.ofEpochSecond(0);
+                    OffsetTime.ofInstant(instant,  null);
+                }).to.throw(NullPointerException);
+            });
+
+            it('allSpecsInDay', () => {
+                for (let i = 0; i < (2 * 24 * 60 * 60); i += 100) {
+                    const instant = Instant.ofEpochSecond(i, 8);
+                    const test = OffsetTime.ofInstant(instant, ZoneOffset.UTC);
+                    expect(test.hour()).to.be.equal(Math.floor(i / (60 * 60)) % 24);
+                    expect(test.minute()).to.be.equal(Math.floor(i / 60) % 60);
+                    expect(test.second()).to.be.equal(i % 60);
+                    expect(test.nano()).to.be.equal(8);
+                }
+            });
+
+            it('beforeEpoch', () => {
+                for (let i =-1; i >= -(24 * 60 * 60); i -= 100) {
+                    const instant = Instant.ofEpochSecond(i, 8);
+                    const test = OffsetTime.ofInstant(instant, ZoneOffset.UTC);
+                    expect(test.hour()).to.be.equal(Math.floor((i + 24 * 60 * 60) / (60 * 60)) % 24);
+                    expect(test.minute()).to.be.equal(Math.floor((i + 24 * 60 * 60) / 60) % 60);
+                    expect(test.second()).to.be.equal(Math.floor(i + 24 * 60 * 60) % 60);
+                    expect(test.nano()).to.be.equal(8);
+                }
+            });
+
+            it('maxYear', () => {
+                const test = OffsetTime.ofInstant(Instant.MAX, ZoneOffset.UTC);
+                expect(test.hour()).to.be.equal(23);
+                expect(test.minute()).to.be.equal(59);
+                expect(test.second()).to.be.equal(59);
+                expect(test.nano()).to.be.equal( 999999999);
+            });
+
+            it('minYear', () => {
+                const test = OffsetTime.ofInstant(Instant.MIN, ZoneOffset.UTC);
+                expect(test.hour()).to.be.equal(0);
+                expect(test.minute()).to.be.equal(0);
+                expect(test.second()).to.be.equal(0);
+                expect(test.nano()).to.be.equal(0);
+            });
+        });
+
+        describe('from(TemporalAccessor)', () => {
+            it('OT', () => {
+                expect(OffsetTime.from(OffsetTime.of(LocalTime.of(17, 30), OFFSET_PONE)))
+                    .to.be.eql(OffsetTime.of(LocalTime.of(17, 30), OFFSET_PONE));
+            });
+
+            it('ZDT', () => {
+                const base = LocalDateTime.of(2007, 7, 15, 11, 30, 59, 500).atZone(OFFSET_PONE);
+                expect(OffsetTime.from(base)).to.be.eql(TEST_11_30_59_500_PONE);
+            });
+
+            it('invalid_noDerive', () => {
+                expect(() => {
+                    OffsetTime.from(LocalDate.of(2007, 7, 15));
+                }).to.throw(DateTimeException);
+            });
+
+            it('null', () => {
+                expect(() => {
+                    OffsetTime.from(null);
+                }).to.throw(NullPointerException);
+            });
+        });
+
+        describe('parse(String)', () => {
+            it('validText', () => {
+                dataProviderTest(sampleToString, (h, m, s, n, offsetId, parsable) => {
+                    const t = OffsetTime.parse(parsable);
+                    assertNotNull(t, parsable);
+                    check(t, h, m, s, n, ZoneOffset.of(offsetId));
+                });
+            });
+
+            const sampleBadParse = [
+                '00;00',
+                '12-00',
+                '-01:00',
+                '00:00:00-09',
+                '00:00:00,09',
+                '00:00:abs',
+                '11',
+                '11:30',
+                '11:30+01:00[Europe/Paris]',
+            ];
+
+            it('invalidText', () => {
+                dataProviderTest(sampleBadParse, (unparsable) => {
+                    expect(() => {
+                        OffsetTime.parse(unparsable);
+                    }).to.throw(DateTimeParseException);
+                });
+            });
+
+            it('illegalHour', () => {
+                expect(() => {
+                    OffsetTime.parse('25:00+01:00');
+                }).to.throw(DateTimeParseException);
+            });
+
+            it('illegalHour', () => {
+                expect(() => {
+                    OffsetTime.parse('25:00+01:00');
+                }).to.throw(DateTimeParseException);
+            });
+
+
+            it('illegalMinute', () => {
+                expect(() => {
+                    OffsetTime.parse('12:60+01:00');
+                }).to.throw(DateTimeParseException);
+            });
+
+            it('illegalSecond', () => {
+                expect(() => {
+                    OffsetTime.parse('12:12:60+01:00');
+                }).to.throw(DateTimeParseException);
+            });
+        });
+
+        describe('oarse(DateTimeFormatter)', () =>{
+            it('formatter', () => {
+                const f = DateTimeFormatter.ofPattern('H m s XXX');
+                const test = OffsetTime.parse('11 30 0 +01:00', f);
+                expect(test).to.be.eql(OffsetTime.of(LocalTime.of(11, 30), ZoneOffset.ofHours(1)));
+            });
+
+            it('nullText', () =>{
+                expect(() => {
+                    const f = DateTimeFormatter.ofPattern('y M d H m s');
+                    OffsetTime.parse(null, f);
+                }).to.throw(NullPointerException);
+            });
+
+            it('nullFormatter', () =>{
+                expect(() => {
+                    OffsetTime.parse('ANY', null);
+                }).to.throw(NullPointerException);
+            });
+        });
+    });
+
+    describe('constructor', () => {
+        it('nullTime', () => {
+            expect(() => {
+                new OffsetTime(null, OFFSET_PONE);
+            }).to.throw(NullPointerException);
+        });
+
+        it('nullOffset', () => {
+            expect(() => {
+                new OffsetTime(LocalTime.of(11, 30), null);
+            }).to.throw(NullPointerException);
+        });
+    });
+
+    describe('basic', () => {
+
+        it('get', () => {
+            dataProviderTest(sampleTimes, (h, m, s, n, offset) => {
+                const localTime = LocalTime.of(h, m, s, n);
+                const a = OffsetTime.of(localTime, offset);
+
+                assertEquals(a.toLocalTime(), localTime);
+                assertEquals(a.offset(), offset);
+                assertEquals(a.toString(), localTime.toString() + offset.toString());
+                assertEquals(a.hour(), localTime.hour());
+                assertEquals(a.minute(), localTime.minute());
+                assertEquals(a.second(), localTime.second());
+                assertEquals(a.nano(), localTime.nano());
+            });
+        });
+    });
+
+    describe('get(TemporalField)', () => {
+        it('get(temporalField)', () => {
+            const test = OffsetTime.of(LocalTime.of(12, 30, 40, 987654321), OFFSET_PONE);
+            assertEquals(test.get(ChronoField.HOUR_OF_DAY), 12);
+            assertEquals(test.get(ChronoField.MINUTE_OF_HOUR), 30);
+            assertEquals(test.get(ChronoField.SECOND_OF_MINUTE), 40);
+            assertEquals(test.get(ChronoField.NANO_OF_SECOND), 987654321);
+            assertEquals(test.get(ChronoField.HOUR_OF_AMPM), 0);
+            assertEquals(test.get(ChronoField.AMPM_OF_DAY), 1);
+
+            assertEquals(test.get(ChronoField.OFFSET_SECONDS), 3600);
+        });
+
+        it('getLong(temporalField)', () => {
+            const test = OffsetTime.of(LocalTime.of(12, 30, 40, 987654321), OFFSET_PONE);
+            assertEquals(test.getLong(ChronoField.HOUR_OF_DAY), 12);
+            assertEquals(test.getLong(ChronoField.MINUTE_OF_HOUR), 30);
+            assertEquals(test.getLong(ChronoField.SECOND_OF_MINUTE), 40);
+            assertEquals(test.getLong(ChronoField.NANO_OF_SECOND), 987654321);
+            assertEquals(test.getLong(ChronoField.HOUR_OF_AMPM), 0);
+            assertEquals(test.getLong(ChronoField.AMPM_OF_DAY), 1);
+
+            assertEquals(test.getLong(ChronoField.OFFSET_SECONDS), 3600);
+        });
+    });
+
+    describe('query(TemporalQuery)', () => {
+        it('query', () => {
+            assertEquals(TEST_11_30_59_500_PONE.query(TemporalQueries.chronology()), null);
+            assertEquals(TEST_11_30_59_500_PONE.query(TemporalQueries.localDate()), null);
+            assertEquals(TEST_11_30_59_500_PONE.query(TemporalQueries.localTime()), TEST_11_30_59_500_PONE.toLocalTime());
+            assertEquals(TEST_11_30_59_500_PONE.query(TemporalQueries.offset()), TEST_11_30_59_500_PONE.offset());
+            assertEquals(TEST_11_30_59_500_PONE.query(TemporalQueries.precision()), ChronoUnit.NANOS);
+            assertEquals(TEST_11_30_59_500_PONE.query(TemporalQueries.zone()), TEST_11_30_59_500_PONE.offset());
+            assertEquals(TEST_11_30_59_500_PONE.query(TemporalQueries.zoneId()), null);
+        });
+
+        it('query_null', () => {
+            expect(() => {
+                TEST_11_30_59_500_PONE.query(null);
+            }).to.throw(NullPointerException);
+        });
+    });
+
+    describe('withOffsetSameLocal', () => {
+        it('withOffsetSaeLocal', () => {
+            const base = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.withOffsetSameLocal(OFFSET_PTWO);
+            assertEquals(test.toLocalTime(), base.toLocalTime());
+            assertEquals(test.offset(), OFFSET_PTWO);
+        });
+
+        it('noChange', () => {
+            const base = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.withOffsetSameLocal(OFFSET_PONE);
+            assertEquals(test, base);
+        });
+
+        it('null', () => {
+            expect(() => {
+                const base = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
+                base.withOffsetSameLocal(null);
+            }).to.throw(NullPointerException);
+        });
+    });
+
+    describe('withOffsetSameInstant', () => {
+        it('withOffsetSameInstant', () => {
+            const base = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.withOffsetSameInstant(OFFSET_PTWO);
+            const expected = OffsetTime.of(LocalTime.of(12, 30, 59), OFFSET_PTWO);
+            assertEquals(test, expected);
+        });
+
+        it('noChange', () =>  {
+            const base = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.withOffsetSameInstant(OFFSET_PONE);
+            assertEquals(test, base);
+        });
+
+        it('null', () => {
+            expect(() => {
+                const base = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
+                base.withOffsetSameInstant(null);
+            }).to.throw(NullPointerException);
+        });
+    });
+
+    describe('with(WithAdjuster)', () => {
+        it('adjustment', () => {
+            const sample = OffsetTime.of(LocalTime.of(23, 5), OFFSET_PONE);
+            const adjuster = new TemporalAdjuster();
+            adjuster.adjustInto = () => sample;
+            assertEquals(TEST_11_30_59_500_PONE.with(adjuster), sample);
+        });
+
+        it('LocalTime', () => {
+            const test = TEST_11_30_59_500_PONE.with(LocalTime.of(13, 30));
+            assertNotNull(test);
+            assertEquals(test, OffsetTime.of(LocalTime.of(13, 30), OFFSET_PONE));
+        });
+
+        it('OffsetTime', () => {
+            const test = TEST_11_30_59_500_PONE.with(OffsetTime.of(LocalTime.of(13, 35), OFFSET_PTWO));
+            assertEquals(test, OffsetTime.of(LocalTime.of(13, 35), OFFSET_PTWO));
+        });
+
+        it('ZoneOffset', () => {
+            const test = TEST_11_30_59_500_PONE.with(OFFSET_PTWO);
+            assertNotNull(test);
+            assertEquals(test, OffsetTime.of(LocalTime.of(11, 30, 59, 500), OFFSET_PTWO));
+        });
+
+        it('AmPm', () => {
+            const adjuster = new TemporalAdjuster();
+            adjuster.adjustInto = (dateTime) => dateTime.with(ChronoField.HOUR_OF_DAY, 23);
+            const test = TEST_11_30_59_500_PONE.with(adjuster);
+            assertEquals(test, OffsetTime.of(LocalTime.of(23, 30, 59, 500), OFFSET_PONE));
+        });
+
+        it('null', () => {
+            expect(() => {
+                TEST_11_30_59_500_PONE.with(null);
+            }).to.throw(NullPointerException);
+        });
+    });
+
+    describe('with(TemporalField, long', () => {
+        it('TemporalField', () => {
+            const test = OffsetTime.of(LocalTime.of(12, 30, 40, 987654321), OFFSET_PONE);
+            assertEquals(test.with(ChronoField.HOUR_OF_DAY, 15), OffsetTime.of(LocalTime.of(15, 30, 40, 987654321), OFFSET_PONE));
+            assertEquals(test.with(ChronoField.MINUTE_OF_HOUR, 50), OffsetTime.of(LocalTime.of(12, 50, 40, 987654321), OFFSET_PONE));
+            assertEquals(test.with(ChronoField.SECOND_OF_MINUTE, 50), OffsetTime.of(LocalTime.of(12, 30, 50, 987654321), OFFSET_PONE));
+            assertEquals(test.with(ChronoField.NANO_OF_SECOND, 12345), OffsetTime.of(LocalTime.of(12, 30, 40, 12345), OFFSET_PONE));
+            assertEquals(test.with(ChronoField.HOUR_OF_AMPM, 6), OffsetTime.of(LocalTime.of(18, 30, 40, 987654321), OFFSET_PONE));
+            assertEquals(test.with(ChronoField.AMPM_OF_DAY, 0), OffsetTime.of(LocalTime.of(0, 30, 40, 987654321), OFFSET_PONE));
+
+            assertEquals(test.with(ChronoField.OFFSET_SECONDS, 7205), OffsetTime.of(LocalTime.of(12, 30, 40, 987654321), ZoneOffset.ofHoursMinutesSeconds(2, 0, 5)));
+        });
+
+        it('null', () => {
+            expect(() => {
+                TEST_11_30_59_500_PONE.with( null, 0);
+            }).to.throw(NullPointerException);
+        });
+
+        it('invalidField', () => {
+            expect(() => {
+                TEST_11_30_59_500_PONE.with(ChronoField.YEAR, 0);
+            }).to.throw(DateTimeException);
+        });
+    });
+
+    describe('withHour', () => {
+        it('normal', () => {
+            const base = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.withHour(15);
+            assertEquals(test, OffsetTime.of(LocalTime.of(15, 30, 59), OFFSET_PONE));
+        });
+
+        it('noChange', () => {
+            const base = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.withHour(11);
+            assertEquals(test, base);
+        });
+    });
+    
+    describe('withMinute', () => {
+        it('normal', function () {
+            const base = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.withMinute(15);
+            assertEquals(test, OffsetTime.of(LocalTime.of(11, 15, 59), OFFSET_PONE));
+        });
+
+        it('noChange', function () {
+            const base = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.withMinute(30);
+            assertEquals(test, base);
+        });
+    });
+
+    describe('withSecond', () => {
+        it('normal', () => {
+            const base = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.withSecond(15);
+            assertEquals(test, OffsetTime.of(LocalTime.of(11, 30, 15), OFFSET_PONE));
+        });
+
+        it('noChange', () => {
+            const base = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.withSecond(59);
+            assertEquals(test, base);
+        });
+    });
+
+    describe('withNano', () => {
+        it('normal', () => {
+            const base = OffsetTime.of(LocalTime.of(11, 30, 59, 1), OFFSET_PONE);
+            const test = base.withNano(15);
+            assertEquals(test, OffsetTime.of(LocalTime.of(11, 30, 59, 15), OFFSET_PONE));
+        });
+
+        it('noChange', () => {
+            const base = OffsetTime.of(LocalTime.of(11, 30, 59, 1), OFFSET_PONE);
+            const test = base.withNano(1);
+            assertEquals(test, base);
+        });
+    });
+
+    describe('trauncatedTo(TemporalUnit)', () => {
+        it('normal', () => {
+            assertEquals(TEST_11_30_59_500_PONE.truncatedTo(ChronoUnit.NANOS), TEST_11_30_59_500_PONE);
+            assertEquals(TEST_11_30_59_500_PONE.truncatedTo(ChronoUnit.SECONDS), TEST_11_30_59_500_PONE.withNano(0));
+            assertEquals(TEST_11_30_59_500_PONE.truncatedTo(ChronoUnit.DAYS), TEST_11_30_59_500_PONE.with(LocalTime.MIDNIGHT));
+        });
+
+        it('null', () => {
+            expect(() => {
+                TEST_11_30_59_500_PONE.truncatedTo(null);
+            }).to.throw(NullPointerException);
+        });
+    });
+
+    describe('plus(PlustAdjuster)', () => {
+        it('normal', () => {
+            const period = MockSimplePeriod.of(7, ChronoUnit.MINUTES);
+            const t = TEST_11_30_59_500_PONE.plus(period);
+            assertEquals(t, OffsetTime.of(LocalTime.of(11, 37, 59, 500), OFFSET_PONE));
+        });
+
+        it('noChange', () => {
+            const t = TEST_11_30_59_500_PONE.plus(MockSimplePeriod.of(0, ChronoUnit.SECONDS));
+            assertEquals(t, TEST_11_30_59_500_PONE);
+        });
+
+        it('zero', () => {
+            const t = TEST_11_30_59_500_PONE.plus(Period.ZERO);
+            assertEquals(t, TEST_11_30_59_500_PONE);
+        });
+
+        it('null', () => {
+            expect(() => {
+                TEST_11_30_59_500_PONE.plus(null);
+            }).to.throw(NullPointerException);
+        });
+    });
+
+    describe('plusHours', () => {
+        it('normal', () => {
+            const base = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.plusHours(13);
+            assertEquals(test, OffsetTime.of(LocalTime.of(0, 30, 59), OFFSET_PONE));
+        });
+
+        it('zero', () => {
+            const base = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.plusHours(0);
+            assertEquals(test, base);
+        });
+    });
+
+    describe('plusMinutes', () => {
+        it('normal', () => {
+            const base = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.plusMinutes(30);
+            assertEquals(test, OffsetTime.of(LocalTime.of(12, 0, 59), OFFSET_PONE));
+        });
+
+        it('zero', () => {
+            const base = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.plusMinutes(0);
+            assertEquals(test, base);
+        });
+    });
+
+    describe('plusSeconds', () => {
+        it('normal', () => {
+            const base = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.plusSeconds(1);
+            assertEquals(test, OffsetTime.of(LocalTime.of(11, 31, 0), OFFSET_PONE));
+        });
+
+        it('zero', () => {
+            const base = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.plusSeconds(0);
+            assertEquals(test, base);
+        });
+    });
+
+    describe('plusNanos', () => {
+        it('normal', () => {
+            const base = OffsetTime.of(LocalTime.of(11, 30, 59, 0), OFFSET_PONE);
+            const test = base.plusNanos(1);
+            assertEquals(test, OffsetTime.of(LocalTime.of(11, 30, 59, 1), OFFSET_PONE));
+        });
+
+        it('zero', () => {
+            const base = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.plusNanos(0);
+            assertEquals(test, base);
+        });
+    });
+
+    describe('minus(MinusAdjuster)', () => {
+        it('normal', () => {
+            const period = MockSimplePeriod.of(7, ChronoUnit.MINUTES);
+            const t = TEST_11_30_59_500_PONE.minus(period);
+            assertEquals(t, OffsetTime.of(LocalTime.of(11, 23, 59, 500), OFFSET_PONE));
+        });
+
+        it('noChange', () => {
+            const t = TEST_11_30_59_500_PONE.minus(MockSimplePeriod.of(0, ChronoUnit.SECONDS));
+            assertEquals(t, TEST_11_30_59_500_PONE);
+        });
+
+        it('zero', () => {
+            const t = TEST_11_30_59_500_PONE.minus(Period.ZERO);
+            assertEquals(t, TEST_11_30_59_500_PONE);
+        });
+
+        it('null', () => {
+            expect(() => {
+                TEST_11_30_59_500_PONE.minus(null);
+            }).to.throw(NullPointerException);
+        });
+    });
+
+    describe('minunsHours', () => {
+        it('normal', () => {
+            const base = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.minusHours(-13);
+            assertEquals(test, OffsetTime.of(LocalTime.of(0, 30, 59), OFFSET_PONE));
+        });
+
+        it('zero', () => {
+            const base = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.minusHours(0);
+            assertEquals(test, base);
+        });
+    });
+
+    describe('minusMinutes', () => {
+        it('normal', () => {
+            const base = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.minusMinutes(50);
+            assertEquals(test, OffsetTime.of(LocalTime.of(10, 40, 59), OFFSET_PONE));
+        });
+
+        it('zero', () => {
+            const base = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.minusMinutes(0);
+            assertEquals(test, base);
+        });
+    });
+
+    describe('minusSeconds', () => {
+        it('normal', () => {
+            const base = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.minusSeconds(60);
+            assertEquals(test, OffsetTime.of(LocalTime.of(11, 29, 59), OFFSET_PONE));
+        });
+
+        it('zero', () => {
+            const base = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.minusSeconds(0);
+            assertEquals(test, base);
+        });
+    });
+
+    describe('minusNanos', () => {
+        it('normal', () => {
+            const base = OffsetTime.of(LocalTime.of(11, 30, 59, 0), OFFSET_PONE);
+            const test = base.minusNanos(1);
+            assertEquals(test, OffsetTime.of(LocalTime.of(11, 30, 58, 999999999), OFFSET_PONE));
+        });
+
+        it('zero', () => {
+            const base = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
+            const test = base.minusNanos(0);
+            assertEquals(test, base);
+        });
+    });
+
+    describe('compareTo', () => {
+        it('time', () => {
+            const a = OffsetTime.of(LocalTime.of(11, 29), OFFSET_PONE);
+            const b = OffsetTime.of(LocalTime.of(11, 30), OFFSET_PONE);  // a is before b due to time
+            assertEquals(a.compareTo(b) < 0, true);
+            assertEquals(b.compareTo(a) > 0, true);
+            assertEquals(a.compareTo(a) === 0, true);
+            assertEquals(b.compareTo(b) === 0, true);
+            assertEquals(convertInstant(a).compareTo(convertInstant(b)) < 0, true);
+        });
+
+        it('offset', () => {
+            const a = OffsetTime.of(LocalTime.of(11, 30), OFFSET_PTWO);
+            const b = OffsetTime.of(LocalTime.of(11, 30), OFFSET_PONE);  // a is before b due to offset
+            expect(a.compareTo(b)).to.be.lessThan(0);
+            expect(b.compareTo(a)).to.be.greaterThan(0);
+            assertEquals(a.compareTo(b) < 0, true);
+            assertEquals(b.compareTo(a) > 0, true);
+            assertEquals(a.compareTo(a) === 0, true);
+            assertEquals(b.compareTo(b) === 0, true);
+            assertEquals(convertInstant(a).compareTo(convertInstant(b)) < 0, true);
+        });
+
+        it('both', () => {
+            const a = OffsetTime.of(LocalTime.of(11, 50), OFFSET_PTWO);
+            const b = OffsetTime.of(LocalTime.of(11, 20), OFFSET_PONE);  // a is before b on instant scale
+            assertEquals(a.compareTo(b) < 0, true);
+            assertEquals(b.compareTo(a) > 0, true);
+            assertEquals(a.compareTo(a) === 0, true);
+            assertEquals(b.compareTo(b) === 0, true);
+            assertEquals(convertInstant(a).compareTo(convertInstant(b)) < 0, true);
+        });
+
+        it('bothNearStartOfDay', () => {
+            const a = OffsetTime.of(LocalTime.of(0, 10), OFFSET_PONE);
+            const b = OffsetTime.of(LocalTime.of(2, 30), OFFSET_PTWO);  // a is before b on instant scale
+            assertEquals(a.compareTo(b) < 0, true);
+            assertEquals(b.compareTo(a) > 0, true);
+            assertEquals(a.compareTo(a) === 0, true);
+            assertEquals(b.compareTo(b) === 0, true);
+            assertEquals(convertInstant(a).compareTo(convertInstant(b)) < 0, true);
+        });
+
+        it('hourDifference', () => {
+            const a = OffsetTime.of(LocalTime.of(10, 0), OFFSET_PONE);
+            const b = OffsetTime.of(LocalTime.of(11, 0), OFFSET_PTWO);  // a is before b despite being same time-line time
+            assertEquals(a.compareTo(b) < 0, true);
+            assertEquals(b.compareTo(a) > 0, true);
+            assertEquals(a.compareTo(a) === 0, true);
+            assertEquals(b.compareTo(b) === 0, true);
+            assertEquals(convertInstant(a).compareTo(convertInstant(b)) === 0, true);
+        });
+
+        it('null', () => {
+            expect(() => {
+                const a = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
+                a.compareTo(null);
+            }).to.throw(NullPointerException);
+        });
+
+        it('nonOffsetTime', () => {
+            expect(() => {
+                const c = TEST_11_30_59_500_PONE;
+                c.compareTo(new Object());
+            }).to.throw(IllegalArgumentException); // ClassCastException
+        });
+
+        function convertInstant(ot) {
+            return DATE.atTime(ot.toLocalTime()).toInstant(ot.offset());
+        }
+    });
+
+    describe('isAfter/isBefore/isEqual', () => {
+        it('isBeforeIsAfterIsEqual1', () => {
+            const a = OffsetTime.of(LocalTime.of(11, 30, 58), OFFSET_PONE);
+            const b = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);  // a is before b due to time
+            assertEquals(a.isBefore(b), true);
+            assertEquals(a.isEqual(b), false);
+            assertEquals(a.isAfter(b), false);
+
+            assertEquals(b.isBefore(a), false);
+            assertEquals(b.isEqual(a), false);
+            assertEquals(b.isAfter(a), true);
+
+            assertEquals(a.isBefore(a), false);
+            assertEquals(b.isBefore(b), false);
+
+            assertEquals(a.isEqual(a), true);
+            assertEquals(b.isEqual(b), true);
+
+            assertEquals(a.isAfter(a), false);
+            assertEquals(b.isAfter(b), false);
+        });
+
+        it('isBeforeIsAfterIsEqual1nanos', () => {
+            const a = OffsetTime.of(LocalTime.of(11, 30, 59, 3), OFFSET_PONE);
+            const b = OffsetTime.of(LocalTime.of(11, 30, 59, 4), OFFSET_PONE);  // a is before b due to time
+            assertEquals(a.isBefore(b), true);
+            assertEquals(a.isEqual(b), false);
+            assertEquals(a.isAfter(b), false);
+
+            assertEquals(b.isBefore(a), false);
+            assertEquals(b.isEqual(a), false);
+            assertEquals(b.isAfter(a), true);
+
+            assertEquals(a.isBefore(a), false);
+            assertEquals(b.isBefore(b), false);
+
+            assertEquals(a.isEqual(a), true);
+            assertEquals(b.isEqual(b), true);
+
+            assertEquals(a.isAfter(a), false);
+            assertEquals(b.isAfter(b), false);
+        });
+
+        it('isBeforeIsAfterIsEqual2', () => {
+            const a = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PTWO);
+            const b = OffsetTime.of(LocalTime.of(11, 30, 58), OFFSET_PONE);  // a is before b due to offset
+            assertEquals(a.isBefore(b), true);
+            assertEquals(a.isEqual(b), false);
+            assertEquals(a.isAfter(b), false);
+
+            assertEquals(b.isBefore(a), false);
+            assertEquals(b.isEqual(a), false);
+            assertEquals(b.isAfter(a), true);
+
+            assertEquals(a.isBefore(a), false);
+            assertEquals(b.isBefore(b), false);
+
+            assertEquals(a.isEqual(a), true);
+            assertEquals(b.isEqual(b), true);
+
+            assertEquals(a.isAfter(a), false);
+            assertEquals(b.isAfter(b), false);
+        });
+
+        it('isBeforeIsAfterIsEqual2nanos', () => {
+            const a = OffsetTime.of(LocalTime.of(11, 30, 59, 4), ZoneOffset.ofTotalSeconds(OFFSET_PONE.totalSeconds() + 1));
+            const b = OffsetTime.of(LocalTime.of(11, 30, 59, 3), OFFSET_PONE);  // a is before b due to offset
+            assertEquals(a.isBefore(b), true);
+            assertEquals(a.isEqual(b), false);
+            assertEquals(a.isAfter(b), false);
+
+            assertEquals(b.isBefore(a), false);
+            assertEquals(b.isEqual(a), false);
+            assertEquals(b.isAfter(a), true);
+
+            assertEquals(a.isBefore(a), false);
+            assertEquals(b.isBefore(b), false);
+
+            assertEquals(a.isEqual(a), true);
+            assertEquals(b.isEqual(b), true);
+
+            assertEquals(a.isAfter(a), false);
+            assertEquals(b.isAfter(b), false);
+        });
+
+        it('instantComparison', () => {
+            const a = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PTWO);
+            const b = OffsetTime.of(LocalTime.of(10, 30, 59), OFFSET_PONE);  // a is same instant as b
+            assertEquals(a.isBefore(b), false);
+            assertEquals(a.isEqual(b), true);
+            assertEquals(a.isAfter(b), false);
+
+            assertEquals(b.isBefore(a), false);
+            assertEquals(b.isEqual(a), true);
+            assertEquals(b.isAfter(a), false);
+
+            assertEquals(a.isBefore(a), false);
+            assertEquals(b.isBefore(b), false);
+
+            assertEquals(a.isEqual(a), true);
+            assertEquals(b.isEqual(b), true);
+
+            assertEquals(a.isAfter(a), false);
+            assertEquals(b.isAfter(b), false);
+        });
+
+        it('isBefore_null', () => {
+            expect(() => {
+                const a = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
+                a.isBefore(null);
+            }).to.throw(NullPointerException);
+        });
+
+        it('isAfter_null', () => {
+            expect(() => {
+                const a = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
+                a.isAfter(null);
+            }).to.throw(NullPointerException);
+        });
+
+        it('isEqual_null', () => {
+            expect(() => {
+                const a = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
+                a.isEqual(null);
+            }).to.throw(NullPointerException);
+        });
+    });
+
+    describe('equals/hashCode', () => {
+        it('equals_true', () => {
+            dataProviderTest(sampleTimes, (h, m, s, n) => {
+                const a = OffsetTime.of(LocalTime.of(h, m, s, n), OFFSET_PONE);
+                const b = OffsetTime.of(LocalTime.of(h, m, s, n), OFFSET_PONE);
+                assertEquals(a.equals(b), true);
+                assertEquals(a.hashCode() === b.hashCode(), true);
+            });
+        });
+
+        it('equals_false_hour_differs', () => {
+            dataProviderTest(sampleTimes, (h, m, s, n) => {
+                h = (h === 23 ? 22 : h);
+                const a = OffsetTime.of(LocalTime.of(h, m, s, n), OFFSET_PONE);
+                const b = OffsetTime.of(LocalTime.of(h + 1, m, s, n), OFFSET_PONE);
+                assertEquals(a.equals(b), false);
+            });
+        });
+
+        it('equals_false_minute_differs', () => {
+            dataProviderTest(sampleTimes, (h, m, s, n) => {
+                m = (m === 59 ? 58 : m);
+                const a = OffsetTime.of(LocalTime.of(h, m, s, n), OFFSET_PONE);
+                const b = OffsetTime.of(LocalTime.of(h, m + 1, s, n), OFFSET_PONE);
+                assertEquals(a.equals(b), false);
+            });
+        });
+
+        it('equals_false_second_differs', () => {
+            dataProviderTest(sampleTimes, (h, m, s, n) => {
+                s = (s === 59 ? 58 : s);
+                const a = OffsetTime.of(LocalTime.of(h, m, s, n), OFFSET_PONE);
+                const b = OffsetTime.of(LocalTime.of(h, m, s + 1, n), OFFSET_PONE);
+                assertEquals(a.equals(b), false);
+            });
+        });
+
+        it('equals_false_nano_differs', () => {
+            dataProviderTest(sampleTimes, (h, m, s, n) => {
+                n = (n === 999999999 ? 999999998 : n);
+                const a = OffsetTime.of(LocalTime.of(h, m, s, n), OFFSET_PONE);
+                const b = OffsetTime.of(LocalTime.of(h, m, s, n + 1), OFFSET_PONE);
+                assertEquals(a.equals(b), false);
+            });
+        });
+
+        it('equals_false_offset_differs', () => {
+            dataProviderTest(sampleTimes, (h, m, s, n) => {
+                const a = OffsetTime.of(LocalTime.of(h, m, s, n), OFFSET_PONE);
+                const b = OffsetTime.of(LocalTime.of(h, m, s, n), OFFSET_PTWO);
+                assertEquals(a.equals(b), false);
+            });
+        });
+
+        it('itself_true', () => {
+            assertEquals(TEST_11_30_59_500_PONE.equals(TEST_11_30_59_500_PONE), true);
+        });
+
+        it('string_false', () => {
+            assertEquals(TEST_11_30_59_500_PONE.equals('2007-07-15'), false);
+        });
+
+        it('null_fa;se', () => {
+            assertEquals(TEST_11_30_59_500_PONE.equals(null), false);
+        });
+    });
+
+    describe('toString', () => {
+        it('toString', () => {
+            dataProviderTest(sampleToString, (h, m, s, n, offsetId, expected) => {
+                const t = OffsetTime.of(LocalTime.of(h, m, s, n), ZoneOffset.of(offsetId));
+                const str = t.toString();
+                assertEquals(str, expected);
+            });
+        });
+    });
+
+    describe('format(DateTimeFormatter)', () => {
+        it('normal', () => {
+            const f = DateTimeFormatter.ofPattern('H m s');
+            const t = OffsetTime.of(LocalTime.of(11, 30), OFFSET_PONE).format(f);
+            assertEquals(t, '11 30 0');
+        });
+
+        it('null', () => {
+            expect(() => {
+                OffsetTime.of(LocalTime.of(11, 30), OFFSET_PONE).format(null);
+            }).to.throw(NullPointerException);
+        });
+    });
+});

--- a/packages/core/test/reference/ZoneOffsetTest.js
+++ b/packages/core/test/reference/ZoneOffsetTest.js
@@ -15,6 +15,7 @@ import {Duration} from '../../src/Duration';
 import {LocalTime} from '../../src/LocalTime';
 import {LocalDate} from '../../src/LocalDate';
 import {LocalDateTime} from '../../src/LocalDateTime';
+import {OffsetTime} from '../../src/OffsetTime';
 import {ZonedDateTime} from '../../src/ZonedDateTime';
 import {ZoneOffset} from '../../src/ZoneOffset';
 
@@ -366,7 +367,7 @@ describe('org.threeten.bp.TestZoneOffset', () => {
     describe('from(TemporalAccessor)', () => {
 
         it('test_factory_TemporalAccessor', () => {
-            // assertEquals(ZoneOffset.from(OffsetTime.of(LocalTime.of(12, 30), ZoneOffset.ofHours(6))), ZoneOffset.ofHours(6));
+            assertEquals(ZoneOffset.from(OffsetTime.of(LocalTime.of(12, 30), ZoneOffset.ofHours(6))), ZoneOffset.ofHours(6));
             assertEquals(ZoneOffset.from(ZonedDateTime.of(LocalDateTime.of(LocalDate.of(2007, 7, 15),
                 LocalTime.of(17, 30)), ZoneOffset.ofHours(2))), ZoneOffset.ofHours(2));
         });

--- a/packages/core/test/zone/CurrentStandardZone.js
+++ b/packages/core/test/zone/CurrentStandardZone.js
@@ -282,3 +282,28 @@ export class CurrentStandardZoneAsiaGaza extends CurrentStandardZone{
 
 }
 
+
+export class CurrentStandardZoneEuropeParis extends CurrentStandardZone{
+    constructor(){
+        super(
+            'Pseudo/Europe/Paris',
+            ZoneOffset.ofHours(1),
+            ZoneOffset.ofHours(2),
+            (year) => {
+                return this.lastSundayOfMonthAtStartOfDay(year, Month.MARCH).plusHours(2);
+            },
+            (year) => {
+                return this.lastSundayOfMonthAtStartOfDay(year, Month.OCTOBER).plusHours(3);
+            }
+        );
+    }
+
+    lastSundayOfMonthAtStartOfDay(year, month){
+        return LocalDate
+            .of(year, 1, 1)
+            .withMonth(month)
+            .with(TemporalAdjusters.lastInMonth(DayOfWeek.SUNDAY))
+            .atStartOfDay();
+    }
+
+}


### PR DESCRIPTION
Closes #240

Thanks for creating this repository.
Recently, I have an increased need for `OffsetTime` and `OffsetDateTime`, so I am trying to add them.

I used the below source files as reference implementation.

* src
  * https://github.com/ThreeTen/threetenbp/blob/800401d216666575853412a459f8e8a83af95709/src/main/java/org/threeten/bp/OffsetDateTime.java
  * https://github.com/ThreeTen/threetenbp/blob/800401d216666575853412a459f8e8a83af95709/src/main/java/org/threeten/bp/OffsetTime.java
* test
  * https://github.com/ThreeTen/threetenbp/blob/800401d216666575853412a459f8e8a83af95709/src/test/java/org/threeten/bp/TestOffsetDateTime.java
  * https://github.com/ThreeTen/threetenbp/blob/800401d216666575853412a459f8e8a83af95709/src/test/java/org/threeten/bp/TestOffsetTime.java

IIUC, their license (BSD-3) is compatible with this repository. 

Please be aware that some extensive test cases are really slow, so I added `this.timeout(50000);` to extend timeout.


