### PR TITLE
Feature DateTimeFormatterBuilder.parseDefaulting()

### DIFF
--- a/packages/core/src/format/DateTimeFormatterBuilder.js
+++ b/packages/core/src/format/DateTimeFormatterBuilder.js
@@ -175,6 +175,39 @@ export class DateTimeFormatterBuilder {
     }
 
     /**
+     * Appends a default value for a field to the formatter for use in parsing.
+     * <p>
+     * This appends an instruction to the builder to inject a default value
+     * into the parsed result. This is especially useful in conjunction with
+     * optional parts of the formatter.
+     * <p>
+     * For example, consider a formatter that parses the year, followed by
+     * an optional month, with a further optional day-of-month. Using such a
+     * formatter would require the calling code to check whether a full date,
+     * year-month or just a year had been parsed. This method can be used to
+     * default the month and day-of-month to a sensible value, such as the
+     * first of the month, allowing the calling code to always get a date.
+     * <p>
+     * During formatting, this method has no effect.
+     * <p>
+     * During parsing, the current state of the parse is inspected.
+     * If the specified field has no associated value, because it has not been
+     * parsed successfully at that point, then the specified value is injected
+     * into the parse result. Injection is immediate, thus the field-value pair
+     * will be visible to any subsequent elements in the formatter.
+     * As such, this method is normally called at the end of the builder.
+     *
+     * @param {TemporalField} field  the field to default the value of, not null
+     * @param {number} value  the value to default the field to
+     * @return {DateTimeFormatterBuilder} this, for chaining, not null
+     */
+    parseDefaulting(field, value) {
+        requireNonNull(field);
+        this._appendInternal(new DefaultingParser(field, value));
+        return this;
+    }
+
+    /**
      * appendValue function overloading
      */
     appendValue(){
@@ -1527,6 +1560,44 @@ class InstantPrinterParser  {
     }
 }
 
+/**
+ * Used by parseDefaulting().
+ * @implements {DateTimePrinterParser}
+ * @private
+ */
+class DefaultingParser {
+    /**
+     * @param {TemporalField} field 
+     * @param {number} value 
+     */
+    constructor(field, value) {
+        this._field = field;
+        this._value = value;
+    }
+
+    /**
+     * @param {DateTimePrintContext} context
+     * @param {StringBuilder} buf
+     * @return {boolean}
+     */
+    print(context,  buf) {
+        return true;
+    }
+
+
+    /** 
+     * @param {DateTimeParseContext} context 
+     * @param {string} text
+     * @param {number} position 
+     * @returns {number}
+     */
+    parse(context, text, position) {
+        if (context.getParsed(this._field) == null) {
+            context.setParsedField(this._field, this._value, position, position);
+        }
+        return position;
+    }
+}
 
 export function _init() {
     ReducedPrinterParser.BASE_DATE = LocalDate.of(2000, 1, 1);

--- a/packages/core/test/format/DateTimeFormatterBuilderTest.js
+++ b/packages/core/test/format/DateTimeFormatterBuilderTest.js
@@ -7,8 +7,12 @@ import { dataProviderTest } from '../testUtils';
 
 import '../_init';
 
+import { ChronoField } from '../../src/temporal/ChronoField';
 import { DateTimeFormatterBuilder } from '../../src/format/DateTimeFormatterBuilder';
 import { IllegalArgumentException } from '../../src/errors';
+import { LocalDate } from '../../src/LocalDate';
+import { LocalDateTime } from '../../src/LocalDateTime';
+import { ResolverStyle } from '../../src/format/ResolverStyle';
 
 /* these tests are not copied from threetenbp, but js-joda tests to increase coverage */
 
@@ -87,6 +91,62 @@ describe('js-joda DateTimeFormatterBuilderTest', () => {
             });
         });
         
