### PR TITLE
simplify nativeJs implementation

### DIFF
--- a/packages/core/src/nativeJs.js
+++ b/packages/core/src/nativeJs.js
@@ -4,7 +4,6 @@
  */
 
 import { requireNonNull } from './assert';
-import { IllegalArgumentException } from './errors';
 import { Instant, ZoneId } from './js-joda';
 
 /**
@@ -16,10 +15,5 @@ import { Instant, ZoneId } from './js-joda';
 export function nativeJs(date, zone = ZoneId.systemDefault()) {
     requireNonNull(date, 'date');
     requireNonNull(zone, 'zone');
-    if(date instanceof Date) {
-        return Instant.ofEpochMilli(date.getTime()).atZone(zone);
-    } else if(typeof date.toDate === 'function' &&  date.toDate() instanceof Date) {
-        return Instant.ofEpochMilli(date.valueOf()).atZone(zone);
-    }
-    throw new IllegalArgumentException('date must be a javascript Date or a moment instance');
+    return Instant.ofEpochMilli(date.valueOf()).atZone(zone);
 }


### PR DESCRIPTION
Both `Date` and `Moment` provide primitive conversion with `valueOf()`.

- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/valueOf
- https://momentjs.com/docs/#/displaying/unix-timestamp-milliseconds/

It turns out that there is no need for any conditional constructs.