### PR TITLE
Fix broken table in WeekFields.js~WeekFields.html

### DIFF
--- a/docs/class/packages/locale/src/temporal/WeekFields.js~WeekFields.html
+++ b/docs/class/packages/locale/src/temporal/WeekFields.js~WeekFields.html
@@ -164,19 +164,19 @@ The month is divided into periods where each period starts on the defined first 
 The earliest period is referred to as week 0 if it has less than the minimal number of days
 and week 1 if it has at least the minimal number of days.</li></p>
 <p></p><p></p>
-<p>&lt;table cellpadding=&quot;0&quot; cellspacing=&quot;3&quot; border=&quot;0&quot; style=&quot;text-align: left; width: 50%;&quot;&gt;</p>
-<p>&lt;caption&gt;Examples of WeekFields&lt;/caption&gt;</p>
-<p>&lt;tr&gt;&lt;th&gt;Date&lt;/th&gt;&lt;td&gt;Day-of-week&lt;/td&gt;
- &lt;td&gt;First day: Monday<br>Minimal days: 4&lt;/td&gt;&lt;td&gt;First day: Monday<br>Minimal days: 5&lt;/td&gt;&lt;/tr&gt;</p>
-<p>&lt;tr&gt;&lt;th&gt;2008-12-31&lt;/th&gt;&lt;td&gt;Wednesday&lt;/td&gt;
- &lt;td&gt;Week 5 of December 2008&lt;/td&gt;&lt;td&gt;Week 5 of December 2008&lt;/td&gt;&lt;/tr&gt;</p>
-<p>&lt;tr&gt;&lt;th&gt;2009-01-01&lt;/th&gt;&lt;td&gt;Thursday&lt;/td&gt;
- &lt;td&gt;Week 1 of January 2009&lt;/td&gt;&lt;td&gt;Week 0 of January 2009&lt;/td&gt;&lt;/tr&gt;</p>
-<p>&lt;tr&gt;&lt;th&gt;2009-01-04&lt;/th&gt;&lt;td&gt;Sunday&lt;/td&gt;
- &lt;td&gt;Week 1 of January 2009&lt;/td&gt;&lt;td&gt;Week 0 of January 2009&lt;/td&gt;&lt;/tr&gt;</p>
-<p>&lt;tr&gt;&lt;th&gt;2009-01-05&lt;/th&gt;&lt;td&gt;Monday&lt;/td&gt;
- &lt;td&gt;Week 2 of January 2009&lt;/td&gt;&lt;td&gt;Week 1 of January 2009&lt;/td&gt;&lt;/tr&gt;
-&lt;/table&gt;</p>
+<table cellpadding="0" cellspacing="3" border="0" style="text-align: left; width: 50%;">
+<caption>Examples of WeekFields</caption>
+<tr><th>Date</th><td>Day-of-week</td>
+ <td>First day: Monday<br>Minimal days: 4</td><td>First day: Monday<br>Minimal days: 5</td></tr>
+<tr><th>2008-12-31</th><td>Wednesday</td>
+ <td>Week 5 of December 2008</td><td>Week 5 of December 2008</td></tr>
+<tr><th>2009-01-01</th><td>Thursday</td>
+ <td>Week 1 of January 2009</td><td>Week 0 of January 2009</td></tr>
+<tr><th>2009-01-04</th><td>Sunday</td>
+ <td>Week 1 of January 2009</td><td>Week 0 of January 2009</td></tr>
+<tr><th>2009-01-05</th><td>Monday</td>
+ <td>Week 2 of January 2009</td><td>Week 1 of January 2009</td></tr>
+</table>
 <p></p><p></p>
 <p></p><h3>Week of Year</h3>
 One field is used: week-of-year.


### PR DESCRIPTION
Ignore this PR if this file is autogenerated. Currently the table [here](https://js-joda.github.io/js-joda/class/packages/locale/src/temporal/WeekFields.js~WeekFields.html) is a bit broken.