### PR TITLE
lengthInDays(): POSITIVE_INFINITY instead of NaN if range is unbounded

### DIFF
--- a/packages/core/test/reference/LocalDateTest.js
+++ b/packages/core/test/reference/LocalDateTest.js
@@ -351,7 +351,7 @@ describe('org.threeten.bp.TestLocalDate', () => {
 
         it('factory_ofYearDay_ints_yearTooLow', () => {
             expect(() => {
-                LocalDate.ofYearDay(Number.MIN_SAFE_INTEGER, 1);
+                LocalDate.ofYearDay(MathUtil.MIN_SAFE_INTEGER, 1);
             }).to.throw(DateTimeException);
         });
     });

--- a/packages/extra/src/LocalDateRange.js
+++ b/packages/extra/src/LocalDateRange.js
@@ -670,13 +670,13 @@ export class LocalDateRange {
      * Obtains the length of this range in days.
      * 
      * This returns the number of days between the start and end dates.
-     * Unbounded ranges return `Number.NaN`.
+     * Unbounded ranges return `Number.POSITIVE_INFINITY`.
      *
-     * @return {number} the length in days, Number.NaN if unbounded
+     * @return {number} the length in days, `Number.POSITIVE_INFINITY` if unbounded
      */
     lengthInDays() {
         if (this.isUnboundedStart() || this.isUnboundedEnd()) {
-            return Number.NaN;
+            return Number.POSITIVE_INFINITY;
         }
         return this._end.toEpochDay() - this._start.toEpochDay();
     }

--- a/packages/extra/test/reference/LocalDateRangeTest.js
+++ b/packages/extra/test/reference/LocalDateRangeTest.js
@@ -68,7 +68,7 @@ describe('org.threeten.extra.TestLocalDateRange', () => {
         assertEquals(false, test.isEmpty());
         assertEquals(true, test.isUnboundedStart());
         assertEquals(false, test.isUnboundedEnd());
-        assertEquals(true, Number.isNaN(test.lengthInDays()));
+        assertEquals(Number.POSITIVE_INFINITY, test.lengthInDays());
         assertEquals('-999999-01-01/2012-07-31', test.toString());
     });
 
@@ -80,7 +80,7 @@ describe('org.threeten.extra.TestLocalDateRange', () => {
         assertEquals(false, test.isEmpty());
         assertEquals(false, test.isUnboundedStart());
         assertEquals(true, test.isUnboundedEnd());
-        assertEquals(true, Number.isNaN(test.lengthInDays()));
+        assertEquals(Number.POSITIVE_INFINITY, test.lengthInDays());
         assertEquals('2012-07-28/+999999-12-31', test.toString());
     });
 
@@ -92,7 +92,7 @@ describe('org.threeten.extra.TestLocalDateRange', () => {
         assertEquals(false, test.isEmpty());
         assertEquals(true, test.isUnboundedStart());
         assertEquals(true, test.isUnboundedEnd());
-        assertEquals(true, Number.isNaN(test.lengthInDays()));
+        assertEquals(Number.POSITIVE_INFINITY, test.lengthInDays());
         assertEquals('-999999-01-01/+999999-12-31', test.toString());
     });
 
@@ -116,7 +116,7 @@ describe('org.threeten.extra.TestLocalDateRange', () => {
         assertEquals(false, test.isEmpty());
         assertEquals(true, test.isUnboundedStart());
         assertEquals(false, test.isUnboundedEnd());
-        assertEquals(true, Number.isNaN(test.lengthInDays()));
+        assertEquals(Number.POSITIVE_INFINITY, test.lengthInDays());
         assertEquals('-999999-01-01/-999999-01-03', test.toString());
     });
 
@@ -128,7 +128,7 @@ describe('org.threeten.extra.TestLocalDateRange', () => {
         assertEquals(false, test.isEmpty());
         assertEquals(false, test.isUnboundedStart());
         assertEquals(false, test.isUnboundedEnd());
-        //assertEquals(1, test.lengthInDays());
+        assertEquals(1, test.lengthInDays());
         assertEquals('-999999-01-02/-999999-01-03', test.toString());
     });
 
@@ -193,7 +193,7 @@ describe('org.threeten.extra.TestLocalDateRange', () => {
         assertEquals(false, test.isEmpty());
         assertEquals(true, test.isUnboundedStart());
         assertEquals(false, test.isUnboundedEnd());
-        assertEquals(true, Number.isNaN(test.lengthInDays()));
+        assertEquals(Number.POSITIVE_INFINITY, test.lengthInDays());
         assertEquals('-999999-01-01/2012-07-31', test.toString());
     });
 
@@ -205,7 +205,7 @@ describe('org.threeten.extra.TestLocalDateRange', () => {
         assertEquals(false, test.isEmpty());
         assertEquals(false, test.isUnboundedStart());
         assertEquals(true, test.isUnboundedEnd());
-        //assertEquals(Integer.MAX_VALUE, test.lengthInDays());
+        assertEquals(Number.POSITIVE_INFINITY, test.lengthInDays());
         assertEquals('2012-07-28/+999999-12-31', test.toString());
     });
 
@@ -217,7 +217,7 @@ describe('org.threeten.extra.TestLocalDateRange', () => {
         assertEquals(false, test.isEmpty());
         assertEquals(true, test.isUnboundedStart());
         assertEquals(true, test.isUnboundedEnd());
-        assertEquals(true, Number.isNaN(test.lengthInDays()));
+        assertEquals(Number.POSITIVE_INFINITY, test.lengthInDays());
         assertEquals('-999999-01-01/+999999-12-31', test.toString());
     });
 
@@ -233,7 +233,7 @@ describe('org.threeten.extra.TestLocalDateRange', () => {
         assertEquals(false, test.isEmpty());
         assertEquals(true, test.isUnboundedStart());
         assertEquals(false, test.isUnboundedEnd());
-        assertEquals(true, Number.isNaN(test.lengthInDays()));
+        assertEquals(Number.POSITIVE_INFINITY, test.lengthInDays());
         assertEquals('-999999-01-01/-999999-01-03', test.toString());
     });
 
@@ -257,7 +257,7 @@ describe('org.threeten.extra.TestLocalDateRange', () => {
         assertEquals(false, test.isEmpty());
         assertEquals(true, test.isUnboundedStart());
         assertEquals(false, test.isUnboundedEnd());
-        assertEquals(true, Number.isNaN(test.lengthInDays()));
+        assertEquals(Number.POSITIVE_INFINITY, test.lengthInDays());
         assertEquals('-999999-01-01/-999999-01-04', test.toString());
     });
 
@@ -979,9 +979,9 @@ describe('org.threeten.extra.TestLocalDateRange', () => {
         assertEquals(2, LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_29).lengthInDays());
         assertEquals(1, LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_29).lengthInDays());
         assertEquals(0, LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_29).lengthInDays());
