### PR TITLE
WeekFields export and typings

### DIFF
--- a/packages/core/typings/js-joda.d.ts
+++ b/packages/core/typings/js-joda.d.ts
@@ -1770,7 +1770,6 @@ export class OffsetTime extends Temporal implements TemporalAdjuster {
     plusNanos(nanos: number): OffsetTime;
     plusSeconds(seconds: number): OffsetTime;
     second(): number;
-    toEpochSecond(date: LocalDate): number;
     toJSON(): string;
     toLocalTime(): LocalTime;
     toString(): string;

--- a/packages/locale/src/js-joda-locale.js
+++ b/packages/locale/src/js-joda-locale.js
@@ -5,12 +5,11 @@
 import { use } from '@js-joda/core';
 import plug from './plug';
 import Locale from './Locale';
-import { WeekFields, ComputedDayOfField } from './temporal/WeekFields';
+import { WeekFields } from './temporal/WeekFields';
 
 use(plug);
 
 export {
     Locale,
-    WeekFields,
-    ComputedDayOfField
+    WeekFields
 };

--- a/packages/locale/src/js-joda-locale.js
+++ b/packages/locale/src/js-joda-locale.js
@@ -5,9 +5,12 @@
 import { use } from '@js-joda/core';
 import plug from './plug';
 import Locale from './Locale';
+import { WeekFields, ComputedDayOfField } from './temporal/WeekFields';
 
 use(plug);
 
 export {
-    Locale
+    Locale,
+    WeekFields,
+    ComputedDayOfField
 };

--- a/packages/locale/test/typescript_definitions/js-joda-locale-tests.ts
+++ b/packages/locale/test/typescript_definitions/js-joda-locale-tests.ts
@@ -4,8 +4,10 @@ import {
   DateTimeFormatterBuilder,
   ChronoField,
   TextStyle,
+  DayOfWeek,
+  TemporalField,
 } from '@js-joda/core';
-import { Locale } from '../..';
+import {Locale, WeekFields} from '../..';
 
 function test_Locale() {
   const locale = new Locale('en');
@@ -57,6 +59,25 @@ function test_DateTimeFormatterBuilder() {
     .toFormatter(TextStyle.NARROW);
 
   expectType<DateTimeFormatter>(formatter);
+}
+
+function test_WeekFields() {
+
+  expectType<WeekFields>(WeekFields.of(DayOfWeek.MONDAY));
+  expectType<WeekFields>(WeekFields.of(new Locale('en')));
+  expectType<WeekFields>(WeekFields.ofLocale(new Locale('en')));
+  expectType<WeekFields>(WeekFields.ofFirstDayOfWeekMinDays(DayOfWeek.MONDAY, 7));
+
+  expectType<WeekFields>(WeekFields.SUNDAY_START);
+  expectType<WeekFields>(WeekFields.ISO);
+  expectType<DayOfWeek>(WeekFields.ISO.firstDayOfWeek());
+  expectType<number>(WeekFields.ISO.minimalDaysInFirstWeek());
+  expectType<TemporalField>(WeekFields.ISO.dayOfWeek());
+  expectType<TemporalField>(WeekFields.ISO.weekOfMonth());
+  expectType<TemporalField>(WeekFields.ISO.weekOfYear());
+  expectType<TemporalField>(WeekFields.ISO.weekOfWeekBasedYear());
+  expectType<TemporalField>(WeekFields.ISO.weekBasedYear());
+  expectType<boolean>(WeekFields.ISO.equals("foo"));
 }
 
 /**

--- a/packages/locale/test/typescript_definitions/js-joda-locale-tests.ts
+++ b/packages/locale/test/typescript_definitions/js-joda-locale-tests.ts
@@ -63,10 +63,8 @@ function test_DateTimeFormatterBuilder() {
 
 function test_WeekFields() {
 
-  expectType<WeekFields>(WeekFields.of(DayOfWeek.MONDAY));
+  expectType<WeekFields>(WeekFields.of(DayOfWeek.MONDAY, 7));
   expectType<WeekFields>(WeekFields.of(new Locale('en')));
-  expectType<WeekFields>(WeekFields.ofLocale(new Locale('en')));
-  expectType<WeekFields>(WeekFields.ofFirstDayOfWeekMinDays(DayOfWeek.MONDAY, 7));
 
   expectType<WeekFields>(WeekFields.SUNDAY_START);
   expectType<WeekFields>(WeekFields.ISO);
@@ -78,6 +76,8 @@ function test_WeekFields() {
   expectType<TemporalField>(WeekFields.ISO.weekOfWeekBasedYear());
   expectType<TemporalField>(WeekFields.ISO.weekBasedYear());
   expectType<boolean>(WeekFields.ISO.equals("foo"));
+  expectType<number>(WeekFields.ISO.hashCode());
+  expectType<string>(WeekFields.ISO.toString());
 }
 
 /**

--- a/packages/locale/typings/js-joda-locale.d.ts
+++ b/packages/locale/typings/js-joda-locale.d.ts
@@ -16,8 +16,8 @@ export class WeekFields {
     public static ISO: WeekFields;
     public static SUNDAY_START: WeekFields;
     public static ofLocale(locale: Locale): WeekFields;
-    public static of(firstDayOrLocale: core.DayOfWeek | Locale, minDays?: number);
-    public static ofFirstDayOfWeekMinDays(firstDayOfWeek: DayOfWeek, minimalDaysInFirstWeek: number);
+    public static of(firstDayOrLocale: core.DayOfWeek | Locale, minDays?: number): WeekFields;
+    public static ofFirstDayOfWeekMinDays(firstDayOfWeek: DayOfWeek, minimalDaysInFirstWeek: number): WeekFields;
     public firstDayOfWeek(): core.DayOfWeek;
     public minimalDaysInFirstWeek(): number;
     public dayOfWeek(): core.TemporalField;

--- a/packages/locale/typings/js-joda-locale.d.ts
+++ b/packages/locale/typings/js-joda-locale.d.ts
@@ -1,3 +1,5 @@
+import * as core from '@js-joda/core';
+
 export class Locale {
     public static getAvailableLocales(): string[];
 
@@ -48,8 +50,6 @@ export namespace Locale {
     const HINDI: Locale;
     const RUSSIAN: Locale;
 }
-
-import * as core from '@js-joda/core';
 
 declare module '@js-joda/core' {
     namespace DateTimeFormatter {

--- a/packages/locale/typings/js-joda-locale.d.ts
+++ b/packages/locale/typings/js-joda-locale.d.ts
@@ -1,3 +1,5 @@
+import {DayOfWeek} from "@js-joda/core";
+
 export class Locale {
     public static getAvailableLocales(): string[];
 
@@ -10,31 +12,12 @@ export class Locale {
     public equals(other: any): boolean;
 }
 
-export class ComputedDayOfField {
-    public static ofDayOfWeekField(weekDef: WeekFields);
-    public static ofWeekOfMonthField(weekDef: WeekFields);
-    public static ofWeekOfYearField(weekDef: WeekFields);
-    public static ofWeekOfWeekBasedYearField(weekDef: WeekFields);
-    public static ofWeekBasedYearField(weekDef: WeekFields);
-    public getFrom(temporal: core.TemporalAccessor);
-    public adjustInto(temporal: core.Temporal, newValue: number);
-    public resolve(fieldValues: core.EnumMap, partialTemporal: core.TemporalAccessor, resolverStyle: core.ResolverStyle);
-    public name(): string;
-    public getBaseUnit(): core.TemporalUnit;
-    public getRangeUnit(): core.TemporalUnit;
-    public range(): core.ValueRange;
-    public isDateBased(): boolean;
-    public isTimeBased(): boolean;
-    public isSupportedBy(temporal: core.TemporalAccessor): boolean;
-    public rangeRefinedBy(temporal: core.TemporalAccessor): core.ValueRange;
-}
-
 export class WeekFields {
     public static ISO: WeekFields;
     public static SUNDAY_START: WeekFields;
     public static ofLocale(locale: Locale): WeekFields;
     public static of(firstDayOrLocale: core.DayOfWeek | Locale, minDays?: number);
-    public static ofFirstDayOfWeekMinDays(firstDayOfWeek, minimalDaysInFirstWeek);
+    public static ofFirstDayOfWeekMinDays(firstDayOfWeek: DayOfWeek, minimalDaysInFirstWeek: number);
     public firstDayOfWeek(): core.DayOfWeek;
     public minimalDaysInFirstWeek(): number;
     public dayOfWeek(): core.TemporalField;
@@ -86,21 +69,6 @@ declare module '@js-joda/core' {
         appendLocalizedOffset(textStyle: core.TextStyle): DateTimeFormatterBuilder;
     }
 
-    export interface Nameable {
-        name(): string;
-    }
-
-    export interface EnumMap {
-        putAll(otherMap: EnumMap): EnumMap;
-        containsKey(key: Nameable): boolean;
-        get(key: Nameable): any;
-        put(key: Nameable, val): EnumMap;
-        set(key: Nameable, val): EnumMap;
-        retainAll(keyList): EnumMap;
-        remove(key: Nameable): any;
-        keySet(): Record<string, any>;
-        clear();
-    }
 }
 
 export const __esModule: true;

--- a/packages/locale/typings/js-joda-locale.d.ts
+++ b/packages/locale/typings/js-joda-locale.d.ts
@@ -1,5 +1,3 @@
-import {DayOfWeek} from "@js-joda/core";
-
 export class Locale {
     public static getAvailableLocales(): string[];
 
@@ -15,9 +13,8 @@ export class Locale {
 export class WeekFields {
     public static ISO: WeekFields;
     public static SUNDAY_START: WeekFields;
-    public static ofLocale(locale: Locale): WeekFields;
-    public static of(firstDayOrLocale: core.DayOfWeek | Locale, minDays?: number): WeekFields;
-    public static ofFirstDayOfWeekMinDays(firstDayOfWeek: DayOfWeek, minimalDaysInFirstWeek: number): WeekFields;
+    public static of(locale: Locale): WeekFields;
+    public static of(firstDayOfWeek: core.DayOfWeek, minDays: number): WeekFields;
     public firstDayOfWeek(): core.DayOfWeek;
     public minimalDaysInFirstWeek(): number;
     public dayOfWeek(): core.TemporalField;
@@ -26,6 +23,8 @@ export class WeekFields {
     public weekOfWeekBasedYear(): core.TemporalField;
     public weekBasedYear(): core.TemporalField;
     public equals(other: any): boolean;
+    public hashCode(): number;
+    public toString(): string;
 }
 
 export namespace Locale {

--- a/packages/locale/typings/js-joda-locale.d.ts
+++ b/packages/locale/typings/js-joda-locale.d.ts
@@ -10,6 +10,41 @@ export class Locale {
     public equals(other: any): boolean;
 }
 
+export class ComputedDayOfField {
+    public static ofDayOfWeekField(weekDef: WeekFields);
+    public static ofWeekOfMonthField(weekDef: WeekFields);
+    public static ofWeekOfYearField(weekDef: WeekFields);
+    public static ofWeekOfWeekBasedYearField(weekDef: WeekFields);
+    public static ofWeekBasedYearField(weekDef: WeekFields);
+    public getFrom(temporal: core.TemporalAccessor);
+    public adjustInto(temporal: core.Temporal, newValue: number);
+    public resolve(fieldValues: core.EnumMap, partialTemporal: core.TemporalAccessor, resolverStyle: core.ResolverStyle);
+    public name(): string;
+    public getBaseUnit(): core.TemporalUnit;
+    public getRangeUnit(): core.TemporalUnit;
+    public range(): core.ValueRange;
+    public isDateBased(): boolean;
+    public isTimeBased(): boolean;
+    public isSupportedBy(temporal: core.TemporalAccessor): boolean;
+    public rangeRefinedBy(temporal: core.TemporalAccessor): core.ValueRange;
+}
+
+export class WeekFields {
+    public static ISO: WeekFields;
+    public static SUNDAY_START: WeekFields;
+    public static ofLocale(locale: Locale): WeekFields;
+    public static of(firstDayOrLocale: core.DayOfWeek | Locale, minDays?: number);
+    public static ofFirstDayOfWeekMinDays(firstDayOfWeek, minimalDaysInFirstWeek);
+    public firstDayOfWeek(): core.DayOfWeek;
+    public minimalDaysInFirstWeek(): number;
+    public dayOfWeek(): core.TemporalField;
+    public weekOfMonth(): core.TemporalField;
+    public weekOfYear(): core.TemporalField;
+    public weekOfWeekBasedYear(): core.TemporalField;
+    public weekBasedYear(): core.TemporalField;
+    public equals(other: any): boolean;
+}
+
 export namespace Locale {
     const ENGLISH: Locale;
     const US: Locale;
@@ -49,6 +84,22 @@ declare module '@js-joda/core' {
         appendWeekField(field: string, count: number): DateTimeFormatterBuilder;
         appendZoneText(textStyle: core.TextStyle): DateTimeFormatterBuilder;
         appendLocalizedOffset(textStyle: core.TextStyle): DateTimeFormatterBuilder;
+    }
+
+    export interface Nameable {
+        name(): string;
+    }
+
+    export interface EnumMap {
+        putAll(otherMap: EnumMap): EnumMap;
+        containsKey(key: Nameable): boolean;
+        get(key: Nameable): any;
+        put(key: Nameable, val): EnumMap;
+        set(key: Nameable, val): EnumMap;
+        retainAll(keyList): EnumMap;
+        remove(key: Nameable): any;
+        keySet(): Record<string, any>;
+        clear();
     }
 }
 


### PR DESCRIPTION
exporting WeekFields and ComputedDayOfField from locale package.  Plus, typings for same.  Permits one to do: 

```
import {WeekFields} from "@js-joda/locale";
```

rather than import directly from locale/src folder (as per docs) and then have to juggle your ts/babel/jest/etc config to accomodate that one file ... 

I've added a typing for `EnumMap`.  Unsure if you'd like this in the core typings, but, it is in the locale typings atm.  Let me know if you want that changed.