### PR TITLE
augment Date

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ## Why yet another JavaScript date and time library?
 
-- Popular JavaScript date libraries like [moment](https://momentjs.com/) or [date-utils](https://github.com/continuouscalendar/dateutils) are **wrappers** around the native JavaScript `Date` object, providing syntactic sugar. The native `Date` object always consist of a date, time and a timezone part. In contrast, js-joda is a **standalone** date and time implementation.
+- Popular JavaScript date libraries like [moment](https://momentjs.com/) or [date-utils](https://github.com/continuouscalendar/dateutils) are **wrappers** around the native JavaScript `Date` object, providing syntactic sugar. In contrast, js-joda is a **standalone** date and time implementation.
 
 - The API has a **domain-driven design** with classes for each of the different use cases, like `LocalDate`, `ZonedDateTime` or `Period`. For example, `LocalDate` allows you to handle dates without times (like birthdays or holidays) in a clean and error-safe way, especially if these dates are persisted to an external server.
 
@@ -36,15 +36,17 @@
 
 ### Dates and Times
 
-- **LocalDate** represents a date without a time and timezone in the ISO-8601 calendar system, such as 2007-12-24.
+- **LocalDate** represents a date without a timezone in the ISO-8601 calendar system, such as 2007-12-24.
 
-- **LocalTime** represents a time without timezone in the ISO-8601 calendar system such as '11:55:00'.
+- **LocalTime** represents a time without a timezone in the ISO-8601 calendar system, such as 16:15:30.
 
-- **LocalDateTime** is a description of the date (LocalDate), as used for birthdays, combined with the local time (LocalTime) as seen on a wall clock.
+- **LocalDateTime** represents a date-time without a timezone in the ISO-8601 calendar system, such as 2007-12-24T16:15:30.
 
-- **ZonedDateTime** is a date-time with a timezone in the ISO-8601 calendar system, such as 2007-12-24T16:15:30+01:00 UTC+01:00.
+- **OffsetDateTime** is a date-time with a offset in the ISO-8601 calendar system, such as 2007-12-24T16:15:30+01:00.
 
-- **Instant** is an instantaneous point on the time-line measured from the epoch of _1970-01-01T00:00:00Z_ in epoch-seconds and nanosecond-of-second.
+- **ZonedDateTime** is a date-time with a timezone in the ISO-8601 calendar system, such as 2007-12-24T16:15:30+01:00[Europe/London].
+
+- **Instant** is an instantaneous point on the time-line measured from the epoch (1970-01-01T00:00:00Z) in epoch-seconds and nanosecond-of-second.
 
 ### Duration and Period
 

--- a/esdoc.json
+++ b/esdoc.json
@@ -31,6 +31,7 @@
             "./esdoc/manual/formatting.md",
             "./esdoc/manual/Locale.md",
             "./esdoc/manual/customizing.md",
+            "./esdoc/manual/convert.md",
             "./esdoc/manual/convert-native.md"
           ]
         }

--- a/esdoc/manual/convert-native.md
+++ b/esdoc/manual/convert-native.md
@@ -1,4 +1,10 @@
-# Convert from/ to native js
+# Convert from/to native js (deprecated)
+
+## Deprecation notice
+
+`nativeJs` and `convert` are deprecated in favor of `Date.from(instant)` and `date.toInstant()`.
+
+See the preferred way to [convert from/to Date](convert.html).
 
 ## Convert from Date to a js-joda temporal
 

--- a/esdoc/manual/convert.md
+++ b/esdoc/manual/convert.md
@@ -1,0 +1,32 @@
+# Convert from/to Date
+
+## Date -> Instant
+
+To convert `Date` to `Instant`, use `date.toInstant()`.
+
+```javascript
+const date = new Date();
+const instant = date.toInstant();
+```
+
+Add `ZoneId` and you will be able to easily obtain any other `Temporal`.
+
+```javascript
+const zonedDateTime = instant.atZone(ZoneId.systemDefault());
+```
+
+## Instant -> Date
+
+To convert `Instant` to `Date`, use `Date.from(instant)`.
+
+```javascript
+const instant = Instant.now();
+const date = Date.from(instant);
+```
+
+Note that most of `Temporal`s  can be converted to `Instant` in a single step.
+
+```javascript
+const zonedDateTime = ZonedDateTime.now();
+const instant = zonedDateTime.toInstant();
+```

