### PR TITLE
Fixes #546 by reverting .equals() being type predicates

### DIFF
--- a/packages/core/dist/js-joda.d.ts
+++ b/packages/core/dist/js-joda.d.ts
@@ -1103,7 +1103,7 @@ export class Duration extends TemporalAmount {
     addTo<T extends Temporal>(temporal: T): T;
     compareTo(otherDuration: Duration): number;
     dividedBy(divisor: number): Duration;
-    equals(other: any): other is Duration;
+    equals(other: any): boolean;
     get(unit: TemporalUnit): number;
     isNegative(): boolean;
     isZero(): boolean;
@@ -1163,7 +1163,7 @@ export class Instant extends Temporal implements TemporalAdjuster {
     atZone(zone: ZoneId): ZonedDateTime;
     compareTo(otherInstant: Instant): number;
     epochSecond(): number;
-    equals(other: any): other is Instant;
+    equals(other: any): boolean;
     getLong(field: TemporalField): number;
     hashCode(): number;
     isAfter(otherInstant: Instant): boolean;
@@ -1223,7 +1223,7 @@ export class LocalDate extends ChronoLocalDate implements TemporalAdjuster {
     dayOfMonth(): number;
     dayOfWeek(): DayOfWeek;
     dayOfYear(): number;
-    equals(other: any): other is LocalDate;
+    equals(other: any): boolean;
     getLong(field: TemporalField): number;
     hashCode(): number;
     isAfter(other: LocalDate): boolean;
@@ -1293,7 +1293,7 @@ export class LocalDateTime extends ChronoLocalDateTime implements TemporalAdjust
     dayOfMonth(): number;
     dayOfWeek(): DayOfWeek;
     dayOfYear(): number;
-    equals(other: any): other is LocalDateTime;
+    equals(other: any): boolean;
     format(formatter: DateTimeFormatter): string;
     getLong(field: TemporalField): number;
     hashCode(): number;
@@ -1387,7 +1387,7 @@ export class LocalTime extends Temporal implements TemporalAdjuster {
     atDate(date: LocalDate): LocalDateTime;
     atOffset(offset: ZoneOffset): OffsetTime;
     compareTo(other: LocalTime): number;
-    equals(other: any): other is LocalTime;
+    equals(other: any): boolean;
     format(formatter: DateTimeFormatter): string;
     getLong(field: ChronoField): number;
     hashCode(): number;
@@ -1446,7 +1446,7 @@ export class MonthDay extends TemporalAccessor implements TemporalAdjuster {
     atYear(year: number): LocalDate;
     compareTo(other: MonthDay): number;
     dayOfMonth(): number;
-    equals(other: any): other is MonthDay;
+    equals(other: any): boolean;
     format(formatter: DateTimeFormatter): string;
     getLong(field: TemporalField): number;
     isAfter(other: MonthDay): boolean;
@@ -1479,7 +1479,7 @@ export class Period extends TemporalAmount {
     addTo<T extends Temporal>(temporal: T): T;
     chronology(): IsoChronology;
     days(): number;
-    equals(other: any): other is Period;
+    equals(other: any): boolean;
     get(unit: TemporalUnit): number;
     hashCode(): number;
     isNegative(): boolean;
@@ -1526,7 +1526,7 @@ export class Year extends Temporal implements TemporalAdjuster {
     atMonth(month: Month | number): YearMonth;
     atMonthDay(monthDay: MonthDay): LocalDate;
     compareTo(other: Year): number;
-    equals(other: any): other is Year;
+    equals(other: any): boolean;
     getLong(field: TemporalField): number;
     isAfter(other: Year): boolean;
     isBefore(other: Year): boolean;
@@ -1569,7 +1569,7 @@ export class YearMonth extends Temporal implements TemporalAdjuster {
     atDay(dayOfMonth: number): LocalDate;
     atEndOfMonth(): LocalDate;
     compareTo(other: YearMonth): number;
-    equals(other: any): other is YearMonth;
+    equals(other: any): boolean;
     format(formatter: DateTimeFormatter): string;
     getLong(field: TemporalField): number;
     isAfter(other: YearMonth): boolean;
@@ -1649,7 +1649,7 @@ export class OffsetDateTime extends Temporal implements TemporalAdjuster {
     dayOfMonth(): number;
     dayOfWeek(): DayOfWeek;
     dayOfYear(): number;
-    equals(other: any): other is OffsetDateTime;
+    equals(other: any): boolean;
     format(formatter: DateTimeFormatter): string;
     getLong(field: TemporalField): number;
     hashCode(): number;
@@ -1745,7 +1745,7 @@ export class OffsetTime extends Temporal implements TemporalAdjuster {
     adjustInto(temporal: Temporal): Temporal;
     atDate(date: LocalDate): OffsetDateTime;
     compareTo(other: OffsetTime): number;
-    equals(other: any): other is OffsetTime;
+    equals(other: any): boolean;
     format(formatter: DateTimeFormatter): string;
     getLong(field: TemporalField): number;
     hashCode(): number;
@@ -1900,7 +1900,7 @@ export class ZonedDateTime extends ChronoZonedDateTime {
     dayOfMonth(): number;
     dayOfWeek(): DayOfWeek;
     dayOfYear(): number;
-    equals(other: any): other is ZonedDateTime;
+    equals(other: any): boolean;
     getLong(field: TemporalField): number;
     hashCode(): number;
     hour(): number;

--- a/packages/core/test/typescript_definitions/core-test.ts
+++ b/packages/core/test/typescript_definitions/core-test.ts
@@ -95,10 +95,10 @@ it('ZonedDateTime', () => {
     expectType<string>(zdt.toString());
     expectType<string>(zdt.toJSON());
 
-    // .equals is a type predicate
-    const temp: Temporal = ZonedDateTime.parse(zdt.toString());
-    if (zdt.equals(temp)) {
-        expectType<ZonedDateTime>(temp);
+    // .equals is not a type predicate
+    const temp = ZonedDateTime.now();
+    if (!zdt.equals(temp)) {
+        expectType<boolean>(temp.equals(zdt));
     }
 });
 
@@ -163,10 +163,10 @@ it('OffsetDateTime', () => {
     expectType<string>(odt.toString());
     expectType<string>(odt.toJSON());
 
-    // .equals is a type predicate
-    const temp: Temporal = OffsetDateTime.parse(odt.toString());
-    if (odt.equals(temp)) {
-        expectType<OffsetDateTime>(temp);
+    // .equals is not a type predicate
+    const temp = OffsetDateTime.now();
+    if (!odt.equals(temp)) {
+        expectType<boolean>(temp.equals(odt));
     }
 });
 
@@ -259,10 +259,10 @@ it('OffsetTime', () => {
     expectType<OffsetTime | null>(t1.query(OffsetTime.FROM));
     expectType<LocalDate | null>(t1.query(TemporalQueries.localDate()));
 
-    // .equals is a type predicate
-    const temp: Temporal = OffsetTime.parse(ot.toString());
-    if (ot.equals(temp)) {
-        expectType<OffsetTime>(temp);
+    // .equals is not a type predicate
+    const temp = OffsetTime.now();
+    if (!ot.equals(temp)) {
+        expectType<boolean>(temp.equals(ot));
     }
 });
 
@@ -378,10 +378,10 @@ it('LocalDate', () => {
     expectType<LocalDateTime>(d1.atTime(LocalTime.now()));
     expectType<OffsetDateTime>(d1.atTime(OffsetTime.now()));
 
-    // .equals is a type predicate
-    const temp: Temporal = LocalDate.parse(d.toString());
-    if (d.equals(temp)) {
-        expectType<LocalDate>(temp);
+    // .equals is not a type predicate
+    const temp = LocalDate.now();
+    if (!d.equals(temp)) {
+        expectType<boolean>(temp.equals(d));
     }
 });
 
@@ -482,10 +482,10 @@ it('LocalTime', () => {
     expectType<OffsetTime>(t.atOffset(ZoneOffset.MIN));
     expectType<LocalDateTime>(t.atDate(LocalDate.now()));
 
-    // .equals is a type predicate
-    const temp: Temporal = LocalTime.parse(t.toString());
-    if (t.equals(temp)) {
-        expectType<LocalTime>(temp);
+    // .equals is not a type predicate
+    const temp = LocalTime.now();
+    if (!t.equals(temp)) {
+        expectType<boolean>(temp.equals(t));
     }
 });
 
@@ -639,10 +639,10 @@ it('LocalDateTime', () => {
     expectType<OffsetDateTime>(dt.atOffset(ZoneOffset.MIN));
     expectType<ZonedDateTime>(dt.atZone(ZoneId.UTC));
 
-    // .equals is a type predicate
-    const temp: Temporal = LocalDateTime.parse(dt.toString());
-    if (dt.equals(temp)) {
-        expectType<LocalDateTime>(temp);
+    // .equals is not a type predicate
+    const temp = LocalDateTime.now();
+    if (!dt.equals(temp)) {
+        expectType<boolean>(temp.equals(dt));
     }
 });
 
@@ -670,10 +670,10 @@ it('Instant', () => {
     expectType<OffsetDateTime>(i.atOffset(ZoneOffset.MAX));
     expectType<ZonedDateTime>(i.atZone(ZoneId.UTC));
 
-    // .equals is a type predicate
-    const temp: Temporal = Instant.parse(i.toString());
-    if (i.equals(temp)) {
-        expectType<Instant>(temp);
+    // .equals is not a type predicate
+    const temp = Instant.now();
+    if (!i.equals(temp)) {
+        expectType<boolean>(temp.equals(i));
     }
 });
 
@@ -720,10 +720,10 @@ it('Year', () => {
     expectType<Year | null>(year.query(Year.FROM));
     expectType<LocalDate | null>(year.query(TemporalQueries.localDate()));
 
-    // .equals is a type predicate
-    const temp: Temporal = Year.parse(year.toString());
-    if (year.equals(temp)) {
-        expectType<Year>(temp);
+    // .equals is not a type predicate
+    const temp = Year.now();
+    if (!year.equals(temp)) {
+        expectType<boolean>(temp.equals(year));
     }
 });
 
@@ -789,10 +789,10 @@ it('YearMonth', () => {
     expectType<YearMonth | null>(ym.query(YearMonth.FROM));
     expectType<LocalDate | null>(ym.query(TemporalQueries.localDate()));
 
-    // .equals is a type predicate
-    const temp: Temporal = YearMonth.parse(ym.toString());
-    if (ym.equals(temp)) {
-        expectType<YearMonth>(temp);
+    // .equals is not a type predicate
+    const temp = YearMonth.now();
+    if (!ym.equals(temp)) {
+        expectType<boolean>(temp.equals(ym));
     }
 });
 
@@ -840,10 +840,10 @@ it('MonthDay', () => {
     expectType<MonthDay | null>(md.query(MonthDay.FROM));
     expectType<LocalDate | null>(md.query(TemporalQueries.localDate()));
 
-    // .equals is a type predicate
-    const temp: TemporalAccessor = MonthDay.parse(md.toString());
-    if (md.equals(temp)) {
-        expectType<MonthDay>(temp);
+    // .equals is not a type predicate
+    const temp = MonthDay.now();
+    if (!md.equals(temp)) {
+        expectType<boolean>(temp.equals(md));
     }
 });
 
@@ -870,10 +870,10 @@ it('Period', () => {
 
     Period.between(LocalDate.parse('2012-06-30'), LocalDate.parse('2012-08-31'));
 
-    // .equals is a type predicate
-    const temp: TemporalAmount = Period.parse(p.toString());
-    if (p.equals(temp)) {
-        expectType<Period>(temp);
+    // .equals is not a type predicate
+    const temp = Period.ZERO;
+    if (!p.equals(temp)) {
+        expectType<boolean>(temp.equals(p));
     }
 });
 
@@ -900,10 +900,10 @@ it('Duration', () => {
     expectType<Duration>(dur.plus(Duration.ofNanos(1)));
     expectType<Duration>(dur.plus(1, ChronoUnit.NANOS));
 
-    // .equals is a type predicate
-    const temp: TemporalAmount = Duration.parse(dur.toString());
-    if (dur.equals(temp)) {
-        expectType<Duration>(temp);
+    // .equals is not a type predicate
+    const temp = Duration.ZERO;
+    if (!dur.equals(temp)) {
+        expectType<boolean>(temp.equals(dur));
     }
 });
 


### PR DESCRIPTION
Fixes #546 

It (mostly) reverts #457, the tests were updated so they now fails when .equals are type predicates (a revert would have simply removed the tests).