### PR TITLE
Add type definition for Duration#plusDuration

### DIFF
--- a/packages/core/typings/js-joda.d.ts
+++ b/packages/core/typings/js-joda.d.ts
@@ -1121,6 +1121,7 @@ export class Duration extends TemporalAmount {
     plus(amount: number, unit: TemporalUnit): Duration;
     plus(duration: Duration): Duration;
     plusDays(daysToAdd: number): Duration;
+    plusDuration(duration: Duration): Duration;
     plusHours(hoursToAdd: number): Duration;
     plusMillis(millisToAdd: number): Duration;
     plusMinutes(minutesToAdd: number): Duration;


### PR DESCRIPTION
closes https://github.com/js-joda/js-joda/issues/712

Adds a missing typescript type definition für `Duration#plusDuration` that is documented here: https://js-joda.github.io/js-joda/class/packages/core/src/Duration.js~Duration.html#instance-method-plusDuration

In the flow typings, it is already available: https://github.com/js-joda/js-joda/blob/c635147087af60f35b964ba3f327715436e4ba05/packages/core/typings/js-joda.flow.js#L96
