### PR TITLE
Fix optional parameter type of appendInstant method

### DIFF
--- a/packages/core/typings/js-joda.d.ts
+++ b/packages/core/typings/js-joda.d.ts
@@ -2185,7 +2185,7 @@ export class DateTimeFormatterBuilder {
 
     append(formatter: DateTimeFormatter): DateTimeFormatterBuilder;
     appendFraction(field: TemporalField, minWidth: number, maxWidth: number, decimalPoint: boolean): DateTimeFormatterBuilder;
-    appendInstant(fractionalDigits: number): DateTimeFormatterBuilder;
+    appendInstant(fractionalDigits?: number): DateTimeFormatterBuilder;
     appendLiteral(literal: any): DateTimeFormatterBuilder;
     appendOffset(pattern: string, noOffsetText: string): DateTimeFormatterBuilder;
     appendOffsetId(): DateTimeFormatterBuilder;


### PR DESCRIPTION
`DateTimeFormatterBuilder.appendInstant` parameter should be optional according to [code](https://github.com/alisabzevari/js-joda/blob/b23a9e2c16bc5d632f6b76b14df5983cfd7ddbfa/packages/core/src/format/DateTimeFormatterBuilder.js#L547) and [documentation](https://js-joda.github.io/js-joda/class/packages/core/src/format/DateTimeFormatterBuilder.js~DateTimeFormatterBuilder.html#instance-method-appendInstant).
I have just made the parameter optional in typing.