### PR TITLE
core - sync homepage in package.json and bower.json

### DIFF
--- a/packages/core/bower.json
+++ b/packages/core/bower.json
@@ -12,7 +12,7 @@
     "time",
     "timezone"
   ],
-  "homepage": "https://github.com/js-joda/joda-js",
+  "homepage": "https://js-joda.github.io/js-joda",
   "ignore": [
     "**/.*",
     "node_modules",


### PR DESCRIPTION
Now "homepage" in `bower.json` is the same as in `package.json`