### PR TITLE
Include source maps for ESM

### DIFF
--- a/packages/locale/rollup.config.js
+++ b/packages/locale/rollup.config.js
@@ -30,7 +30,8 @@ module.exports = [
     mergeDeepRight(defaultConfig, {
         output: {
             file: 'dist/js-joda-locale.esm.js',
-            format: 'es'
+            format: 'es',
+            sourcemap: true,
         },
     }),
     mergeDeepRight(defaultConfig, {

--- a/packages/locale/utils/create_packages.js
+++ b/packages/locale/utils/create_packages.js
@@ -113,7 +113,7 @@ Object.keys(argv.packages).forEach((packageName) => {
     fs.copyFileSync(path.resolve(__dirname, '..', 'typings', 'js-joda-locale.d.ts'),
         path.resolve(packageDir, 'dist', 'js-joda-locale.d.ts'));
 
-    for (const file of ['index.js', 'index.js.map', 'index.min.js', 'index.esm.js']) {
+    for (const file of ['index.js', 'index.js.map', 'index.min.js', 'index.esm.js', 'index.esm.js.map']) {
         fs.copyFileSync(
             path.resolve(prebuiltDir, file),
             path.resolve(packageDir, 'dist', file));


### PR DESCRIPTION
This fixes warnings similar to the following in Webpack:

> webpack compiled with 1 warning
> WARNING in ../../node_modules/@js-joda/locale_en-us/dist/index.esm.js
> Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):
> Failed to parse source map from 'node_modules/@js-joda/locale_en-us/dist/index.esm.js.map' file: Error: ENOENT: no such file or directory, open 'node_modules/@js-joda/locale_en-us/dist/index.esm.js.map'

These warnings started appearing in @js-joda/locale 4.12.0 as a result of #722.

Fixes #728