### PR TITLE
Remove edge case handling for minusUnit

### DIFF
--- a/packages/core/src/temporal/Temporal.js
+++ b/packages/core/src/temporal/Temporal.js
@@ -6,7 +6,6 @@
 
 import {assert, abstractMethodFail, requireInstance, requireNonNull} from '../assert';
 import {IllegalArgumentException} from '../errors';
-import {MAX_SAFE_INTEGER, MIN_SAFE_INTEGER} from '../MathUtil';
 import {TemporalAccessor} from './TemporalAccessor';
 import {TemporalAmount} from './TemporalAmount';
 import {TemporalUnit} from './TemporalUnit';

--- a/packages/core/src/temporal/Temporal.js
+++ b/packages/core/src/temporal/Temporal.js
@@ -156,9 +156,7 @@ export class Temporal extends TemporalAccessor {
         requireNonNull(amountToSubtract, 'amountToSubtract');
         requireNonNull(unit, 'unit');
         requireInstance(unit, TemporalUnit, 'unit');
-        return (amountToSubtract === MIN_SAFE_INTEGER
-            ? this._plusUnit(MAX_SAFE_INTEGER, unit)._plusUnit(1, unit)
-            : this._plusUnit(-amountToSubtract, unit));
+        return this._plusUnit(-amountToSubtract, unit);
     }
 
     /**

--- a/packages/core/test/temporal/TemporalTest.js
+++ b/packages/core/test/temporal/TemporalTest.js
@@ -8,6 +8,7 @@ import {Period} from '../../src/Period';
 import {ChronoField} from '../../src/temporal/ChronoField';
 import {TemporalField} from '../../src/temporal/TemporalField';
 import {UnsupportedTemporalTypeException} from '../../src/errors';
+import {MathUtil} from '../../src/MathUtil';
 
 // NOTE: This is an incomplete implementation!
 class BasicYearMock extends Temporal {
@@ -64,11 +65,11 @@ describe('js-joda Temporal', () => {
 
         it('should subtract MIN_SAFE_INTEGER of a given value', () => {
             const result = new BasicYearMock(0)
-                .minus(Number.MIN_SAFE_INTEGER, ChronoUnit.YEARS);
+                .minus(MathUtil.MIN_SAFE_INTEGER, ChronoUnit.YEARS);
 
-            console.log(result, new BasicYearMock(Number.MAX_SAFE_INTEGER));
+            console.log(result, new BasicYearMock(MathUtil.MAX_SAFE_INTEGER));
 
-            expect(new BasicYearMock(Number.MAX_SAFE_INTEGER).equals(result)).to.equal(true);
+            expect(new BasicYearMock(MathUtil.MAX_SAFE_INTEGER).equals(result)).to.equal(true);
         });
     });
 

--- a/packages/core/test/temporal/TemporalTest.js
+++ b/packages/core/test/temporal/TemporalTest.js
@@ -62,14 +62,14 @@ describe('js-joda Temporal', () => {
             expect(new BasicYearMock(8).equals(result)).to.equal(true);
         });
 
-        /*it('should subtract MIN_SAFE_INTEGER of a given value', () => {
+        it('should subtract MIN_SAFE_INTEGER of a given value', () => {
             const result = new BasicYearMock(0)
                 .minus(Number.MIN_SAFE_INTEGER, ChronoUnit.YEARS);
 
             console.log(result, new BasicYearMock(Number.MAX_SAFE_INTEGER));
 
             expect(new BasicYearMock(Number.MAX_SAFE_INTEGER).equals(result)).to.equal(true);
-        });*/
+        });
     });
 
     describe('plus', () => {


### PR DESCRIPTION
Handle this case as in all other temporal implementations.

Not sure why threeten is handling the edge case in such a strange way, but since js-joda is currently using the default implementation just for `Year` and `YearMonth`. let's ignore the edge case, makes no sense.