-        assertEquals(true, Number.isNaN(LocalDateRange.of(LocalDate.MIN, DATE_2012_07_29).lengthInDays()));
-        assertEquals(true, Number.isNaN(LocalDateRange.of(DATE_2012_07_29, LocalDate.MAX).lengthInDays()));
-        assertEquals(false, Number.isNaN(LocalDateRange.of(MINP1, MAXM1).lengthInDays()));
+        assertEquals(Number.POSITIVE_INFINITY, LocalDateRange.of(LocalDate.MIN, DATE_2012_07_29).lengthInDays());
+        assertEquals(Number.POSITIVE_INFINITY, LocalDateRange.of(DATE_2012_07_29, LocalDate.MAX).lengthInDays());
+        assertEquals(MINP1.daysUntil(MAXM1), LocalDateRange.of(MINP1, MAXM1).lengthInDays());
     });
 
     it('test_toPeriod', () => {

--- a/packages/extra/test/reference/OffsetDateTest.js
+++ b/packages/extra/test/reference/OffsetDateTest.js
@@ -37,6 +37,10 @@ import { OffsetDate } from '../../src/OffsetDate';
 
 import { MockSimplePeriod } from './MockSimplePeriod';
 
+import { _ as jodaInternal } from '@js-joda/core';
+
+const MathUtil = jodaInternal.MathUtil;
+
 describe('org.threeten.extra.TestOffsetDate', () => {
     const OFFSET_PONE = ZoneOffset.ofHours(1);
     const OFFSET_PTWO = ZoneOffset.ofHours(2);
@@ -351,7 +355,7 @@ describe('org.threeten.extra.TestOffsetDate', () => {
         });
 
         it('factory_of_ints_yearTooLow', () => {
-            assertThrows(DateTimeException, () => OffsetDate.of(Number.MIN_SAFE_INTEGER, 1, 1, OFFSET_PONE));
+            assertThrows(DateTimeException, () => OffsetDate.of(MathUtil.MIN_SAFE_INTEGER, 1, 1, OFFSET_PONE));
         });
 
         it('factory_of_ints_nullOffset', () => {
@@ -860,12 +864,12 @@ describe('org.threeten.extra.TestOffsetDate', () => {
 
         it('test_plusYears_long_invalidTooLargeMaxAddMax', () => {
             const test = OffsetDate.of(Year.MAX_VALUE, 12, 1, OFFSET_PONE);
-            assertThrows(DateTimeException, () => test.plusYears(Number.MAX_SAFE_INTEGER));
+            assertThrows(DateTimeException, () => test.plusYears(MathUtil.MAX_SAFE_INTEGER));
         });
 
         it('test_plusYears_long_invalidTooLargeMaxAddMin', () => {
             const test = OffsetDate.of(Year.MAX_VALUE, 12, 1, OFFSET_PONE);
-            assertThrows(DateTimeException, () => test.plusYears(Number.MIN_SAFE_INTEGER));
+            assertThrows(DateTimeException, () => test.plusYears(MathUtil.MIN_SAFE_INTEGER));
         });
 
         it('test_plusYears_long_invalidTooSmall', () => {
@@ -932,12 +936,12 @@ describe('org.threeten.extra.TestOffsetDate', () => {
 
         it('test_plusMonths_long_invalidTooLargeMaxAddMax', () => {
             const test = OffsetDate.of(Year.MAX_VALUE, 12, 1, OFFSET_PONE);
-            assertThrows(DateTimeException, () => test.plusMonths(Number.MAX_SAFE_INTEGER));
+            assertThrows(DateTimeException, () => test.plusMonths(MathUtil.MAX_SAFE_INTEGER));
         });
 
         it('test_plusMonths_long_invalidTooLargeMaxAddMin', () => {
             const test = OffsetDate.of(Year.MAX_VALUE, 12, 1, OFFSET_PONE);
-            assertThrows(DateTimeException, () => test.plusMonths(Number.MIN_SAFE_INTEGER));
+            assertThrows(DateTimeException, () => test.plusMonths(MathUtil.MIN_SAFE_INTEGER));
         });
 
         it('test_plusMonths_long_invalidTooSmall', () => {
@@ -1022,11 +1026,11 @@ describe('org.threeten.extra.TestOffsetDate', () => {
         });
 
         it('test_plusWeeks_invalidMaxMinusMax', () => {
-            assertThrows(ArithmeticException, () => OffsetDate.of(Year.MAX_VALUE, 12, 25, OFFSET_PONE).plusWeeks(Number.MAX_SAFE_INTEGER));
+            assertThrows(ArithmeticException, () => OffsetDate.of(Year.MAX_VALUE, 12, 25, OFFSET_PONE).plusWeeks(MathUtil.MAX_SAFE_INTEGER));
         });
 
         it('test_plusWeeks_invalidMaxMinusMin', () => {
-            assertThrows(ArithmeticException, () => OffsetDate.of(Year.MAX_VALUE, 12, 25, OFFSET_PONE).plusWeeks(Number.MIN_SAFE_INTEGER));
+            assertThrows(ArithmeticException, () => OffsetDate.of(Year.MAX_VALUE, 12, 25, OFFSET_PONE).plusWeeks(MathUtil.MIN_SAFE_INTEGER));
         });
     });
 
@@ -1107,11 +1111,11 @@ describe('org.threeten.extra.TestOffsetDate', () => {
         });
 
         it('test_plusDays_overflowTooLarge', () => {
-            assertThrows(ArithmeticException, () => OffsetDate.of(Year.MAX_VALUE, 12, 31, OFFSET_PONE).plusDays(Number.MAX_SAFE_INTEGER));
+            assertThrows(ArithmeticException, () => OffsetDate.of(Year.MAX_VALUE, 12, 31, OFFSET_PONE).plusDays(MathUtil.MAX_SAFE_INTEGER));
         });
 
         it('test_plusDays_overflowTooSmall', () => {
-            assertThrows(ArithmeticException, () => OffsetDate.of(Year.MIN_VALUE, 1, 1, OFFSET_PONE).plusDays(Number.MIN_SAFE_INTEGER));
+            assertThrows(ArithmeticException, () => OffsetDate.of(Year.MIN_VALUE, 1, 1, OFFSET_PONE).plusDays(MathUtil.MIN_SAFE_INTEGER));
         });
     });
 
@@ -1179,12 +1183,12 @@ describe('org.threeten.extra.TestOffsetDate', () => {
 
         it('test_minusYears_long_invalidTooLargeMaxAddMax', () => {
             const test = OffsetDate.of(Year.MAX_VALUE, 12, 1, OFFSET_PONE);
-            assertThrows(DateTimeException, () => test.minusYears(Number.MAX_SAFE_INTEGER));
+            assertThrows(DateTimeException, () => test.minusYears(MathUtil.MAX_SAFE_INTEGER));
         });
 
         it('test_minusYears_long_invalidTooLargeMaxAddMin', () => {
             const test = OffsetDate.of(Year.MAX_VALUE, 12, 1, OFFSET_PONE);
-            assertThrows(DateTimeException, () => test.minusYears(Number.MIN_SAFE_INTEGER));
+            assertThrows(DateTimeException, () => test.minusYears(MathUtil.MIN_SAFE_INTEGER));
         });
 
         it('test_minusYears_long_invalidTooSmall', () => {
@@ -1250,12 +1254,12 @@ describe('org.threeten.extra.TestOffsetDate', () => {
 
         it('test_minusMonths_long_invalidTooLargeMaxAddMax', () => {
             const test = OffsetDate.of(Year.MAX_VALUE, 12, 1, OFFSET_PONE);
-            assertThrows(DateTimeException, () => test.minusMonths(Number.MAX_SAFE_INTEGER));
+            assertThrows(DateTimeException, () => test.minusMonths(MathUtil.MAX_SAFE_INTEGER));
         });
 
         it('test_minusMonths_long_invalidTooLargeMaxAddMin', () => {
             const test = OffsetDate.of(Year.MAX_VALUE, 12, 1, OFFSET_PONE);
-            assertThrows(DateTimeException, () => test.minusMonths(Number.MIN_SAFE_INTEGER));
+            assertThrows(DateTimeException, () => test.minusMonths(MathUtil.MIN_SAFE_INTEGER));
         });
 
         it('test_minusMonths_long_invalidTooSmall', () => {
@@ -1341,11 +1345,11 @@ describe('org.threeten.extra.TestOffsetDate', () => {
         });
 
         it('test_minusWeeks_invalidMaxMinusMax', () => {
-            assertThrows(ArithmeticException, () => OffsetDate.of(Year.MAX_VALUE, 12, 25, OFFSET_PONE).minusWeeks(Number.MAX_SAFE_INTEGER));
+            assertThrows(ArithmeticException, () => OffsetDate.of(Year.MAX_VALUE, 12, 25, OFFSET_PONE).minusWeeks(MathUtil.MAX_SAFE_INTEGER));
         });
 
         it('test_minusWeeks_invalidMaxMinusMin', () => {
-            assertThrows(ArithmeticException, () => OffsetDate.of(Year.MAX_VALUE, 12, 25, OFFSET_PONE).minusWeeks(Number.MIN_SAFE_INTEGER));
+            assertThrows(ArithmeticException, () => OffsetDate.of(Year.MAX_VALUE, 12, 25, OFFSET_PONE).minusWeeks(MathUtil.MIN_SAFE_INTEGER));
         });
     });
 
@@ -1426,11 +1430,11 @@ describe('org.threeten.extra.TestOffsetDate', () => {
         });
 
         it('test_minusDays_overflowTooLarge', () => {
-            assertThrows(ArithmeticException, () => OffsetDate.of(Year.MAX_VALUE, 12, 31, OFFSET_PONE).minusDays(Number.MIN_SAFE_INTEGER));
+            assertThrows(ArithmeticException, () => OffsetDate.of(Year.MAX_VALUE, 12, 31, OFFSET_PONE).minusDays(MathUtil.MIN_SAFE_INTEGER));
         });
 
         it('test_minusDays_overflowTooSmall', () => {
-            assertThrows(ArithmeticException, () => OffsetDate.of(Year.MIN_VALUE, 1, 1, OFFSET_PONE).minusDays(Number.MAX_SAFE_INTEGER));
+            assertThrows(ArithmeticException, () => OffsetDate.of(Year.MIN_VALUE, 1, 1, OFFSET_PONE).minusDays(MathUtil.MAX_SAFE_INTEGER));
         });
     });
 

--- a/packages/extra/test/reference/YearWeekTest.js
+++ b/packages/extra/test/reference/YearWeekTest.js
@@ -34,6 +34,10 @@ import { assertEquals, assertFalse, assertThrows, assertTrue } from '../testUtil
 
 import { YearWeek } from '../../src/YearWeek';
 
+import { _ as jodaInternal } from '@js-joda/core';
+
+const MathUtil = jodaInternal.MathUtil;
+
 describe('org.threeten.extra.TestYearWeek', () => {
     const TEST_NON_LEAP = YearWeek.of(2014, 1);
     const TEST = YearWeek.of(2015, 1);
@@ -290,11 +294,11 @@ describe('org.threeten.extra.TestYearWeek', () => {
         });
 
         it('test_of_year_tooLow', () => {
-            assertThrows(DateTimeException, () => YearWeek.of(Number.MIN_SAFE_INTEGER, 1));
+            assertThrows(DateTimeException, () => YearWeek.of(MathUtil.MIN_SAFE_INTEGER, 1));
         });
 
         it('test_of_year_tooHigh', () => {
-            assertThrows(DateTimeException, () => YearWeek.of(Number.MAX_SAFE_INTEGER, 1));
+            assertThrows(DateTimeException, () => YearWeek.of(MathUtil.MAX_SAFE_INTEGER, 1));
         });
 
         it('test_of_invalidWeekValue', () => {
@@ -721,11 +725,11 @@ describe('org.threeten.extra.TestYearWeek', () => {
         });
 
         it('test_withYear_int_max', () => {
-            assertThrows(DateTimeException, () => TEST.withYear(Number.MAX_SAFE_INTEGER));
+            assertThrows(DateTimeException, () => TEST.withYear(MathUtil.MAX_SAFE_INTEGER));
         });
 
         it('test_withYear_int_min', () => {
-            assertThrows(DateTimeException, () => TEST.withYear(Number.MIN_SAFE_INTEGER));
+            assertThrows(DateTimeException, () => TEST.withYear(MathUtil.MIN_SAFE_INTEGER));
         });
     });
 
@@ -767,11 +771,11 @@ describe('org.threeten.extra.TestYearWeek', () => {
         });
 
         it('test_withWeek_int_max', () => {
-            assertThrows(DateTimeException, () => TEST.withWeek(Number.MAX_SAFE_INTEGER));
+            assertThrows(DateTimeException, () => TEST.withWeek(MathUtil.MAX_SAFE_INTEGER));
         });
 
         it('test_withWeek_int_min', () => {
-            assertThrows(DateTimeException, () => TEST.withWeek(Number.MIN_SAFE_INTEGER));
+            assertThrows(DateTimeException, () => TEST.withWeek(MathUtil.MIN_SAFE_INTEGER));
         });
     });
 
@@ -828,11 +832,11 @@ describe('org.threeten.extra.TestYearWeek', () => {
         });
 
         it('test_plusWeeks_max_long', () => {
-            assertThrows(ArithmeticException, () => TEST.plusWeeks(Number.MAX_SAFE_INTEGER));
+            assertThrows(ArithmeticException, () => TEST.plusWeeks(MathUtil.MAX_SAFE_INTEGER));
         });
 
         it('test_plusWeeks_min_long', () => {
-            assertThrows(ArithmeticException, () => TEST.plusWeeks(Number.MIN_SAFE_INTEGER));
+            assertThrows(ArithmeticException, () => TEST.plusWeeks(MathUtil.MIN_SAFE_INTEGER));
         });
     });
 
@@ -845,7 +849,7 @@ describe('org.threeten.extra.TestYearWeek', () => {
         });
 
         it('test_minus_overflow', () => {
-            assertThrows(ArithmeticException, () => TEST.minus(Number.MIN_SAFE_INTEGER, ChronoUnit.WEEKS));
+            assertThrows(ArithmeticException, () => TEST.minus(MathUtil.MIN_SAFE_INTEGER, ChronoUnit.WEEKS));
         });
     });
 
@@ -912,11 +916,11 @@ describe('org.threeten.extra.TestYearWeek', () => {
         });
 
         it('test_minWeeks_max_long', () => {
-            assertThrows(ArithmeticException, () => TEST.plusWeeks(Number.MAX_SAFE_INTEGER));
+            assertThrows(ArithmeticException, () => TEST.plusWeeks(MathUtil.MAX_SAFE_INTEGER));
         });
 
         it('test_minWeeks_min_long', () => {
-            assertThrows(ArithmeticException, () => TEST.plusWeeks(Number.MIN_SAFE_INTEGER));
+            assertThrows(ArithmeticException, () => TEST.plusWeeks(MathUtil.MIN_SAFE_INTEGER));
         });
     });
 


### PR DESCRIPTION
In case of unbounded ranges, `LocalDateRange.lengthInDays()` should return `Number.POSITIVE_INFINITY` instead of `Number.NaN`.

This also fixes #629.