### PR TITLE
Add Instant micro methods to Typescript definitions.

### DIFF
--- a/packages/core/test/typescript_definitions/core-test.ts
+++ b/packages/core/test/typescript_definitions/core-test.ts
@@ -647,7 +647,11 @@ it('LocalDateTime', () => {
 });
 
 it('Instant', () => {
-    let i = Instant.parse('2019-03-24T23:32:46.488Z');
+    let i = Instant.ofEpochMicro(new Date().getTime() * 1000)
+    i.plusMicros(100)
+    i.minusMicros(200)
+
+    i = Instant.parse('2019-03-24T23:32:46.488Z');
 
     i.toString();
     i.toJSON();

--- a/packages/core/typings/js-joda.d.ts
+++ b/packages/core/typings/js-joda.d.ts
@@ -1152,6 +1152,7 @@ export class Instant extends Temporal implements TemporalAdjuster {
 
     static from(temporal: TemporalAccessor): Instant;
     static now(clock?: Clock): Instant;
+    static ofEpochMicro(epochMicro: number): Instant;
     static ofEpochMilli(epochMilli: number): Instant;
     static ofEpochSecond(epochSecond: number, nanoAdjustment?: number): Instant;
     static parse(text: string): Instant;
@@ -1171,12 +1172,14 @@ export class Instant extends Temporal implements TemporalAdjuster {
     isSupported(fieldOrUnit: TemporalField | TemporalUnit): boolean;
     minus(amountToSubtract: number, unit: TemporalUnit): Instant;
     minus(amount: TemporalAmount): Instant;
+    minusMicros(microsToSubtract: number): Instant;
     minusMillis(millisToSubtract: number): Instant;
     minusNanos(nanosToSubtract: number): Instant;
     minusSeconds(secondsToSubtract: number): Instant;
     nano(): number;
     plus(amountToAdd: number, unit: TemporalUnit): Instant;
     plus(amount: TemporalAmount): Instant;
+    plusMicros(microsToAdd: number): Instant;
     plusMillis(millisToAdd: number): Instant;
     plusNanos(nanosToAdd: number): Instant;
     plusSeconds(secondsToAdd: number): Instant;

--- a/packages/core/typings/js-joda.flow.js
+++ b/packages/core/typings/js-joda.flow.js
@@ -122,6 +122,7 @@ declare module "js-joda" {
         MAX_SECONDS: Instant;
         from(temporal: TemporalAccessor): Instant;
         now(clock?: Clock): Instant;
+        ofEpochMicro(epochMicro: number): Instant;
         ofEpochMilli(epochMilli: number): Instant;
         ofEpochSecond(epochSecond: number, nanoAdjustment?: number): Instant;
         parse(text: string): Instant;
@@ -137,12 +138,14 @@ declare module "js-joda" {
         isSupported(fieldOrUnit: TemporalField | TemporalUnit): boolean;
         minus(amount: TemporalAmount): Instant;
         minus(amountToSubtract: number, unit: TemporalUnit): Instant;
+        minusMicros(microsToSubtract: number): Instant;
         minusMillis(millisToSubtract: number): Instant;
         minusNanos(nanosToSubtract: number): Instant;
         minusSeconds(secondsToSubtract: number): Instant;
         nano(): number;
         plus(amount: TemporalAmount): Instant;
         plus(amountToAdd: number, unit: TemporalUnit): Instant;
+        plusMicros(microsToAdd: number): Instant;
         plusMillis(millisToAdd: number): Instant;
         plusNanos(nanosToAdd: number): Instant;
         plusSeconds(secondsToAdd: number): Instant;


### PR DESCRIPTION
These methods were added to js-joda recently, and the typescript definition should match.