### PR TITLE
fix and simplify nativeJs implementation

### DIFF
--- a/packages/core/src/nativeJs.js
+++ b/packages/core/src/nativeJs.js
@@ -4,7 +4,6 @@
  */
 
 import { requireNonNull } from './assert';
-import { IllegalArgumentException } from './errors';
 import { Instant, ZoneId } from './js-joda';
 
 /**
@@ -16,12 +15,5 @@ import { Instant, ZoneId } from './js-joda';
 export function nativeJs(date, zone = ZoneId.systemDefault()) {
     requireNonNull(date, 'date');
     requireNonNull(zone, 'zone');
-    switch (date.constructor.name) {
-        case 'Date':
-            return Instant.ofEpochMilli(date.getTime()).atZone(zone);
-        case 'Moment':
-            return Instant.ofEpochMilli(date.valueOf()).atZone(zone);
-        default:
-            throw new IllegalArgumentException('date must be a javascript Date or a moment instance');
-    }
+    return Instant.ofEpochMilli(date.valueOf()).atZone(zone);
 }


### PR DESCRIPTION
1. Switching by constructor name can break code that are using certain bundlers.

2. Both `Date` and `Moment` provide primitive conversion with `valueOf()`.
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/valueOf
- https://momentjs.com/docs/#/displaying/unix-timestamp-milliseconds/

It turns out that there is no need for any conditional constructs.