### PR TITLE
fix urls in timezone package

### DIFF
--- a/packages/timezone/bower.json
+++ b/packages/timezone/bower.json
@@ -11,7 +11,7 @@
     "time",
     "timezone"
   ],
-  "homepage": "https://github.com/js-joda/js-joda-timezone",
+  "homepage": "https://js-joda.github.io/js-joda",
   "ignore": [
     "**/.*",
     "node_modules",

--- a/packages/timezone/package.json
+++ b/packages/timezone/package.json
@@ -50,7 +50,7 @@
   },
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/js-joda/js-joda-timezone/issues"
+    "url": "https://github.com/js-joda/js-joda/issues"
   },
-  "homepage": "https://github.com/js-joda/js-joda-timezone#readme"
+  "homepage": "https://js-joda.github.io/js-joda"
 }


### PR DESCRIPTION
Now "homepage" and "bugs url" in `timezone` package leads to the current monorepo instead of the old repo.