### PR TITLE
add extra/Temporals

### DIFF
--- a/packages/core/src/js-joda.js
+++ b/packages/core/src/js-joda.js
@@ -59,6 +59,7 @@ import { ValueRange } from './temporal/ValueRange';
 import { DateTimeFormatter } from './format/DateTimeFormatter';
 import { DateTimeFormatterBuilder } from './format/DateTimeFormatterBuilder';
 import { DecimalStyle } from './format/DecimalStyle';
+import { ParsePosition } from './format/ParsePosition';
 import { ResolverStyle } from './format/ResolverStyle';
 import { SignStyle } from './format/SignStyle';
 import { TextStyle } from './format/TextStyle';
@@ -111,6 +112,7 @@ const jsJodaExports = {
     OffsetDateTime,
     Month,
     MonthDay,
+    ParsePosition,
     Period,
     Year,
     YearConstants,
@@ -179,6 +181,7 @@ export {
     OffsetTime,
     OffsetDateTime,
     Period,
+    ParsePosition,
     Year,
     YearConstants,
     YearMonth,

--- a/packages/core/src/temporal/IsoFields.js
+++ b/packages/core/src/temporal/IsoFields.js
@@ -812,7 +812,7 @@ class Unit extends TemporalUnit {
     }
 
     toString() {
-        return name;
+        return this._name;
     }
 }
 

--- a/packages/core/test/temporal/IsoFieldsTest.js
+++ b/packages/core/test/temporal/IsoFieldsTest.js
@@ -1,0 +1,44 @@
+import { expect } from 'chai';
+
+import '../_init';
+
+import { IsoFields, TemporalField, TemporalUnit } from '../../src/js-joda';
+
+describe('js-joda IsoFields', () => {
+    describe('toString', () => {
+        it('returns a string', () => {
+            for (const field of allIsoFields()) {
+                expect(field.toString()).to.be.string;
+            }
+            for (const field of allIsoUnits()) {
+                expect(field.toString()).to.be.string;
+            }
+        });
+    });
+});
+
+function allIsoFields() {
+    const fields = [];
+    for (const key in IsoFields) {
+        if (
+            Object.prototype.hasOwnProperty.call(IsoFields, key) &&
+            IsoFields[key] instanceof TemporalField
+        ) {
+            fields.push(IsoFields[key]);
+        }
+    }
+    return fields;
+}
+
+function allIsoUnits() {
+    const fields = [];
+    for (const key in IsoFields) {
+        if (
+            Object.prototype.hasOwnProperty.call(IsoFields, key) &&
+            IsoFields[key] instanceof TemporalUnit
+        ) {
+            fields.push(IsoFields[key]);
+        }
+    }
+    return fields;
+}

--- a/packages/extra/src/Temporals.js
+++ b/packages/extra/src/Temporals.js
@@ -1,5 +1,5 @@
 /**
- * @copyright (c) 2016, Philipp Thürwächter & Pattrick Hüper & Michał Sobkiewicz
+ * @copyright (c) 2015-present, Philipp Thürwächter & Pattrick Hüper & Michał Sobkiewicz
  * @copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos
  * @license BSD-3-Clause (see LICENSE in the root directory of this source tree)
  */

--- a/packages/extra/src/Temporals.js
+++ b/packages/extra/src/Temporals.js
@@ -1,0 +1,296 @@
+/**
+ * @copyright (c) 2016, Philipp Thürwächter & Pattrick Hüper & Michał Sobkiewicz
+ * @copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos
+ * @license BSD-3-Clause (see LICENSE in the root directory of this source tree)
+ */
+
+import { requireNonNull } from './assert';
+import { ChronoField, ChronoUnit, DateTimeException, DateTimeParseException, IsoFields, ParsePosition, TemporalAdjuster, UnsupportedTemporalTypeException } from '@js-joda/core';
+
+import { _ as jodaInternal } from '@js-joda/core';
+
+const MathUtil = jodaInternal.MathUtil;
+
+/**
+ * Additional utilities for working with temporal classes.
+ * 
+ * This includes:
+ * - adjusters that ignore Saturday/Sunday weekends
+ * - conversion between `TimeUnit` and `ChronoUnit`
+ * - converting an amount to another unit
+ *
+ */
+export class Temporals {
+    //-------------------------------------------------------------------------
+    /**
+     * Returns an adjuster that returns the next working day, ignoring Saturday and Sunday.
+     * 
+     * Some territories have weekends that do not consist of Saturday and Sunday.
+     * No implementation is supplied to support this, however an adjuster
+     * can be easily written to do so.
+     *
+     * @return {TemporalAdjuster} the next working day adjuster, not null
+     */
+    static nextWorkingDay() {
+        return Adjuster.NEXT_WORKING;
+    }
+
+    /**
+     * Returns an adjuster that returns the next working day or same day if already working day, ignoring Saturday and Sunday.
+     * 
+     * Some territories have weekends that do not consist of Saturday and Sunday.
+     * No implementation is supplied to support this, however an adjuster
+     * can be easily written to do so.
+     * 
+     * @return {TemporalAdjuster} the next working day or same adjuster, not null
+     */
+    static nextWorkingDayOrSame() {
+        return Adjuster.NEXT_WORKING_OR_SAME;
+    }
+
+    /**
+     * Returns an adjuster that returns the previous working day, ignoring Saturday and Sunday.
+     * 
+     * Some territories have weekends that do not consist of Saturday and Sunday.
+     * No implementation is supplied to support this, however an adjuster
+     * can be easily written to do so.
+     *
+     * @return {TemporalAdjuster} the previous working day adjuster, not null
+     */
+    static previousWorkingDay() {
+        return Adjuster.PREVIOUS_WORKING;
+    }
+
+    /**
+     * Returns an adjuster that returns the previous working day or same day if already working day, ignoring Saturday and Sunday.
+     * 
+     * Some territories have weekends that do not consist of Saturday and Sunday.
+     * No implementation is supplied to support this, however an adjuster
+     * can be easily written to do so.
+     * 
+     * @return {TemporalAdjuster} the previous working day or same adjuster, not null
+     */
+    static previousWorkingDayOrSame() {
+        return Adjuster.PREVIOUS_WORKING_OR_SAME;
+    }
+
+    //-------------------------------------------------------------------------
+    /**
+     * Parses the text using one of the formatters.
+     * 
+     * This will try each formatter in turn, attempting to fully parse the specified text.
+     * The temporal query is typically a method reference to a `from(TemporalAccessor)` method.
+     * For example:
+     * ```
+     *  LocalDateTime dt = Temporals.parseFirstMatching(str, LocalDateTime.FROM, fm1, fm2, fm3);
+     * ```
+     * If the parse completes without reading the entire length of the text,
+     * or a problem occurs during parsing or merging, then an exception is thrown.
+     *
+     * @param {string} text  the text to parse, not null
+     * @param {TemporalQuery} query  the query defining the type to parse to, not null
+     * @param {DateTimeFormatter[]} formatters  the formatters to try, not null
+     * @return {*} the parsed date-time, not null
+     * @throws {DateTimeParseException} if unable to parse the requested result
+     */
+    static parseFirstMatching(text, query, ...formatters) {
+        requireNonNull(text, 'text');
+        requireNonNull(query, 'query');
+        requireNonNull(formatters, 'formatters');
+        if (formatters.length === 0) {
+            throw new DateTimeParseException('No formatters specified', text, 0);
+        }
+        if (formatters.length === 1) {
+            return formatters[0].parse(text, query);
+        }
+        for (const formatter of formatters) {
+            try {
+                const pp = new ParsePosition(0);
+                formatter.parseUnresolved(text, pp);
+                const len = text.length;
+                if (pp.getErrorIndex() === -1 && pp.getIndex() === len) {
+                    return formatter.parse(text, query);
+                }
+            } catch (ignored) {
+                // should not happen, but ignore if it does
+            }
+        }
+        throw new DateTimeParseException(`Text '${text}' could not be parsed`, text, 0);
+    }
+
+    //-------------------------------------------------------------------------
+    /**
+     * Converts an amount from one unit to another.
+     * 
+     * This works on the units in `ChronoUnit` and `IsoFields`.
+     * The `DAYS` and `WEEKS` units are handled as exact multiple of 24 hours.
+     * The `ERAS` and `FOREVER` units are not supported.
+     *
+     * @param {long} amount  the input amount in terms of the `fromUnit`
+     * @param {TemporalUnit} fromUnit  the unit to convert from, not null
+     * @param {TemporalUnit} toUnit  the unit to convert to, not null
+     * @return {long[]} the conversion array,
+     *  element 0 is the signed whole number,
+     *  element 1 is the signed remainder in terms of the input unit,
+     *  not null
+     * @throws DateTimeException if the units cannot be converted
+     * @throws UnsupportedTemporalTypeException if the units are not supported
+     * @throws ArithmeticException if numeric overflow occurs
+     */
+    static convertAmount(amount, fromUnit, toUnit) {
+        requireNonNull(fromUnit, 'fromUnit');
+        requireNonNull(toUnit, 'toUnit');
+        Temporals._validateUnit(fromUnit);
+        Temporals._validateUnit(toUnit);
+        if (fromUnit === toUnit) {
+            return [amount, 0];
+        }
+        // precise-based
+        if (Temporals._isPrecise(fromUnit) && Temporals._isPrecise(toUnit)) {
+            const fromNanos = fromUnit.duration().toNanos();
+            const toNanos = toUnit.duration().toNanos();
+            if (fromNanos > toNanos) {
+                const multiple = MathUtil.intDiv(fromNanos, toNanos);
+                return [MathUtil.safeMultiply(amount, multiple), 0];
+            } else {
+                const multiple = MathUtil.intDiv(toNanos, fromNanos);
+                return [MathUtil.intDiv(amount, multiple), MathUtil.intMod(amount, multiple)];
+            }
+        }
+        // month-based
+        const fromMonthFactor = Temporals._monthMonthFactor(fromUnit, fromUnit, toUnit);
+        const toMonthFactor = Temporals._monthMonthFactor(toUnit, fromUnit, toUnit);
+        if (fromMonthFactor > toMonthFactor) {
+            const multiple = MathUtil.intDiv(fromMonthFactor, toMonthFactor);
+            return [MathUtil.safeMultiply(amount, multiple), 0];
+        } else {
+            const multiple = MathUtil.intDiv(toMonthFactor, fromMonthFactor);
+            return [MathUtil.intDiv(amount, multiple), MathUtil.intMod(amount, multiple)];
+        }
+    }
+
+    /**
+     * 
+     * @param {TemporalUnit} unit
+     * @private
+     */
+    static _validateUnit(unit) {
+        if (unit instanceof ChronoUnit) {
+            if (unit === ChronoUnit.ERAS || unit === ChronoUnit.FOREVER) {
+                throw new UnsupportedTemporalTypeException(`Unsupported TemporalUnit: ${unit}`);
+            }
+        } else if (unit !== IsoFields.QUARTER_YEARS) {
+            throw new UnsupportedTemporalTypeException(`Unsupported TemporalUnit: ${unit}`);
+        }
+    }
+
+    /**
+     * 
+     * @param {TemporalUnit} unit
+     * @return {boolean}
+     * @private
+     */
+    static _isPrecise(unit) {
+        return unit instanceof ChronoUnit && unit.compareTo(ChronoUnit.WEEKS) <= 0;
+    }
+
+    /**
+     * 
+     * @param {TemporalUnit} unit
+     * @param {TemporalUnit} fromUnit
+     * @param {TemporalUnit} toUnit
+     * @return {int}
+     * @private
+     */
+    static _monthMonthFactor(unit, fromUnit, toUnit) {
+        if (unit instanceof ChronoUnit) {
+            switch (unit) {
+                case ChronoUnit.MONTHS:
+                    return 1;
+                case ChronoUnit.YEARS:
+                    return 12;
+                case ChronoUnit.DECADES:
+                    return 120;
+                case ChronoUnit.CENTURIES:
+                    return 1200;
+                case ChronoUnit.MILLENNIA:
+                    return 12000;
+                default:
+                    throw new DateTimeException(`Unable to convert between units: ${fromUnit} to ${toUnit}`);
+            }
+        }
+        return 3; // quarters
+    }
+
+    /**
+     * Restricted constructor.
+     * 
+     * @private
+     */
+    constructor() {
+    }
+}
+
+const Adjuster = {};
+
+export function _init() {
+    /** Next working day adjuster. */
+    Adjuster.NEXT_WORKING = new class extends TemporalAdjuster {
+        adjustInto(temporal) {
+            const dow = temporal.get(ChronoField.DAY_OF_WEEK);
+            switch (dow) {
+                case 6:  // Saturday
+                    return temporal.plus(2, ChronoUnit.DAYS);
+                case 5:  // Friday
+                    return temporal.plus(3, ChronoUnit.DAYS);
+                default:
+                    return temporal.plus(1, ChronoUnit.DAYS);
+            }
+        }
+    };
+
+    /** Previous working day adjuster. */
+    Adjuster.PREVIOUS_WORKING = new class extends TemporalAdjuster {
+        adjustInto(temporal) {
+            const dow = temporal.get(ChronoField.DAY_OF_WEEK);
+            switch (dow) {
+                case 1:  // Monday
+                    return temporal.minus(3, ChronoUnit.DAYS);
+                case 7:  // Sunday
+                    return temporal.minus(2, ChronoUnit.DAYS);
+                default:
+                    return temporal.minus(1, ChronoUnit.DAYS);
+            }
+        }
+    };
+
+    /** Next working day or same adjuster. */
+    Adjuster.NEXT_WORKING_OR_SAME = new class extends TemporalAdjuster {
+        adjustInto(temporal) {
+            const dow = temporal.get(ChronoField.DAY_OF_WEEK);
+            switch (dow) {
+                case 6: // Saturday
+                    return temporal.plus(2, ChronoUnit.DAYS);
+                case 7: // Sunday
+                    return temporal.plus(1, ChronoUnit.DAYS);
+                default:
+                    return temporal;
+            }
+        }
+    };
+
+    /** Previous working day or same adjuster. */
+    Adjuster.PREVIOUS_WORKING_OR_SAME = new class extends TemporalAdjuster {
+        adjustInto(temporal) {
+            const dow = temporal.get(ChronoField.DAY_OF_WEEK);
+            switch (dow) {
+                case 6: //Saturday
+                    return temporal.minus(1, ChronoUnit.DAYS);
+                case 7:  // Sunday
+                    return temporal.minus(2, ChronoUnit.DAYS);
+                default:
+                    return temporal;
+            }
+        }
+    };
+}

--- a/packages/extra/src/_init.js
+++ b/packages/extra/src/_init.js
@@ -9,6 +9,7 @@ import { _init as intervalInit } from './Interval';
 import { _init as localDateRangeInit } from './LocalDateRange';
 import { _init as offsetDateInit } from './OffsetDate';
 import { _init as quarterInit } from './Quarter';
+import { _init as temporalsInit } from './Temporals';
 import { _init as yearQuarterInit } from './YearQuarter';
 import { _init as yearWeekInit } from './YearWeek';
 
@@ -27,6 +28,7 @@ function init() {
     localDateRangeInit();
     offsetDateInit();
     quarterInit();
+    temporalsInit();
     yearQuarterInit();
     yearWeekInit();
 }

--- a/packages/extra/src/js-joda-extra.js
+++ b/packages/extra/src/js-joda-extra.js
@@ -11,6 +11,7 @@ import { Interval } from './Interval';
 import { LocalDateRange } from './LocalDateRange';
 import { OffsetDate } from './OffsetDate';
 import { Quarter } from './Quarter';
+import { Temporals } from './Temporals';
 import { YearQuarter } from './YearQuarter';
 import { YearWeek } from './YearWeek';
 import plug from './plug';
@@ -24,6 +25,7 @@ export {
     LocalDateRange,
     OffsetDate,
     Quarter,
+    Temporals,
     YearQuarter,
     YearWeek,
 };

--- a/packages/extra/src/plug.js
+++ b/packages/extra/src/plug.js
@@ -9,6 +9,7 @@
 // import { LocalDateRange } from './LocalDateRange';
 // import { OffsetDate } from './OffsetDate';
 // import { Quarter } from './Quarter';
+// import { Temporals } from './Temporals';
 // import { YearQuarter } from './YearQuarter';
 // import { YearWeek } from './YearWeek';
 
@@ -27,6 +28,7 @@ export default function (/* jsJoda */) {
     // jsJoda.LocalDateRange = LocalDateRange;
     // jsJoda.OffsetDate = OffsetDate;
     // jsJoda.Quarter = Quarter;
+    // jsJoda.Temporals = Temporals;
     // jsJoda.YearQuarter = YearQuarter;
     // jsJoda.YearWeek = YearWeek;
 }

--- a/packages/extra/test/reference/TemporalsTest.js
+++ b/packages/extra/test/reference/TemporalsTest.js
@@ -39,7 +39,7 @@ describe('org.threeten.extra.TestTemporals', () => {
                     assertTrue(test.isAfter(date));
                     assertNotEquals(DayOfWeek.SATURDAY, test.dayOfWeek());
                     assertNotEquals(DayOfWeek.SUNDAY, test.dayOfWeek());
-    
+
                     switch (date.dayOfWeek()) {
                         case DayOfWeek.FRIDAY:
                         case DayOfWeek.SATURDAY:
@@ -48,7 +48,7 @@ describe('org.threeten.extra.TestTemporals', () => {
                         default:
                             assertEquals(date.dayOfWeek().plus(1), test.dayOfWeek());
                     }
-    
+
                     if (test.year() === 2007) {
                         const dayDiff = test.dayOfYear() - date.dayOfYear();
                         switch (date.dayOfWeek()) {
@@ -92,7 +92,7 @@ describe('org.threeten.extra.TestTemporals', () => {
                     const test = Temporals.nextWorkingDayOrSame().adjustInto(date);
                     assertNotEquals(DayOfWeek.SATURDAY, test.dayOfWeek());
                     assertNotEquals(DayOfWeek.SUNDAY, test.dayOfWeek());
-    
+
                     switch (date.dayOfWeek()) {
                         case DayOfWeek.SATURDAY:
                         case DayOfWeek.SUNDAY:
@@ -101,7 +101,7 @@ describe('org.threeten.extra.TestTemporals', () => {
                         default:
                             assertEquals(date.dayOfWeek(), test.dayOfWeek());
                     }
-    
+
                     if (test.year() === 2007) {
                         const dayDiff = test.dayOfYear() - date.dayOfYear();
                         switch (date.dayOfWeek()) {
@@ -146,7 +146,7 @@ describe('org.threeten.extra.TestTemporals', () => {
                     assertTrue(test.isBefore(date));
                     assertNotEquals(DayOfWeek.SATURDAY, test.dayOfWeek());
                     assertNotEquals(DayOfWeek.SUNDAY, test.dayOfWeek());
-    
+
                     switch (date.dayOfWeek()) {
                         case DayOfWeek.MONDAY:
                         case DayOfWeek.SUNDAY:
@@ -155,7 +155,7 @@ describe('org.threeten.extra.TestTemporals', () => {
                         default:
                             assertEquals(date.dayOfWeek().minus(1), test.dayOfWeek());
                     }
-    
+
                     if (test.year() === 2007) {
                         const dayDiff = test.dayOfYear() - date.dayOfYear();
                         switch (date.dayOfWeek()) {
@@ -199,7 +199,7 @@ describe('org.threeten.extra.TestTemporals', () => {
                     const test = Temporals.previousWorkingDayOrSame().adjustInto(date);
                     assertNotEquals(DayOfWeek.SATURDAY, test.dayOfWeek());
                     assertNotEquals(DayOfWeek.SUNDAY, test.dayOfWeek());
-    
+
                     switch (date.dayOfWeek()) {
                         case DayOfWeek.SATURDAY:
                         case DayOfWeek.SUNDAY:
@@ -208,7 +208,7 @@ describe('org.threeten.extra.TestTemporals', () => {
                         default:
                             assertEquals(date.dayOfWeek(), test.dayOfWeek());
                     }
-    
+
                     if (test.year() === 2007) {
                         const dayDiff = test.dayOfYear() - date.dayOfYear();
                         switch (date.dayOfWeek()) {

--- a/packages/extra/test/reference/TemporalsTest.js
+++ b/packages/extra/test/reference/TemporalsTest.js
@@ -22,7 +22,7 @@ import { _ as jodaInternal } from '@js-joda/core';
 
 const MathUtil = jodaInternal.MathUtil;
 
-import { assertEquals, assertFalse, assertThrows, assertTrue } from '../testUtils';
+import { assertEquals, assertNotEquals, assertThrows, assertTrue } from '../testUtils';
 
 import { Temporals } from '../../src/Temporals';
 
@@ -37,8 +37,8 @@ describe('org.threeten.extra.TestTemporals', () => {
                     const date = LocalDate.of(2007, month, i);
                     const test = Temporals.nextWorkingDay().adjustInto(date);
                     assertTrue(test.isAfter(date));
-                    assertFalse(test.dayOfWeek().equals(DayOfWeek.SATURDAY));
-                    assertFalse(test.dayOfWeek().equals(DayOfWeek.SUNDAY));
+                    assertNotEquals(DayOfWeek.SATURDAY, test.dayOfWeek());
+                    assertNotEquals(DayOfWeek.SUNDAY, test.dayOfWeek());
     
                     switch (date.dayOfWeek()) {
                         case DayOfWeek.FRIDAY:
@@ -90,13 +90,13 @@ describe('org.threeten.extra.TestTemporals', () => {
                 for (let i = 1; i <= month.length(false); i++) {
                     const date = LocalDate.of(2007, month, i);
                     const test = Temporals.nextWorkingDayOrSame().adjustInto(date);
-                    assertFalse(test.dayOfWeek().equals(DayOfWeek.SATURDAY));
-                    assertFalse(test.dayOfWeek().equals(DayOfWeek.SUNDAY));
+                    assertNotEquals(DayOfWeek.SATURDAY, test.dayOfWeek());
+                    assertNotEquals(DayOfWeek.SUNDAY, test.dayOfWeek());
     
                     switch (date.dayOfWeek()) {
                         case DayOfWeek.SATURDAY:
                         case DayOfWeek.SUNDAY:
-                            assertEquals(test.dayOfWeek(), DayOfWeek.MONDAY);
+                            assertEquals(DayOfWeek.MONDAY, test.dayOfWeek());
                             break;
                         default:
                             assertEquals(date.dayOfWeek(), test.dayOfWeek());
@@ -106,18 +106,18 @@ describe('org.threeten.extra.TestTemporals', () => {
                         const dayDiff = test.dayOfYear() - date.dayOfYear();
                         switch (date.dayOfWeek()) {
                             case DayOfWeek.SATURDAY:
-                                assertEquals(dayDiff, 2);
+                                assertEquals(2, dayDiff);
                                 break;
                             case DayOfWeek.SUNDAY:
-                                assertEquals(dayDiff, 1);
+                                assertEquals(1, dayDiff);
                                 break;
                             default:
-                                assertEquals(dayDiff, 0);
+                                assertEquals(0, dayDiff);
                         }
                     } else {
-                        assertEquals(test.year(), 2008);
-                        assertEquals(test.month(), Month.JANUARY);
-                        assertEquals(test.dayOfMonth(), 1);
+                        assertEquals(2008, test.year());
+                        assertEquals(Month.JANUARY, test.month());
+                        assertEquals(1, test.dayOfMonth());
                     }
                 }
             }
@@ -144,8 +144,8 @@ describe('org.threeten.extra.TestTemporals', () => {
                     const date = LocalDate.of(2007, month, i);
                     const test = Temporals.previousWorkingDay().adjustInto(date);
                     assertTrue(test.isBefore(date));
-                    assertFalse(test.dayOfWeek().equals(DayOfWeek.SATURDAY));
-                    assertFalse(test.dayOfWeek().equals(DayOfWeek.SUNDAY));
+                    assertNotEquals(DayOfWeek.SATURDAY, test.dayOfWeek());
+                    assertNotEquals(DayOfWeek.SUNDAY, test.dayOfWeek());
     
                     switch (date.dayOfWeek()) {
                         case DayOfWeek.MONDAY:
@@ -197,13 +197,13 @@ describe('org.threeten.extra.TestTemporals', () => {
                 for (let i = 1; i <= month.length(false); i++) {
                     const date = LocalDate.of(2007, month, i);
                     const test = Temporals.previousWorkingDayOrSame().adjustInto(date);
-                    assertFalse(test.dayOfWeek().equals(DayOfWeek.SATURDAY));
-                    assertFalse(test.dayOfWeek().equals(DayOfWeek.SUNDAY));
+                    assertNotEquals(DayOfWeek.SATURDAY, test.dayOfWeek());
+                    assertNotEquals(DayOfWeek.SUNDAY, test.dayOfWeek());
     
                     switch (date.dayOfWeek()) {
                         case DayOfWeek.SATURDAY:
                         case DayOfWeek.SUNDAY:
-                            assertEquals(test.dayOfWeek(), DayOfWeek.FRIDAY);
+                            assertEquals(DayOfWeek.FRIDAY, test.dayOfWeek());
                             break;
                         default:
                             assertEquals(date.dayOfWeek(), test.dayOfWeek());
@@ -213,18 +213,18 @@ describe('org.threeten.extra.TestTemporals', () => {
                         const dayDiff = test.dayOfYear() - date.dayOfYear();
                         switch (date.dayOfWeek()) {
                             case DayOfWeek.SATURDAY:
-                                assertEquals(dayDiff, -1);
+                                assertEquals(-1, dayDiff);
                                 break;
                             case DayOfWeek.SUNDAY:
-                                assertEquals(dayDiff, -2);
+                                assertEquals(-2, dayDiff);
                                 break;
                             default:
-                                assertEquals(dayDiff, 0);
+                                assertEquals(0, dayDiff);
                         }
                     } else {
-                        assertEquals(test.year(), 2006);
-                        assertEquals(test.month(), Month.DECEMBER);
-                        assertEquals(test.dayOfMonth(), 29);
+                        assertEquals(2006, test.year());
+                        assertEquals(Month.DECEMBER, test.month());
+                        assertEquals(29, test.dayOfMonth());
                     }
                 }
             }

--- a/packages/extra/test/reference/TemporalsTest.js
+++ b/packages/extra/test/reference/TemporalsTest.js
@@ -1,0 +1,518 @@
+/*
+ * @copyright (c) 2022, Philipp Thürwächter & Pattrick Hüper & Michał Sobkiewicz
+ * @copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos
+ * @license BSD-3-Clause (see LICENSE in the root directory of this source tree)
+ */
+
+import {
+    ChronoUnit,
+    DateTimeException,
+    DateTimeFormatter,
+    DateTimeParseException,
+    DayOfWeek,
+    IsoFields,
+    LocalDate,
+    Month,
+    UnsupportedTemporalTypeException,
+} from '@js-joda/core';
+
+import '../_init';
+
+import { _ as jodaInternal } from '@js-joda/core';
+
+const MathUtil = jodaInternal.MathUtil;
+
+import { assertEquals, assertFalse, assertThrows, assertTrue } from '../testUtils';
+
+import { Temporals } from '../../src/Temporals';
+
+describe('org.threeten.extra.TestTemporals', () => {
+    //-----------------------------------------------------------------------
+    // nextWorkingDay()
+    //-----------------------------------------------------------------------
+    describe('nextWorkingDay()', () => {
+        it('test_nextWorkingDay', () => {
+            for (const month of Month.values()) {
+                for (let i = 1; i <= month.length(false); i++) {
+                    const date = LocalDate.of(2007, month, i);
+                    const test = Temporals.nextWorkingDay().adjustInto(date);
+                    assertTrue(test.isAfter(date));
+                    assertFalse(test.dayOfWeek().equals(DayOfWeek.SATURDAY));
+                    assertFalse(test.dayOfWeek().equals(DayOfWeek.SUNDAY));
+    
+                    switch (date.dayOfWeek()) {
+                        case DayOfWeek.FRIDAY:
+                        case DayOfWeek.SATURDAY:
+                            assertEquals(DayOfWeek.MONDAY, test.dayOfWeek());
+                            break;
+                        default:
+                            assertEquals(date.dayOfWeek().plus(1), test.dayOfWeek());
+                    }
+    
+                    if (test.year() === 2007) {
+                        const dayDiff = test.dayOfYear() - date.dayOfYear();
+                        switch (date.dayOfWeek()) {
+                            case DayOfWeek.FRIDAY:
+                                assertEquals(3, dayDiff);
+                                break;
+                            case DayOfWeek.SATURDAY:
+                                assertEquals(2, dayDiff);
+                                break;
+                            default:
+                                assertEquals(1, dayDiff);
+                        }
+                    } else {
+                        assertEquals(2008, test.year());
+                        assertEquals(Month.JANUARY, test.month());
+                        assertEquals(1, test.dayOfMonth());
+                    }
+                }
+            }
+        });
+
+        it('test_nextWorkingDay_yearChange', () => {
+            const friday = LocalDate.of(2010, Month.DECEMBER, 31);
+            const test1 = Temporals.nextWorkingDay().adjustInto(friday);
+            assertEquals(LocalDate.of(2011, Month.JANUARY, 3), test1);
+
+            const saturday = LocalDate.of(2011, Month.DECEMBER, 31);
+            const test2 = Temporals.nextWorkingDay().adjustInto(saturday);
+            assertEquals(LocalDate.of(2012, Month.JANUARY, 2), test2);
+        });
+    });
+
+    //-----------------------------------------------------------------------
+    // nextWorkingDayOrSame()
+    //-----------------------------------------------------------------------
+    describe('nextWorkingDayOrSame()', () => {
+        it('test_nextWorkingDayOrSame', () => {
+            for (const month of Month.values()) {
+                for (let i = 1; i <= month.length(false); i++) {
+                    const date = LocalDate.of(2007, month, i);
+                    const test = Temporals.nextWorkingDayOrSame().adjustInto(date);
+                    assertFalse(test.dayOfWeek().equals(DayOfWeek.SATURDAY));
+                    assertFalse(test.dayOfWeek().equals(DayOfWeek.SUNDAY));
+    
+                    switch (date.dayOfWeek()) {
+                        case DayOfWeek.SATURDAY:
+                        case DayOfWeek.SUNDAY:
+                            assertEquals(test.dayOfWeek(), DayOfWeek.MONDAY);
+                            break;
+                        default:
+                            assertEquals(date.dayOfWeek(), test.dayOfWeek());
+                    }
+    
+                    if (test.year() === 2007) {
+                        const dayDiff = test.dayOfYear() - date.dayOfYear();
+                        switch (date.dayOfWeek()) {
+                            case DayOfWeek.SATURDAY:
+                                assertEquals(dayDiff, 2);
+                                break;
+                            case DayOfWeek.SUNDAY:
+                                assertEquals(dayDiff, 1);
+                                break;
+                            default:
+                                assertEquals(dayDiff, 0);
+                        }
+                    } else {
+                        assertEquals(test.year(), 2008);
+                        assertEquals(test.month(), Month.JANUARY);
+                        assertEquals(test.dayOfMonth(), 1);
+                    }
+                }
+            }
+        });
+
+        it('test_nextWorkingDayOrSame_yearChange', () => {
+            const saturday = LocalDate.of(2016, Month.DECEMBER, 31);
+            const test1 = Temporals.nextWorkingDayOrSame().adjustInto(saturday);
+            assertEquals(LocalDate.of(2017, Month.JANUARY, 2), test1);
+
+            const sunday = LocalDate.of(2017, Month.DECEMBER, 31);
+            const test2 = Temporals.nextWorkingDayOrSame().adjustInto(sunday);
+            assertEquals(LocalDate.of(2018, Month.JANUARY, 1), test2);
+        });
+    });
+
+    //-----------------------------------------------------------------------
+    // previousWorkingDay()
+    //-----------------------------------------------------------------------
+    describe('previousWorkingDay()', () => {
+        it('test_previousWorkingDay', () => {
+            for (const month of Month.values()) {
+                for (let i = 1; i <= month.length(false); i++) {
+                    const date = LocalDate.of(2007, month, i);
+                    const test = Temporals.previousWorkingDay().adjustInto(date);
+                    assertTrue(test.isBefore(date));
+                    assertFalse(test.dayOfWeek().equals(DayOfWeek.SATURDAY));
+                    assertFalse(test.dayOfWeek().equals(DayOfWeek.SUNDAY));
+    
+                    switch (date.dayOfWeek()) {
+                        case DayOfWeek.MONDAY:
+                        case DayOfWeek.SUNDAY:
+                            assertEquals(DayOfWeek.FRIDAY, test.dayOfWeek());
+                            break;
+                        default:
+                            assertEquals(date.dayOfWeek().minus(1), test.dayOfWeek());
+                    }
+    
+                    if (test.year() === 2007) {
+                        const dayDiff = test.dayOfYear() - date.dayOfYear();
+                        switch (date.dayOfWeek()) {
+                            case DayOfWeek.MONDAY:
+                                assertEquals(-3, dayDiff);
+                                break;
+                            case DayOfWeek.SUNDAY:
+                                assertEquals(-2, dayDiff);
+                                break;
+                            default:
+                                assertEquals(-1, dayDiff);
+                        }
+                    } else {
+                        assertEquals(2006, test.year());
+                        assertEquals(Month.DECEMBER, test.month());
+                        assertEquals(29, test.dayOfMonth());
+                    }
+                }
+            }
+        });
+
+        it('test_previousWorkingDay_yearChange', () => {
+            const monday = LocalDate.of(2011, Month.JANUARY, 3);
+            const test1 = Temporals.previousWorkingDay().adjustInto(monday);
+            assertEquals(LocalDate.of(2010, Month.DECEMBER, 31), test1);
+
+            const sunday = LocalDate.of(2011, Month.JANUARY, 2);
+            const test2 = Temporals.previousWorkingDay().adjustInto(sunday);
+            assertEquals(LocalDate.of(2010, Month.DECEMBER, 31), test2);
+        });
+    });
+
+    //-----------------------------------------------------------------------
+    // previousWorkingDayOrSame()
+    //-----------------------------------------------------------------------
+    describe('previousWorkingDayOrSame()', () => {
+        it('test_previousWorkingDayOrSame', () => {
+            for (const month of Month.values()) {
+                for (let i = 1; i <= month.length(false); i++) {
+                    const date = LocalDate.of(2007, month, i);
+                    const test = Temporals.previousWorkingDayOrSame().adjustInto(date);
+                    assertFalse(test.dayOfWeek().equals(DayOfWeek.SATURDAY));
+                    assertFalse(test.dayOfWeek().equals(DayOfWeek.SUNDAY));
+    
+                    switch (date.dayOfWeek()) {
+                        case DayOfWeek.SATURDAY:
+                        case DayOfWeek.SUNDAY:
+                            assertEquals(test.dayOfWeek(), DayOfWeek.FRIDAY);
+                            break;
+                        default:
+                            assertEquals(date.dayOfWeek(), test.dayOfWeek());
+                    }
+    
+                    if (test.year() === 2007) {
+                        const dayDiff = test.dayOfYear() - date.dayOfYear();
+                        switch (date.dayOfWeek()) {
+                            case DayOfWeek.SATURDAY:
+                                assertEquals(dayDiff, -1);
+                                break;
+                            case DayOfWeek.SUNDAY:
+                                assertEquals(dayDiff, -2);
+                                break;
+                            default:
+                                assertEquals(dayDiff, 0);
+                        }
+                    } else {
+                        assertEquals(test.year(), 2006);
+                        assertEquals(test.month(), Month.DECEMBER);
+                        assertEquals(test.dayOfMonth(), 29);
+                    }
+                }
+            }
+        });
+
+        it('test_previousWorkingDayOrSame_yearChange', () => {
+            const sunday = LocalDate.of(2011, Month.JANUARY, 2);
+            const test1 = Temporals.previousWorkingDayOrSame().adjustInto(sunday);
+            assertEquals(LocalDate.of(2010, Month.DECEMBER, 31), test1);
+
+            const saturday = LocalDate.of(2011, Month.JANUARY, 1);
+            const test2 = Temporals.previousWorkingDayOrSame().adjustInto(saturday);
+            assertEquals(LocalDate.of(2010, Month.DECEMBER, 31), test2);
+        });
+    });
+
+    //-----------------------------------------------------------------------
+    // parseFirstMatching()
+    //-----------------------------------------------------------------------
+    describe('parseFirstMatching()', () => {
+        const data_parseFirstMatching = [
+            ['2016-09-06', DateTimeFormatter.ISO_LOCAL_DATE, DateTimeFormatter.ISO_LOCAL_DATE_TIME],
+            ['2016-09-06T00:00:00', DateTimeFormatter.ISO_LOCAL_DATE, DateTimeFormatter.ISO_LOCAL_DATE_TIME],
+        ];
+
+        it('test_parseFirstMatching', () => {
+            for (const [text, fmt1, fmt2] of data_parseFirstMatching) {
+                assertEquals(LocalDate.of(2016, 9, 6), Temporals.parseFirstMatching(text, LocalDate.FROM, fmt1, fmt2));
+            }
+        });
+
+        it('test_parseFirstMatching_zero', () => {
+            assertThrows(DateTimeParseException, () => Temporals.parseFirstMatching('2016-09-06', LocalDate.FROM));
+        });
+
+        it('test_parseFirstMatching_one', () => {
+            assertEquals(LocalDate.of(2016, 9, 6), Temporals.parseFirstMatching('2016-09-06', LocalDate.FROM, DateTimeFormatter.ISO_LOCAL_DATE));
+        });
+
+        it('test_parseFirstMatching_twoNoMatch', () => {
+            assertThrows(DateTimeParseException, () => Temporals.parseFirstMatching('2016', LocalDate.FROM, DateTimeFormatter.ISO_LOCAL_DATE, DateTimeFormatter.BASIC_ISO_DATE));
+        });
+    });
+
+    //-----------------------------------------------------------------------
+    // convertAmount()
+    //-------------------------------------------------------------------------
+    describe('convertAmount()', () => {
+        const data_convertAmount = [
+            [2, ChronoUnit.NANOS, ChronoUnit.SECONDS, 0, 2],
+            [999999999, ChronoUnit.NANOS, ChronoUnit.SECONDS, 0, 999999999],
+            [1000000000, ChronoUnit.NANOS, ChronoUnit.SECONDS, 1, 0],
+            [1000000001, ChronoUnit.NANOS, ChronoUnit.SECONDS, 1, 1],
+
+            [2, ChronoUnit.NANOS, ChronoUnit.MINUTES, 0, 2],
+            [59999999999, ChronoUnit.NANOS, ChronoUnit.MINUTES, 0, 59999999999],
+            [60000000000, ChronoUnit.NANOS, ChronoUnit.MINUTES, 1, 0],
+            [60000000001, ChronoUnit.NANOS, ChronoUnit.MINUTES, 1, 1],
+
+            [2, ChronoUnit.NANOS, ChronoUnit.HOURS, 0, 2],
+            [3599999999999, ChronoUnit.NANOS, ChronoUnit.HOURS, 0, 3599999999999],
+            [3600000000000, ChronoUnit.NANOS, ChronoUnit.HOURS, 1, 0],
+            [3600000000001, ChronoUnit.NANOS, ChronoUnit.HOURS, 1, 1],
+
+            [2, ChronoUnit.NANOS, ChronoUnit.HALF_DAYS, 0, 2],
+            [3600000000000 * 12 * 3, ChronoUnit.NANOS, ChronoUnit.HALF_DAYS, 3, 0],
+
+            [2, ChronoUnit.NANOS, ChronoUnit.DAYS, 0, 2],
+            [3600000000000 * 24 * 3, ChronoUnit.NANOS, ChronoUnit.DAYS, 3, 0],
+
+            [2, ChronoUnit.NANOS, ChronoUnit.WEEKS, 0, 2],
+            [3600000000000 * 24 * 7 * 3, ChronoUnit.NANOS, ChronoUnit.WEEKS, 3, 0],
+
+            [2, ChronoUnit.SECONDS, ChronoUnit.MINUTES, 0, 2],
+            [59, ChronoUnit.SECONDS, ChronoUnit.MINUTES, 0, 59],
+            [60, ChronoUnit.SECONDS, ChronoUnit.MINUTES, 1, 0],
+            [61, ChronoUnit.SECONDS, ChronoUnit.MINUTES, 1, 1],
+
+            [2, ChronoUnit.SECONDS, ChronoUnit.HOURS, 0, 2],
+            [3599, ChronoUnit.SECONDS, ChronoUnit.HOURS, 0, 3599],
+            [3600, ChronoUnit.SECONDS, ChronoUnit.HOURS, 1, 0],
+            [3601, ChronoUnit.SECONDS, ChronoUnit.HOURS, 1, 1],
+
+            [2, ChronoUnit.SECONDS, ChronoUnit.HALF_DAYS, 0, 2],
+            [3600 * 12 * 3, ChronoUnit.SECONDS, ChronoUnit.HALF_DAYS, 3, 0],
+
+            [2, ChronoUnit.SECONDS, ChronoUnit.DAYS, 0, 2],
+            [3600 * 24 * 3, ChronoUnit.SECONDS, ChronoUnit.DAYS, 3, 0],
+
+            [2, ChronoUnit.SECONDS, ChronoUnit.WEEKS, 0, 2],
+            [3600 * 24 * 7 * 3, ChronoUnit.SECONDS, ChronoUnit.WEEKS, 3, 0],
+
+            [2, ChronoUnit.MINUTES, ChronoUnit.HOURS, 0, 2],
+            [59, ChronoUnit.MINUTES, ChronoUnit.HOURS, 0, 59],
+            [60, ChronoUnit.MINUTES, ChronoUnit.HOURS, 1, 0],
+            [61, ChronoUnit.MINUTES, ChronoUnit.HOURS, 1, 1],
+
+            [2, ChronoUnit.MINUTES, ChronoUnit.HALF_DAYS, 0, 2],
+            [60 * 12 * 3 + 1, ChronoUnit.MINUTES, ChronoUnit.HALF_DAYS, 3, 1],
+
+            [2, ChronoUnit.MINUTES, ChronoUnit.DAYS, 0, 2],
+            [60 * 24 * 3 + 1, ChronoUnit.MINUTES, ChronoUnit.DAYS, 3, 1],
+
+            [2, ChronoUnit.MINUTES, ChronoUnit.WEEKS, 0, 2],
+            [60 * 24 * 7 * 3 + 1, ChronoUnit.MINUTES, ChronoUnit.WEEKS, 3, 1],
+
+            [2, ChronoUnit.HOURS, ChronoUnit.HALF_DAYS, 0, 2],
+            [12 * 3 + 1, ChronoUnit.HOURS, ChronoUnit.HALF_DAYS, 3, 1],
+
+            [2, ChronoUnit.HOURS, ChronoUnit.DAYS, 0, 2],
+            [24 * 3 + 1, ChronoUnit.HOURS, ChronoUnit.DAYS, 3, 1],
+
+            [2, ChronoUnit.HOURS, ChronoUnit.WEEKS, 0, 2],
+            [24 * 7 * 3 + 1, ChronoUnit.HOURS, ChronoUnit.WEEKS, 3, 1],
+
+            [1, ChronoUnit.HALF_DAYS, ChronoUnit.DAYS, 0, 1],
+            [2 * 3 + 1, ChronoUnit.HALF_DAYS, ChronoUnit.DAYS, 3, 1],
+
+            [1, ChronoUnit.HALF_DAYS, ChronoUnit.WEEKS, 0, 1],
+            [2 * 7 * 3 + 1, ChronoUnit.HALF_DAYS, ChronoUnit.WEEKS, 3, 1],
+
+            [1, ChronoUnit.DAYS, ChronoUnit.WEEKS, 0, 1],
+            [7 * 3 + 1, ChronoUnit.DAYS, ChronoUnit.WEEKS, 3, 1],
+
+            [2, ChronoUnit.SECONDS, ChronoUnit.NANOS, 2000000000, 0],
+            [2, ChronoUnit.MINUTES, ChronoUnit.NANOS, 2000000000 * 60, 0],
+            [2, ChronoUnit.HOURS, ChronoUnit.NANOS, 2000000000 * 3600, 0],
+            [2, ChronoUnit.HALF_DAYS, ChronoUnit.NANOS, 2000000000 * 3600 * 12, 0],
+            [2, ChronoUnit.DAYS, ChronoUnit.NANOS, 2000000000 * 3600 * 24, 0],
+            [2, ChronoUnit.WEEKS, ChronoUnit.NANOS, 2000000000 * 3600 * 24 * 7, 0],
+
+            [2, ChronoUnit.MINUTES, ChronoUnit.SECONDS, 2 * 60, 0],
+            [2, ChronoUnit.HOURS, ChronoUnit.SECONDS, 2 * 3600, 0],
+            [2, ChronoUnit.HALF_DAYS, ChronoUnit.SECONDS, 2 * 3600 * 12, 0],
+            [2, ChronoUnit.DAYS, ChronoUnit.SECONDS, 2 * 3600 * 24, 0],
+            [2, ChronoUnit.WEEKS, ChronoUnit.SECONDS, 2 * 3600 * 24 * 7, 0],
+
+            [2, ChronoUnit.HOURS, ChronoUnit.MINUTES, 2 * 60, 0],
+            [2, ChronoUnit.HALF_DAYS, ChronoUnit.MINUTES, 2 * 60 * 12, 0],
+            [2, ChronoUnit.DAYS, ChronoUnit.MINUTES, 2 * 60 * 24, 0],
+            [2, ChronoUnit.WEEKS, ChronoUnit.MINUTES, 2 * 60 * 24 * 7, 0],
+
+            [2, ChronoUnit.HALF_DAYS, ChronoUnit.HOURS, 2 * 12, 0],
+            [2, ChronoUnit.DAYS, ChronoUnit.HOURS, 2 * 24, 0],
+            [2, ChronoUnit.WEEKS, ChronoUnit.HOURS, 2 * 24 * 7, 0],
+
+            [2, ChronoUnit.DAYS, ChronoUnit.HALF_DAYS, 2 * 2, 0],
+            [2, ChronoUnit.WEEKS, ChronoUnit.HALF_DAYS, 2 * 2 * 7, 0],
+
+            [2, ChronoUnit.WEEKS, ChronoUnit.DAYS, 2 * 7, 0],
+
+            [2 * 3 + 1, ChronoUnit.MONTHS, IsoFields.QUARTER_YEARS, 2, 1],
+            [2 * 12 + 1, ChronoUnit.MONTHS, ChronoUnit.YEARS, 2, 1],
+            [2 * 120 + 1, ChronoUnit.MONTHS, ChronoUnit.DECADES, 2, 1],
+            [2 * 1200 + 1, ChronoUnit.MONTHS, ChronoUnit.CENTURIES, 2, 1],
+            [2 * 12000 + 1, ChronoUnit.MONTHS, ChronoUnit.MILLENNIA, 2, 1],
+
+            [2 * 4 + 1, IsoFields.QUARTER_YEARS, ChronoUnit.YEARS, 2, 1],
+            [2 * 40 + 1, IsoFields.QUARTER_YEARS, ChronoUnit.DECADES, 2, 1],
+            [2 * 400 + 1, IsoFields.QUARTER_YEARS, ChronoUnit.CENTURIES, 2, 1],
+            [2 * 4000 + 1, IsoFields.QUARTER_YEARS, ChronoUnit.MILLENNIA, 2, 1],
+
+            [2 * 10 + 1, ChronoUnit.YEARS, ChronoUnit.DECADES, 2, 1],
+            [2 * 100 + 1, ChronoUnit.YEARS, ChronoUnit.CENTURIES, 2, 1],
+            [2 * 1000 + 1, ChronoUnit.YEARS, ChronoUnit.MILLENNIA, 2, 1],
+
+            [2 * 10 + 1, ChronoUnit.DECADES, ChronoUnit.CENTURIES, 2, 1],
+            [2 * 100 + 1, ChronoUnit.DECADES, ChronoUnit.MILLENNIA, 2, 1],
+
+            [2 * 10 + 1, ChronoUnit.CENTURIES, ChronoUnit.MILLENNIA, 2, 1],
+
+            [2, IsoFields.QUARTER_YEARS, ChronoUnit.MONTHS, 2 * 3, 0],
+            [2, ChronoUnit.YEARS, ChronoUnit.MONTHS, 2 * 12, 0],
+            [2, ChronoUnit.DECADES, ChronoUnit.MONTHS, 2 * 120, 0],
+            [2, ChronoUnit.CENTURIES, ChronoUnit.MONTHS, 2 * 1200, 0],
+            [2, ChronoUnit.MILLENNIA, ChronoUnit.MONTHS, 2 * 12000, 0],
+
+            [2, ChronoUnit.YEARS, IsoFields.QUARTER_YEARS, 2 * 4, 0],
+            [2, ChronoUnit.DECADES, IsoFields.QUARTER_YEARS, 2 * 40, 0],
+            [2, ChronoUnit.CENTURIES, IsoFields.QUARTER_YEARS, 2 * 400, 0],
+            [2, ChronoUnit.MILLENNIA, IsoFields.QUARTER_YEARS, 2 * 4000, 0],
+
+            [2, ChronoUnit.DECADES, ChronoUnit.YEARS, 2 * 10, 0],
+            [2, ChronoUnit.CENTURIES, ChronoUnit.YEARS, 2 * 100, 0],
+            [2, ChronoUnit.MILLENNIA, ChronoUnit.YEARS, 2 * 1000, 0],
+
+            [2, ChronoUnit.CENTURIES, ChronoUnit.DECADES, 2 * 10, 0],
+            [2, ChronoUnit.MILLENNIA, ChronoUnit.DECADES, 2 * 100, 0],
+
+            [2, ChronoUnit.MILLENNIA, ChronoUnit.CENTURIES, 2 * 10, 0],
+        ];
+
+        const chronoUnitValues = [
+            ChronoUnit.NANOS,
+            ChronoUnit.MICROS,
+            ChronoUnit.MILLIS,
+            ChronoUnit.SECONDS,
+            ChronoUnit.MINUTES,
+            ChronoUnit.HOURS,
+            ChronoUnit.HALF_DAYS,
+            ChronoUnit.DAYS,
+            ChronoUnit.WEEKS,
+            ChronoUnit.MONTHS,
+            ChronoUnit.YEARS,
+            ChronoUnit.DECADES,
+            ChronoUnit.CENTURIES,
+            ChronoUnit.MILLENNIA,
+            ChronoUnit.ERAS,
+            ChronoUnit.FOREVER,
+        ];
+
+        it('test_convertAmount()', () => {
+            for (const [fromAmount, fromUnit, resultUnit, resultWhole, resultRemainder] of data_convertAmount) {
+                const result = Temporals.convertAmount(fromAmount, fromUnit, resultUnit);
+                assertEquals(resultWhole, result[0]);
+                assertEquals(resultRemainder, result[1]);
+            }
+        });
+
+        it('test_convertAmount_negative', () => {
+            for (const [fromAmount, fromUnit, resultUnit, resultWhole, resultRemainder] of data_convertAmount) {
+                const result = Temporals.convertAmount(-fromAmount, fromUnit, resultUnit);
+                assertEquals(MathUtil.safeZero(-resultWhole), result[0]);
+                assertEquals(MathUtil.safeZero(-resultRemainder), result[1]);
+            }
+        });
+
+        it('test_convertAmountSameUnit_zero', () => {
+            for (const unit of chronoUnitValues) {
+                if (unit !== ChronoUnit.ERAS && unit !== ChronoUnit.FOREVER) {
+                    const result = Temporals.convertAmount(0, unit, unit);
+                    assertEquals(0, result[0]);
+                    assertEquals(0, result[1]);
+                }
+            }
+        });
+
+        it('test_convertAmountSameUnit_nonZero', () => {
+            for (const unit of chronoUnitValues) {
+                if (unit !== ChronoUnit.ERAS && unit !== ChronoUnit.FOREVER) {
+                    const result = Temporals.convertAmount(2, unit, unit);
+                    assertEquals(2, result[0]);
+                    assertEquals(0, result[1]);
+                }
+            }
+        });
+
+        const data_convertAmountInvalid = [
+            [ChronoUnit.SECONDS, ChronoUnit.MONTHS],
+            [ChronoUnit.SECONDS, IsoFields.QUARTER_YEARS],
+            [ChronoUnit.SECONDS, ChronoUnit.YEARS],
+            [ChronoUnit.SECONDS, ChronoUnit.DECADES],
+            [ChronoUnit.SECONDS, ChronoUnit.CENTURIES],
+            [ChronoUnit.SECONDS, ChronoUnit.MILLENNIA],
+
+            [ChronoUnit.MONTHS, ChronoUnit.SECONDS],
+            [IsoFields.QUARTER_YEARS, ChronoUnit.SECONDS],
+            [ChronoUnit.YEARS, ChronoUnit.SECONDS],
+            [ChronoUnit.DECADES, ChronoUnit.SECONDS],
+            [ChronoUnit.CENTURIES, ChronoUnit.SECONDS],
+            [ChronoUnit.MILLENNIA, ChronoUnit.SECONDS],
+        ];
+
+        it('test_convertAmountInvalid', () => {
+            for (const [fromUnit, resultUnit] of data_convertAmountInvalid) {
+                assertThrows(DateTimeException, () => Temporals.convertAmount(1, fromUnit, resultUnit));
+            }
+        });
+
+        const data_convertAmountInvalidUnsupported = [
+            [ChronoUnit.SECONDS, ChronoUnit.ERAS],
+            [ChronoUnit.ERAS, ChronoUnit.SECONDS],
+            [ChronoUnit.YEARS, ChronoUnit.ERAS],
+            [ChronoUnit.ERAS, ChronoUnit.YEARS],
+
+            [ChronoUnit.SECONDS, ChronoUnit.FOREVER],
+            [ChronoUnit.FOREVER, ChronoUnit.SECONDS],
+            [ChronoUnit.YEARS, ChronoUnit.FOREVER],
+            [ChronoUnit.FOREVER, ChronoUnit.YEARS],
+
+            [ChronoUnit.FOREVER, ChronoUnit.ERAS],
+            [ChronoUnit.ERAS, ChronoUnit.FOREVER],
+        ];
+
+        it('test_convertAmountInvalidUnsupported', () => {
+            for (const [fromUnit, resultUnit] of data_convertAmountInvalidUnsupported) {
+                assertThrows(UnsupportedTemporalTypeException, () => Temporals.convertAmount(1, fromUnit, resultUnit));
+            }
+        });
+    });
+});

--- a/packages/extra/test/testUtils.js
+++ b/packages/extra/test/testUtils.js
@@ -27,6 +27,20 @@ export function assertEquals(expected, actual, message) {
     }
 }
 
+export function assertNotEquals(expected, actual, message) {
+    if (expected != null || actual != null) {
+        if (expected != null) {
+            if (typeof expected.equals === 'function') {
+                expect(expected.equals(actual), message != null ? message : `${expected} equals ${actual}`).to.be.false;
+            } else {
+                expect(expected, message).to.not.eql(actual);
+            }
+        } else {
+            expect(actual).to.be.not.null;
+        }
+    }
+}
+
 export function assertSame(expected, actual, message) {
     expect(expected === actual, message != null ? message : `${expected} !== ${actual}`).to.be.true;
 }

--- a/packages/extra/test/typescript_definitions/js-joda-extra-tests.ts
+++ b/packages/extra/test/typescript_definitions/js-joda-extra-tests.ts
@@ -21,7 +21,9 @@ import {
     OffsetDateTime,
     LocalTime,
     Period,
+    TemporalAdjuster,
 } from '@js-joda/core'
+import { expect } from 'chai';
 import {
     DayOfMonth,
     DayOfYear,
@@ -30,7 +32,8 @@ import {
     OffsetDate,
     YearQuarter,
     YearWeek,
-    LocalDateRange
+    LocalDateRange,
+    Temporals
 } from '../../';
 
 // See packages/core/test/typescript_definitions/js-joda-tests.ts for an explanation of these tests.
@@ -259,6 +262,15 @@ function test_Quarter() {
     expectType<ValueRange>(quarter.range(IsoFields.QUARTER_OF_YEAR));
     expectType<string>(quarter.toString());
     expectType<number>(quarter.value());
+}
+
+function test_Temporals() {
+    expectType<TemporalAdjuster>(Temporals.nextWorkingDay());
+    expectType<TemporalAdjuster>(Temporals.nextWorkingDayOrSame());
+    expectType<TemporalAdjuster>(Temporals.previousWorkingDay());
+    expectType<TemporalAdjuster>(Temporals.previousWorkingDayOrSame());
+    expectType<LocalDate>(Temporals.parseFirstMatching('2016-09-06', LocalDate.FROM, DateTimeFormatter.ISO_LOCAL_DATE, DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+    expectType<number[]>(Temporals.convertAmount(1, ChronoUnit.HOURS, ChronoUnit.SECONDS));
 }
 
 function test_YearQuarter() {

--- a/packages/extra/typings/js-joda-extra.d.ts
+++ b/packages/extra/typings/js-joda-extra.d.ts
@@ -211,6 +211,17 @@ export class Quarter extends TemporalAccessor implements TemporalAdjuster {
     value(): number;
 }
 
+export class Temporals {
+    static nextWorkingDay(): TemporalAdjuster;
+    static nextWorkingDayOrSame(): TemporalAdjuster;
+    static previousWorkingDay(): TemporalAdjuster;
+    static previousWorkingDayOrSame(): TemporalAdjuster;
+    static parseFirstMatching<T>(text: string, query: TemporalQuery<T>, ...formatters: DateTimeFormatter[]): T;
+    static convertAmount(amount: number, fromUnit: TemporalUnit, toUnit: TemporalUnit): number[];
+
+    private constructor();
+}
+
 export class YearQuarter extends Temporal {
     static from(temporal: TemporalAccessor): YearQuarter;
     static now(zoneIdOrClock?: ZoneId | Clock): YearQuarter;


### PR DESCRIPTION
I was looking for `Temporals` today (`nextWorkingDayOrSame()` in particular), but found nothing. Here it is then.

Implemented:
- nextWorkingDay()
- nextWorkingDayOrSame()
- previousWorkingDay()
- previousWorkingDayOrSame()
- parseFirstMatching(text, query, ...formatters)
- convertAmount(amount, fromUnit, toUnit)

Missing:
- chronoUnit(timeUnit)
- timeUnit(chronoUnit)
- duration{From,To}Double
- multiply

`chronoUnit` and `timeUnit` were ommitted as there is no `TimeUnit`, thus no need for conversion.

`duration{From,To}Double` and `multiply` are ommitted until someone asks for them. Without `BigDecimal`, they are not so easy to implement.