### PR TITLE
Added toString in YearMonth type definition

### DIFF
--- a/packages/core/typings/js-joda.d.ts
+++ b/packages/core/typings/js-joda.d.ts
@@ -1418,7 +1418,6 @@ export class LocalTime extends Temporal implements TemporalAdjuster {
     toNanoOfDay(): number;
     toSecondOfDay(): number;
     toString(): string;
-    toString(): string;
     truncatedTo(unit: ChronoUnit): LocalTime;
     until(endExclusive: Temporal, unit: TemporalUnit): number;
     with(adjuster: TemporalAdjuster): LocalTime;
@@ -1600,6 +1599,7 @@ export class YearMonth extends Temporal implements TemporalAdjuster {
     withMonth(month: number): YearMonth;
     withYear(year: number): YearMonth;
     year(): number;
+    toString(): string;
 
     protected _minusUnit(amountToSubtract: number, unit: TemporalUnit): YearMonth;
     protected _minusAmount(amount: TemporalAmount): YearMonth;

--- a/packages/core/typings/js-joda.d.ts
+++ b/packages/core/typings/js-joda.d.ts
@@ -1593,13 +1593,13 @@ export class YearMonth extends Temporal implements TemporalAdjuster {
     plusMonths(monthsToAdd: number): YearMonth;
     plusYears(yearsToAdd: number): YearMonth;
     toJSON(): string;
+    toString(): string;
     until(endExclusive: Temporal, unit: TemporalUnit): number;
     with(adjuster: TemporalAdjuster): YearMonth;
     with(field: TemporalField, newValue: number): YearMonth;
     withMonth(month: number): YearMonth;
     withYear(year: number): YearMonth;
     year(): number;
-    toString(): string;
 
     protected _minusUnit(amountToSubtract: number, unit: TemporalUnit): YearMonth;
     protected _minusAmount(amount: TemporalAmount): YearMonth;


### PR DESCRIPTION
1) Added toString() in YearMonth type definition
2) Removed duplicate toString() in LocalTime type definition