### PR TITLE
Duration#(minus|plust) should accept TemporalUnit, not just ChronoUnit

### DIFF
--- a/packages/core/dist/js-joda.d.ts
+++ b/packages/core/dist/js-joda.d.ts
@@ -118,7 +118,7 @@ export class Duration extends TemporalAmount {
     isNegative(): boolean;
     isZero(): boolean;
     minus(duration: Duration): Duration;
-    minus(amount: number, unit: ChronoUnit): Duration;
+    minus(amount: number, unit: TemporalUnit): Duration;
     // TODO: Internal. Remove in next major version.
     minusAmountUnit(amountToSubtract: number, unit: TemporalUnit): Duration;
     minusDays(daysToSubtract: number): Duration;
@@ -133,7 +133,7 @@ export class Duration extends TemporalAmount {
     nano(): number;
     negated(): Duration;
     plus(duration: Duration): Duration;
-    plus(amount: number, unit: ChronoUnit): Duration;
+    plus(amount: number, unit: TemporalUnit): Duration;
     // TODO: Internal. Remove in next major version.
     plusAmountUnit(amountToAdd: number, unit: TemporalUnit): Duration;
     plusDays(daysToAdd: number): Duration;

--- a/packages/core/src/Duration.js
+++ b/packages/core/src/Duration.js
@@ -720,7 +720,7 @@ export class Duration extends TemporalAmount /*implements TemporalAmount, Compar
      * Otherwise {@link Duration.minusAmountUnit} is executed.
      *
      * @param {!(Duration|number)} durationOrNumber
-     * @param {?ChronoUnit} unit
+     * @param {?TemporalUnit} unit
      * @return {Duration}
      */
     minus(durationOrNumber, unit) {


### PR DESCRIPTION
According to ThreeTen reference implementation and OracleJDK Javadoc, `Duration#minus` and `Duration#plus` should accept `TemporalUnit`, which is a super type of `ChronoUnit`.

https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html#plus-long-java.time.temporal.TemporalUnit-
https://github.com/ThreeTen/threetenbp/blob/800401d216666575853412a459f8e8a83af95709/src/main/java/org/threeten/bp/Duration.java#L635

https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html#minus-long-java.time.temporal.TemporalUnit-
https://github.com/ThreeTen/threetenbp/blob/800401d216666575853412a459f8e8a83af95709/src/main/java/org/threeten/bp/Duration.java#L793