### PR TITLE
introduce Date$

### DIFF
--- a/packages/core/src/Date_.js
+++ b/packages/core/src/Date_.js
@@ -1,0 +1,37 @@
+/*
+ * @copyright (c) 2015-present, Philipp Thürwächter, Pattrick Hüper & js-joda contributors
+ * @license BSD-3-Clause (see LICENSE in the root directory of this source tree)
+ */
+
+import { requireInstance, requireNonNull } from './assert';
+import { Instant } from './js-joda';
+
+export class Date$ {
+    /**
+     * Convert an `Instant` object to a `Date`.
+     * @param {!Instant} instant - an `Instant` object
+     * @returns {Date} a `Date` object corresponding to given `instant`
+     */
+    static from(instant) {
+        requireNonNull(instant, 'instant');
+        requireInstance(instant, Instant, 'instant');
+        return new Date(instant.toEpochMilli());
+    }
+
+    /**
+     * Converts a `Date` object to an `Instant`.
+     * @param {!Date} date - a `Date`
+     * @returns {Instant} - an `Instant` corresponding to given `date`
+     */
+    static toInstant(date) {
+        requireNonNull(date, 'date');
+        requireInstance(date, Date, 'date');
+        return Instant.ofEpochMilli(date.getTime());
+    }
+
+    /**
+     * @private
+     */
+    constructor() {
+    }
+}

--- a/packages/core/src/js-joda.js
+++ b/packages/core/src/js-joda.js
@@ -78,6 +78,8 @@ import * as assert from './assert';
 
 import { convert } from './convert';
 import { nativeJs } from './nativeJs';
+import { Date$ } from './Date_';
+
 import { bindUse } from './use';
 
 const _ = {
@@ -94,6 +96,7 @@ const jsJodaExports = {
     _,
     convert,
     nativeJs,
+    Date$,
     ArithmeticException,
     DateTimeException,
     DateTimeParseException,
@@ -162,6 +165,7 @@ export {
     use,
     convert,
     nativeJs,
+    Date$,
     ArithmeticException,
     DateTimeException,
     DateTimeParseException,

--- a/packages/core/test/Date_Test.js
+++ b/packages/core/test/Date_Test.js
@@ -1,0 +1,50 @@
+/*
+ * @copyright (c) 2015-present, Philipp Thürwächter, Pattrick Hüper & js-joda contributors
+ * @license BSD-3-Clause (see LICENSE in the root directory of this source tree)
+ */
+
+import { expect } from 'chai';
+
+import './_init';
+
+import { Instant } from '../src/Instant';
+import { Date$ } from '../src/Date_';
+import { IllegalArgumentException, NullPointerException } from '../src/errors';
+
+describe('Date$', () => {
+    it('.from(Instant) should convert Instant to Date', () => {
+        for (const epochMilli of [0, 1000, 60 * 1000, 60 * 1000, 24 * 60 * 60 * 1000]) {
+            const instant = Instant.ofEpochMilli(epochMilli);
+            const date = Date$.from(instant);
+            expect(date).to.be.instanceOf(Date);
+            expect(date.getTime()).to.equal(epochMilli);
+        }
+    });
+
+    it('.from(Instant) should throw IAE when called with !Instant', () => {
+        expect(() => Date$.from(0)).to.throw(IllegalArgumentException);
+    });
+
+    it('.from(Instant) should throw NPE when called with null or undefined', () => {
+        expect(() => Date$.from(null)).to.throw(NullPointerException);
+        expect(() => Date$.from(undefined)).to.throw(NullPointerException);
+    });
+
+    it('.toInstant(Date) should convert Date to Instant', () => {
+        for (const epochMilli of [0, 1000, 60 * 1000, 60 * 1000, 24 * 60 * 60 * 1000]) {
+            const date = new Date(epochMilli);
+            const instant = Date$.toInstant(date);
+            expect(instant).to.be.instanceOf(Instant);
+            expect(instant.toEpochMilli()).to.equal(epochMilli);
+        }
+    });
+
+    it('.toInstant(Date) should throw IAE when called with !Date', () => {
+        expect(() => Date$.toInstant(0)).to.throw(IllegalArgumentException);
+    });
+
+    it('.toInstant(Date) should throw NPE when called with null or undefined', () => {
+        expect(() => Date$.toInstant(null)).to.throw(NullPointerException);
+        expect(() => Date$.toInstant(undefined)).to.throw(NullPointerException);
+    });
+});

--- a/packages/core/typings/js-joda.d.ts
+++ b/packages/core/typings/js-joda.d.ts
@@ -2488,6 +2488,12 @@ export function convert(
     toEpochMilli: () => number;
 };
 
+export class Date$ {
+    static fromInstant(instant: Instant): Date;
+    static toInstant(date: Date): Instant;
+    private constructor();
+}
+
 export function use(plugin: Function): any;
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
This PR introduces `Date$` class with two static methods:
- `Date$.from(Instant): Date`,
- `Date$.toInstant(Date): Instant`.

They are meant as a replacement for `nativeJs()` and `convert()` which probably should be deprecated. It's very easy to get `Instant` from temporals like `ZoneDateTime` and `OffsetDateTime` and easy enough from `LocalDate`.

I believe it's more beneficial to make clear that `Date` (as a timestamp) corresponds almost 1:1 to `Instant` (marks point on the timeline with similar precision and no notion of time zone) than to pretend, that temporals like `LocalDate` have unambiguous representation as a `Date` (even when time-zone is provided).

Naming is based on:
- https://docs.oracle.com/javase/8/docs/api/java/util/Date.html#from-java.time.Instant-
- https://docs.oracle.com/javase/8/docs/api/java/util/Date.html#toInstant--

If one needs momentjs support, this naming convention suggests `moment$.from(Instant): Moment` and `moment$.toInstant(Moment): Date`, which is - i hope - clear and consistent.

If this PR makes it's way to main, documentation needs to be updated (deprecation of `nativeJs()` and `convert()` + rewrite of convert-native.md).

As always, I'm open for discussion.

Happy New Year!