### PR TITLE
Add more built-in date-time formats to typings

### DIFF
--- a/packages/core/typings/js-joda.d.ts
+++ b/packages/core/typings/js-joda.d.ts
@@ -2162,6 +2162,14 @@ export class DateTimeFormatter {
     static ISO_OFFSET_DATE_TIME: DateTimeFormatter;
     static ISO_OFFSET_TIME: DateTimeFormatter;
     static ISO_ZONED_DATE_TIME: DateTimeFormatter;
+    static BASIC_ISO_DATE: DateTimeFormatter;
+    static ISO_OFFSET_DATE: DateTimeFormatter;
+    static ISO_OFFSET_TIME: DateTimeFormatter;
+    static ISO_ORDINAL_DATE: DateTimeFormatter;
+    static ISO_WEEK_DATE: DateTimeFormatter;
+    static ISO_DATE: DateTimeFormatter;
+    static ISO_TIME: DateTimeFormatter;
+    static ISO_DATE_TIME: DateTimeFormatter;
 
     static ofPattern(pattern: string): DateTimeFormatter;
     static parsedExcessDays(): TemporalQuery<Period>;


### PR DESCRIPTION
These seem to be missing in the typings.
I left out RFC_1123_DATE_TIME since it requires also importing `@js-joda/locales`