### PR TITLE
Methods .equals are now type predicates in TypeScript

### DIFF
--- a/packages/core/dist/js-joda.d.ts
+++ b/packages/core/dist/js-joda.d.ts
@@ -1093,7 +1093,7 @@ export class Duration extends TemporalAmount {
     addTo<T extends Temporal>(temporal: T): T;
     compareTo(otherDuration: Duration): number;
     dividedBy(divisor: number): Duration;
-    equals(other: any): boolean;
+    equals(other: any): other is Duration;
     get(unit: TemporalUnit): number;
     isNegative(): boolean;
     isZero(): boolean;
@@ -1153,7 +1153,7 @@ export class Instant extends Temporal implements TemporalAdjuster {
     atZone(zone: ZoneId): ZonedDateTime;
     compareTo(otherInstant: Instant): number;
     epochSecond(): number;
-    equals(other: any): boolean;
+    equals(other: any): other is Instant;
     getLong(field: TemporalField): number;
     hashCode(): number;
     isAfter(otherInstant: Instant): boolean;
@@ -1206,7 +1206,7 @@ export class LocalDate extends ChronoLocalDate implements TemporalAdjuster {
     dayOfMonth(): number;
     dayOfWeek(): DayOfWeek;
     dayOfYear(): number;
-    equals(other: any): boolean;
+    equals(other: any): other is LocalDate;
     getLong(field: TemporalField): number;
     hashCode(): number;
     isAfter(other: LocalDate): boolean;
@@ -1269,7 +1269,7 @@ export class LocalDateTime extends ChronoLocalDateTime implements TemporalAdjust
     dayOfMonth(): number;
     dayOfWeek(): DayOfWeek;
     dayOfYear(): number;
-    equals(other: any): boolean;
+    equals(other: any): other is LocalDateTime;
     format(formatter: DateTimeFormatter): string;
     getLong(field: TemporalField): number;
     hashCode(): number;
@@ -1356,7 +1356,7 @@ export class LocalTime extends Temporal implements TemporalAdjuster {
     atDate(date: LocalDate): LocalDateTime;
     atOffset(offset: ZoneOffset): OffsetTime;
     compareTo(other: LocalTime): number;
-    equals(other: any): boolean;
+    equals(other: any): other is LocalTime;
     format(formatter: DateTimeFormatter): string;
     getLong(field: ChronoField): number;
     hashCode(): number;
@@ -1408,7 +1408,7 @@ export class MonthDay extends TemporalAccessor implements TemporalAdjuster {
     atYear(year: number): LocalDate;
     compareTo(other: MonthDay): number;
     dayOfMonth(): number;
-    equals(other: any): boolean;
+    equals(other: any): other is MonthDay;
     format(formatter: DateTimeFormatter): string;
     getLong(field: TemporalField): number;
     isAfter(other: MonthDay): boolean;
@@ -1441,7 +1441,7 @@ export class Period extends TemporalAmount {
     addTo<T extends Temporal>(temporal: T): T;
     chronology(): IsoChronology;
     days(): number;
-    equals(other: any): boolean;
+    equals(other: any): other is Period;
     get(unit: TemporalUnit): number;
     hashCode(): number;
     isNegative(): boolean;
@@ -1488,7 +1488,7 @@ export class Year extends Temporal implements TemporalAdjuster {
     atMonth(month: Month | number): YearMonth;
     atMonthDay(monthDay: MonthDay): LocalDate;
     compareTo(other: Year): number;
-    equals(other: any): boolean;
+    equals(other: any): other is Year;
     getLong(field: TemporalField): number;
     isAfter(other: Year): boolean;
     isBefore(other: Year): boolean;
@@ -1524,7 +1524,7 @@ export class YearMonth extends Temporal implements TemporalAdjuster {
     atDay(dayOfMonth: number): LocalDate;
     atEndOfMonth(): LocalDate;
     compareTo(other: YearMonth): number;
-    equals(other: any): boolean;
+    equals(other: any): other is YearMonth;
     format(formatter: DateTimeFormatter): string;
     getLong(field: TemporalField): number;
     isAfter(other: YearMonth): boolean;
@@ -1597,7 +1597,7 @@ export class OffsetDateTime extends Temporal implements TemporalAdjuster {
     dayOfMonth(): number;
     dayOfWeek(): DayOfWeek;
     dayOfYear(): number;
-    equals(obj: any): boolean;
+    equals(other: any): other is OffsetDateTime;
     format(formatter: DateTimeFormatter): string;
     getLong(field: TemporalField): number;
     hashCode(): number;
@@ -1686,7 +1686,7 @@ export class OffsetTime extends Temporal implements TemporalAdjuster {
     adjustInto(temporal: Temporal): Temporal;
     atDate(date: LocalDate): OffsetDateTime;
     compareTo(other: OffsetTime): number;
-    equals(other: any): boolean;
+    equals(other: any): other is OffsetTime;
     format(formatter: DateTimeFormatter): string;
     getLong(field: TemporalField): number;
     hashCode(): number;
@@ -1834,6 +1834,7 @@ export class ZonedDateTime extends ChronoZonedDateTime {
     dayOfMonth(): number;
     dayOfWeek(): DayOfWeek;
     dayOfYear(): number;
+    equals(other: any): other is ZonedDateTime;
     getLong(field: TemporalField): number;
     hashCode(): number;
     hour(): number;

--- a/packages/core/test/typescript_definitions/core-test.ts
+++ b/packages/core/test/typescript_definitions/core-test.ts
@@ -35,6 +35,7 @@ import {
     ValueRange,
     TextStyle,
     TemporalAccessor,
+    TemporalAmount,
 } from '../../'
 
 it('ZonedDateTime', () => {
@@ -93,6 +94,12 @@ it('ZonedDateTime', () => {
 
     expectType<string>(zdt.toString());
     expectType<string>(zdt.toJSON());
+
+    // .equals is a type predicate
+    const temp: Temporal = ZonedDateTime.parse(zdt.toString());
+    if (zdt.equals(temp)) {
+        expectType<ZonedDateTime>(temp);
+    }
 });
 
 it('OffsetDateTime', () => {
@@ -155,6 +162,12 @@ it('OffsetDateTime', () => {
 
     expectType<string>(odt.toString());
     expectType<string>(odt.toJSON());
+
+    // .equals is a type predicate
+    const temp: Temporal = OffsetDateTime.parse(odt.toString());
+    if (odt.equals(temp)) {
+        expectType<OffsetDateTime>(temp);
+    }
 });
 
 it('OffsetTime', () => {
@@ -245,6 +258,12 @@ it('OffsetTime', () => {
 
     expectType<OffsetTime | null>(t1.query(OffsetTime.FROM));
     expectType<LocalDate | null>(t1.query(TemporalQueries.localDate()));
+
+    // .equals is a type predicate
+    const temp: Temporal = OffsetTime.parse(ot.toString());
+    if (ot.equals(temp)) {
+        expectType<OffsetTime>(temp);
+    }
 });
 
 it('LocalDate', () => {
@@ -358,6 +377,12 @@ it('LocalDate', () => {
 
     expectType<LocalDateTime>(d1.atTime(LocalTime.now()));
     expectType<OffsetDateTime>(d1.atTime(OffsetTime.now()));
+
+    // .equals is a type predicate
+    const temp: Temporal = LocalDate.parse(d.toString());
+    if (d.equals(temp)) {
+        expectType<LocalDate>(temp);
+    }
 });
 
 it('LocalTime', () => {
@@ -456,6 +481,12 @@ it('LocalTime', () => {
 
     expectType<OffsetTime>(t.atOffset(ZoneOffset.MIN));
     expectType<LocalDateTime>(t.atDate(LocalDate.now()));
+
+    // .equals is a type predicate
+    const temp: Temporal = LocalTime.parse(t.toString());
+    if (t.equals(temp)) {
+        expectType<LocalTime>(temp);
+    }
 });
 
 it('LocalDateTime', () => {
@@ -607,6 +638,12 @@ it('LocalDateTime', () => {
 
     expectType<OffsetDateTime>(dt.atOffset(ZoneOffset.MIN));
     expectType<ZonedDateTime>(dt.atZone(ZoneId.UTC));
+
+    // .equals is a type predicate
+    const temp: Temporal = LocalDateTime.parse(dt.toString());
+    if (dt.equals(temp)) {
+        expectType<LocalDateTime>(temp);
+    }
 });
 
 it('Instant', () => {
@@ -632,6 +669,12 @@ it('Instant', () => {
 
     expectType<OffsetDateTime>(i.atOffset(ZoneOffset.MAX));
     expectType<ZonedDateTime>(i.atZone(ZoneId.UTC));
+
+    // .equals is a type predicate
+    const temp: Temporal = Instant.parse(i.toString());
+    if (i.equals(temp)) {
+        expectType<Instant>(temp);
+    }
 });
 
 it('Year', () => {
@@ -676,6 +719,12 @@ it('Year', () => {
 
     expectType<Year | null>(year.query(Year.FROM));
     expectType<LocalDate | null>(year.query(TemporalQueries.localDate()));
+
+    // .equals is a type predicate
+    const temp: Temporal = Year.parse(year.toString());
+    if (year.equals(temp)) {
+        expectType<Year>(temp);
+    }
 });
 
 it('YearMonth', () => {
@@ -739,6 +788,12 @@ it('YearMonth', () => {
 
     expectType<YearMonth | null>(ym.query(YearMonth.FROM));
     expectType<LocalDate | null>(ym.query(TemporalQueries.localDate()));
+
+    // .equals is a type predicate
+    const temp: Temporal = YearMonth.parse(ym.toString());
+    if (ym.equals(temp)) {
+        expectType<YearMonth>(temp);
+    }
 });
 
 it('DayOfWeek', () => {
@@ -784,6 +839,12 @@ it('MonthDay', () => {
 
     expectType<MonthDay | null>(md.query(MonthDay.FROM));
     expectType<LocalDate | null>(md.query(TemporalQueries.localDate()));
+
+    // .equals is a type predicate
+    const temp: TemporalAccessor = MonthDay.parse(md.toString());
+    if (md.equals(temp)) {
+        expectType<MonthDay>(temp);
+    }
 });
 
 it('Period', () => {
@@ -808,6 +869,12 @@ it('Period', () => {
     expectType<string>(p.toJSON());
 
     Period.between(LocalDate.parse('2012-06-30'), LocalDate.parse('2012-08-31'));
+
+    // .equals is a type predicate
+    const temp: TemporalAmount = Period.parse(p.toString());
+    if (p.equals(temp)) {
+        expectType<Period>(temp);
+    }
 });
 
 it('Duration', () => {
@@ -832,6 +899,12 @@ it('Duration', () => {
     expectType<Duration>(dur.minus(1, ChronoUnit.NANOS));
     expectType<Duration>(dur.plus(Duration.ofNanos(1)));
     expectType<Duration>(dur.plus(1, ChronoUnit.NANOS));
+
+    // .equals is a type predicate
+    const temp: TemporalAmount = Duration.parse(dur.toString());
+    if (dur.equals(temp)) {
+        expectType<Duration>(temp);
+    }
 });
 
 it('DateTimeFormatter', () => {


### PR DESCRIPTION
This PR makes most of the `.equals` methods [type predicates](https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards) in the TS declarations.

A type predicate is a function that returns `boolean` but the return type is marked with the syntax `parameter is Type` and allows the type system to narrow the type of `parameter` to `Type` in the _then_ branch. In our case it allows patterns like this:

```ts
function foo(temporal: Temporal) {
    const localDate = LocalDate.of(2020, 12, 31);

    // temporal is any Temporal object, but...

    if (localDate.equals(temporal)) {
        // ...if this branch is taken we know that temporal must be
        // of type LocalDate (.equals also checks the constructor) and now
        // the type system knows it as well.

        // I can call a method of LocalDate without complaining
        return temporal.atStartOfDay();
    } else {
        // Here should go some different logic. In this branch temporal is
        // still of type Temporal.
    }
}
```

I convert to type predicates only the `.equals` of the most common classes.