--- a/packages/core/src/Date.js
+++ b/packages/core/src/Date.js
@@ -1,0 +1,17 @@
+/*
+ * @copyright (c) 2016-present, Philipp Thürwächter & Pattrick Hüper & js-joda contributors
+ * @license BSD-3-Clause (see LICENSE in the root directory of this source tree)
+ */
+
+import { Instant } from './Instant';
+import { requireInstance, requireNonNull } from './assert';
+
+Date.from = function(instant) {
+    requireNonNull(instant, 'instant');
+    requireInstance(instant, Instant, 'instant');
+    return new Date(instant.toEpochMilli());
+};
+
+Date.prototype.toInstant = function() {
+    return Instant.ofEpochMilli(this.getTime());
+};

--- a/packages/core/src/_init.js
+++ b/packages/core/src/_init.js
@@ -3,6 +3,8 @@
  * @license BSD-3-Clause (see LICENSE in the root directory of this source tree)
  */
 
+import './Date';
+
 import { _init as ZoneOffsetInit } from './ZoneOffset';
 import { _init as DayOfWeekInit } from './DayOfWeek';
 import { _init as DurationInit } from './Duration';

--- a/packages/core/src/convert.js
+++ b/packages/core/src/convert.js
@@ -81,6 +81,7 @@ class ToNativeJsConverter {
  * @param {!(LocalDate|LocalDateTime|ZonedDateTime)} temporal - a joda temporal instance
  * @param {ZoneId} [zone] - the zone of the temporal
  * @returns {ToNativeJsConverter}
+ * @deprecated Use `Date.from(Instant)` instead.
  */
 export function convert(temporal, zone){
     return new ToNativeJsConverter(temporal, zone);

--- a/packages/core/src/nativeJs.js
+++ b/packages/core/src/nativeJs.js
@@ -12,6 +12,7 @@ import { Instant, ZoneId } from './js-joda';
  * @param {!(Date|moment)} date - a javascript Date or a moment instance
  * @param {ZoneId} [zone = ZoneId.systemDefault()] - the zone of the returned ZonedDateTime, defaults to ZoneId.systemDefault()
  * @returns {ZonedDateTime}
+ * @deprecated Use `date.toInstant()` instead.
  */
 export function nativeJs(date, zone = ZoneId.systemDefault()) {
     requireNonNull(date, 'date');

--- a/packages/core/test/DateTest.js
+++ b/packages/core/test/DateTest.js
@@ -1,0 +1,20 @@
+/*
+ * @copyright (c) 2016-present, Philipp Thürwächter & Pattrick Hüper & js-joda contributors
+ * @license BSD-3-Clause (see LICENSE in the root directory of this source tree)
+ */
+
+import { expect } from 'chai';
+
+import './_init';
+
+import { Instant } from  '../src/Instant';
+
+describe('Date', () => {
+    it('toInstant()', () => {
+        expect(new Date(0).toInstant().toEpochMilli()).to.equal(Instant.EPOCH.toEpochMilli());
+    });
+
+    it('from(Instant)', () => {
+        expect(Date.from(Instant.EPOCH).getTime()).to.equal(new Date(0).getTime());
+    });
+});

--- a/packages/core/test/typescript_definitions/js-joda-tests.ts
+++ b/packages/core/test/typescript_definitions/js-joda-tests.ts
@@ -159,6 +159,13 @@ function test_exceptions() {
     new DateTimeParseException();
 }
 
+function test_Date() {
+    const date = Date.from(Instant.EPOCH);
+    const instant = new Date(0).toInstant();
+    expectType<Date>(date);
+    expectType<Instant>(instant);
+}
+
 /**
  * Use this to check if an expression is of type T.
  * Don't let TypeScript infer the type, give it explicitly.

--- a/packages/core/typings/js-joda.d.ts
+++ b/packages/core/typings/js-joda.d.ts
@@ -2488,6 +2488,16 @@ export function convert(
     toEpochMilli: () => number;
 };
 
+declare global {
+    interface Date {
+        toInstant(): Instant;
+    }
+
+    interface DateConstructor {
+        from(instant: Instant): Date;
+    }
+}
+
 export function use(plugin: Function): any;
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
This is my final attempt on replacing `convert` and `nativeJs` with something less error-prone and more convenient to use.

`Date` gained 2 additional methods:

```javascript
static Date.from(Instant): Date
Date.toInstant(): Instant
```

so the following became possible:

```javascript
const dateFromInstant = Date.from(Instant.now());
const instantFromDate = new Date().toInstant();

const momentFromInstant = moment(Date.from(Instant.now()));
const instantFromMoment = moment().toDate().toInstant();
```

I hope that augmenting native class won't feel too controversial for you. After all, most of polyfills do the same. It seems to be the cleanest solution considering previously explored alternatives and endless naming-related battles. I'm sure that proposed way of converting between `Date` and `Instant` will feel very natural to everyone, especially to java users.

Typings and documentation have been updated accordingly. All IDEs I've tested seem to work as expected.