### PR TITLE
Perf: Remove modulus op in MathUtil verifyInt()

### DIFF
--- a/packages/core/src/MathUtil.js
+++ b/packages/core/src/MathUtil.js
@@ -168,7 +168,7 @@ export class MathUtil {
         if (isNaN(value)) {
             throw new ArithmeticException('Invalid int value, using NaN as argument');
         }
-        if ((value % 1) !== 0) {
+        if (!Number.isInteger(value)) {
             throw new ArithmeticException(`Invalid value: '${value}' is a float`);
         }
         if (value > MAX_SAFE_INTEGER || value < MIN_SAFE_INTEGER) {


### PR DESCRIPTION
I was doing some benchmarking on my application today and noticed a tremendous amount of time spent in `verifyInt()` upwards of up to an entire second of time when doing many `plus()` operations in a loop.

Specifically, it was the modulus math that was taking the bulk of this time:

<img width="708" alt="Screenshot 2024-08-24 at 9 41 22 PM" src="https://github.com/user-attachments/assets/1eefc4ca-7cd4-4342-a193-af650941c259">

After doing a little research I came across [this SO thread](https://stackoverflow.com/questions/45559380/javascript-performance-modulus-operation-of-negative-number-within-decrementing) where someone looked into the V8 machine code to find why the OP was also having terrible performance with modulus math.

I believe `verifyInt()` is also running into this unoptimized machine code causing it to be very slow.

Luckily there's a modern replacement for determining whether a value is an integer: `Number.isInteger()` (https://caniuse.com/mdn-javascript_builtins_number_isinteger) which has 95% browser support.

After patching js-joda to use this instead and re-benchmarking my application I got a 40x speed increase and my application stopped feeling sluggish:

<img width="533" alt="Screenshot 2024-08-24 at 9 43 09 PM" src="https://github.com/user-attachments/assets/9830811b-3fd3-4817-9adb-c0368b8d5205">

So it looks like this little seemingly mundane check was quite the culprit indeed!



