### PR TITLE
fix rounding in OffsetTime and YearMonth

### DIFF
--- a/packages/core/src/OffsetTime.js
+++ b/packages/core/src/OffsetTime.js
@@ -443,12 +443,12 @@ export class OffsetTime extends Temporal {
             const nanosUntil = end._toEpochNano() - this._toEpochNano(); // no overflow
             switch (unit) {
                 case ChronoUnit.NANOS: return nanosUntil;
-                case ChronoUnit.MICROS: return Math.floor(nanosUntil / 1000);
-                case ChronoUnit.MILLIS: return Math.floor(nanosUntil / 1000000);
-                case ChronoUnit.SECONDS: return Math.floor(nanosUntil / LocalTime.NANOS_PER_SECOND);
-                case ChronoUnit.MINUTES: return Math.floor(nanosUntil / LocalTime.NANOS_PER_MINUTE);
-                case ChronoUnit.HOURS: return Math.floor(nanosUntil / LocalTime.NANOS_PER_HOUR);
-                case ChronoUnit.HALF_DAYS: return Math.floor(nanosUntil / (12 * LocalTime.NANOS_PER_HOUR));
+                case ChronoUnit.MICROS: return MathUtil.intDiv(nanosUntil, 1000);
+                case ChronoUnit.MILLIS: return MathUtil.intDiv(nanosUntil, 1000000);
+                case ChronoUnit.SECONDS: return MathUtil.intDiv(nanosUntil, LocalTime.NANOS_PER_SECOND);
+                case ChronoUnit.MINUTES: return MathUtil.intDiv(nanosUntil, LocalTime.NANOS_PER_MINUTE);
+                case ChronoUnit.HOURS: return MathUtil.intDiv(nanosUntil, LocalTime.NANOS_PER_HOUR);
+                case ChronoUnit.HALF_DAYS: return MathUtil.intDiv(nanosUntil, (12 * LocalTime.NANOS_PER_HOUR));
             }
             throw new UnsupportedTemporalTypeException(`Unsupported unit: ${unit}`);
         }

--- a/packages/core/src/YearMonth.js
+++ b/packages/core/src/YearMonth.js
@@ -851,10 +851,10 @@ export class YearMonth extends Temporal {
             const monthsUntil = end._getProlepticMonth() - this._getProlepticMonth();  // no overflow
             switch (unit) {
                 case ChronoUnit.MONTHS: return monthsUntil;
-                case ChronoUnit.YEARS: return monthsUntil / 12;
-                case ChronoUnit.DECADES: return monthsUntil / 120;
-                case ChronoUnit.CENTURIES: return monthsUntil / 1200;
-                case ChronoUnit.MILLENNIA: return monthsUntil / 12000;
+                case ChronoUnit.YEARS: return MathUtil.intDiv(monthsUntil, 12);
+                case ChronoUnit.DECADES: return MathUtil.intDiv(monthsUntil, 120);
+                case ChronoUnit.CENTURIES: return MathUtil.intDiv(monthsUntil, 1200);
+                case ChronoUnit.MILLENNIA: return MathUtil.intDiv(monthsUntil, 12000);
                 case ChronoUnit.ERAS: return end.getLong(ChronoField.ERA) - this.getLong(ChronoField.ERA);
             }
             throw new UnsupportedTemporalTypeException(`Unsupported unit: ${unit}`);

--- a/packages/core/test/YearMonthTest.js
+++ b/packages/core/test/YearMonthTest.js
@@ -208,9 +208,9 @@ describe('js-joda YearMonth', () => {
             const end = YearMonth.of(2016, 12);
             assertEquals(test.until(end, ChronoUnit.YEARS), 1);
             assertEquals(test.until(end, ChronoUnit.MONTHS), 12);
-            assertEquals(test.until(end, ChronoUnit.DECADES), 0.1);
-            assertEquals(test.until(end, ChronoUnit.CENTURIES), 0.01);
-            assertEquals(test.until(end, ChronoUnit.MILLENNIA), 0.001);
+            assertEquals(test.until(end, ChronoUnit.DECADES), 0);
+            assertEquals(test.until(end, ChronoUnit.CENTURIES), 0);
+            assertEquals(test.until(end, ChronoUnit.MILLENNIA), 0);
             assertEquals(test.until(end, ChronoUnit.ERAS), 0);
         });
         


### PR DESCRIPTION
Currently `OffsetTime.until` uses floor rounding and `YearMonth.until` doesn't use rounding at all. In second case, even the tests are broken! It's clear that integer division = rounding towards 0 should be used. And that is precisely what this PR fixes.