+    });
+
+    describe('parseDefaulting', () => {
+        const fields = ['NANO_OF_SECOND', 'NANO_OF_DAY', 'MICRO_OF_DAY', 'MILLI_OF_DAY', 'SECOND_OF_MINUTE', 'SECOND_OF_DAY', 'MINUTE_OF_HOUR', 'MINUTE_OF_DAY', 'HOUR_OF_AMPM', 'HOUR_OF_DAY', 'CLOCK_HOUR_OF_DAY', 'AMPM_OF_DAY', 'DAY_OF_WEEK', 'ALIGNED_DAY_OF_WEEK_IN_MONTH', 'ALIGNED_DAY_OF_WEEK_IN_YEAR', 'DAY_OF_MONTH', 'DAY_OF_YEAR', 'EPOCH_DAY', 'ALIGNED_WEEK_OF_MONTH', 'ALIGNED_WEEK_OF_YEAR', 'MONTH_OF_YEAR', 'YEAR', 'ERA', 'INSTANT_SECONDS', 'OFFSET_SECONDS'];
+
+        for (const field of fields) {
+            const c = ChronoField[field];
+
+            it (`test_parseDefaulting(${field})`, () => { expect(builder.parseDefaulting(c, c.range().maximum()).toFormatter().parse('').get(c)).to.equal(c.range().maximum())});
+        }
+
+        it('test_parseDefaulting optional DayOfMonth', () => {
+            const d = 15;
+            const f = builder
+                .appendPattern('yyyy-MM[-dd]')
+                .parseDefaulting(ChronoField.DAY_OF_MONTH, d)
+                .toFormatter();
+
+            expect(() => { LocalDate.parse('1970-01', f); }).not.to.throw();
+            expect(LocalDate.parse('1970-01', f).dayOfMonth()).to.equal(d);
+            expect(LocalDate.parse('1970-01-01', f).dayOfMonth()).to.equal(1);
+        });
+
+        it('test_parseDefaulting optional Time', () => {
+            const h = 12;
+            const m = 12;
+            const s = 12;
+            const f = builder
+                .appendPattern("yyyy-MM-dd['T'HH:mm:ss]")
+                .parseDefaulting(ChronoField.HOUR_OF_DAY, h)
+                .parseDefaulting(ChronoField.MINUTE_OF_HOUR, m)
+                .parseDefaulting(ChronoField.SECOND_OF_MINUTE, s)
+                .toFormatter();
+
+            expect(() => { LocalDate.parse('1970-01-01', f); }).not.to.throw();
+
+            let ldt = LocalDateTime.parse('1970-01-01', f);
+            expect(ldt.hour()).to.equal(h);
+            expect(ldt.minute()).to.equal(m);
+            expect(ldt.second()).to.equal(s);
+
+            ldt = LocalDateTime.parse('1970-01-01T01:01:01', f);
+            expect(ldt.hour()).to.equal(1);
+            expect(ldt.minute()).to.equal(1);
+            expect(ldt.second()).to.equal(1);
+        });
+
+        it('test_parseDefaulting optional Era (ResolverStyle.STRICT)', () => {
+            // Testsing strict parsing of custom pattern, which may not contain 'uuuu'.
+            const f = builder
+                .appendPattern('dd.MM.yyyy')
+                .parseDefaulting(ChronoField.ERA, 1) // default Era, because of ResolverStyle.STRICT
+                .toFormatter(ResolverStyle.STRICT); // ResolverStyle.STRICT expects an Era for 'yyyy' otherwise i would fail to validate.
+
+            expect(() => { LocalDate.parse('01.01.1970', f); }).not.to.throw();
+        });
     });
 })
 ;

--- a/packages/core/typings/js-joda.d.ts
+++ b/packages/core/typings/js-joda.d.ts
@@ -2198,6 +2198,7 @@ export class DateTimeFormatterBuilder {
     padNext(): DateTimeFormatterBuilder;
     parseCaseInsensitive(): DateTimeFormatterBuilder;
     parseCaseSensitive(): DateTimeFormatterBuilder;
+    parseDefaulting(field: TemporalField, value: number): DateTimeFormatterBuilder;
     parseLenient(): DateTimeFormatterBuilder;
     parseStrict(): DateTimeFormatterBuilder;
     toFormatter(resolverStyle?: ResolverStyle): DateTimeFormatter;

--- a/packages/core/typings/js-joda.flow.js
+++ b/packages/core/typings/js-joda.flow.js
@@ -211,6 +211,7 @@ declare module "js-joda" {
         padNext(): DateTimeFormatterBuilder;
         parseCaseInsensitive(): DateTimeFormatterBuilder;
         parseCaseSensitive(): DateTimeFormatterBuilder;
+        parseDefaulting(field: TemporalField, value: number): DateTimeFormatterBuilder;
         parseLenient(): DateTimeFormatterBuilder;
         parseStrict(): DateTimeFormatterBuilder;
         toFormatter(resolverStyle: ResolverStyle): DateTimeFormatter


### PR DESCRIPTION
This PR ports the `DateTimeFormatterBuilder.parseDefaulting()` Method from ThreeTen/threetenbp to js-joda in order to increase usefulness of parsers with optional fields.
ThreeTen did not include tests, so i implementend a few simple tests seperatly.
`DefaultingParser` is located in _DateTimeFormatterBuilder.js_ since it is of no use outside of it.
I've edited _js-joda.d.ts_ and _js-joda.flow.js_ because the changes seem trivial and i've got no tooling to generate them.