### PR TITLE
Use Symbol.toStringTag for class names

### DIFF
--- a/packages/core/src/Clock.js
+++ b/packages/core/src/Clock.js
@@ -104,7 +104,7 @@ export class Clock {
     static fixed(fixedInstant, zoneId) {
         return new FixedClock(fixedInstant, zoneId);
     }
-    
+
     /**
      * Obtains a clock that returns instants from the specified clock with the
      * specified duration added
@@ -125,7 +125,7 @@ export class Clock {
      * @return a clock based on the base clock with the duration added, not null
      */
     static offset(baseClock, duration) {
-        return new OffsetClock(baseClock, duration);   
+        return new OffsetClock(baseClock, duration);
     }
 
     /**
@@ -162,7 +162,7 @@ export class Clock {
     zone(){
         abstractMethodFail('Clock.zone');
     }
-    
+
     /**
      * Returns a copy of this clock with a different time-zone.
      * <p>
@@ -174,6 +174,10 @@ export class Clock {
      */
     withZone(){
         abstractMethodFail('Clock.withZone');
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'Clock';
     }
 }
 
@@ -192,6 +196,10 @@ class SystemClock extends Clock {
         requireNonNull(zone, 'zone');
         super();
         this._zone = zone;
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'SystemClock';
     }
 
     /**
@@ -217,20 +225,20 @@ class SystemClock extends Clock {
     instant() {
         return Instant.ofEpochMilli(this.millis());
     }
-    
-    equals(obj) {    
-        if (obj instanceof SystemClock) {            
+
+    equals(obj) {
+        if (obj instanceof SystemClock) {
             return this._zone.equals(obj._zone);
         }
-        return false;    
-    }  
-      
+        return false;
+    }
+
     withZone(zone) {
         if (zone.equals(this._zone)) {  // intentional NPE
             return this;
         }
         return new SystemClock(zone);
-    }      
+    }
 
     /**
      *
@@ -254,6 +262,10 @@ class FixedClock extends Clock{
         this._zoneId = zoneId;
     }
 
+    get [Symbol.toStringTag]() {
+        return 'FixedClock';
+    }
+
     instant() {
         return this._instant;
     }
@@ -269,12 +281,12 @@ class FixedClock extends Clock{
     toString(){
         return 'FixedClock[]';
     }
-    
-    equals(obj) {    
-        if (obj instanceof FixedClock) {            
+
+    equals(obj) {
+        if (obj instanceof FixedClock) {
             return this._instant.equals(obj._instant) && this._zoneId.equals(obj._zoneId);
         }
-        return false;    
+        return false;
     }
 
     withZone(zone) {
@@ -282,8 +294,8 @@ class FixedClock extends Clock{
             return this;
         }
         return new FixedClock(this._instant, zone);
-    }      
-    
+    }
+
 }
 
 
@@ -296,33 +308,37 @@ class OffsetClock extends Clock {
         this._baseClock = baseClock;
         this._offset = offset;
     }
-   
+
+    get [Symbol.toStringTag]() {
+        return 'OffsetClock';
+    }
+
     zone() {
         return this._baseClock.zone();
     }
-        
+
     withZone(zone) {
         if (zone.equals(this._baseClock.zone())) {  // intentional NPE
             return this;
         }
         return new OffsetClock(this._baseClock.withZone(zone), this._offset);
     }
-    
+
     millis() {
         return this._baseClock.millis() + this._offset.toMillis();
     }
-    
+
     instant() {
         return this._baseClock.instant().plus(this._offset);
     }
-        
+
     equals(obj) {
-        if (obj instanceof OffsetClock) {            
+        if (obj instanceof OffsetClock) {
             return this._baseClock.equals(obj._baseClock) && this._offset.equals(obj._offset);
         }
         return false;
     }
-    
+
     toString() {
         return `OffsetClock[${this._baseClock},${this._offset}]`;
     }

--- a/packages/core/src/DayOfWeek.js
+++ b/packages/core/src/DayOfWeek.js
@@ -41,6 +41,10 @@ export class DayOfWeek extends TemporalAccessor {
         this._name = name;
     }
 
+    get [Symbol.toStringTag]() {
+        return 'DayOfWeek';
+    }
+
     /**
      *
      * @returns {number}
@@ -122,7 +126,7 @@ export class DayOfWeek extends TemporalAccessor {
             return DayOfWeek.of(temporal.get(ChronoField.DAY_OF_WEEK));
         } catch (ex) {
             if(ex instanceof DateTimeException) {
-                throw new DateTimeException(`Unable to obtain DayOfWeek from TemporalAccessor: ${ 
+                throw new DateTimeException(`Unable to obtain DayOfWeek from TemporalAccessor: ${
                     temporal}, type ${temporal.constructor != null ? temporal.constructor.name : ''}`, ex);
             } else {
                 throw ex;
@@ -386,7 +390,7 @@ export class DayOfWeek extends TemporalAccessor {
      *
      * @returns {boolean}
      */
-    equals(other){ 
+    equals(other){
         return this === other;
     }
 
@@ -406,7 +410,7 @@ export class DayOfWeek extends TemporalAccessor {
      *
      * @param {DayOfWeek} other  the other year to compare to, not null
      * @return {number} the comparator value, negative if less, positive if greater
-     */    
+     */
     compareTo(other) {
         requireNonNull(other, 'other');
         requireInstance(other, DayOfWeek, 'other');

--- a/packages/core/src/Duration.js
+++ b/packages/core/src/Duration.js
@@ -60,6 +60,10 @@ export class Duration extends TemporalAmount /*implements TemporalAmount, Compar
         this._nanos = MathUtil.safeToInt(nanos);
     }
 
+    get [Symbol.toStringTag]() {
+        return 'Duration';
+    }
+
     //-----------------------------------------------------------------------
     /**
      * Obtains an instance of {@link Duration} from a number of standard 24 hour days.

--- a/packages/core/src/Instant.js
+++ b/packages/core/src/Instant.js
@@ -208,7 +208,7 @@ export class Instant extends Temporal {
             const nanoOfSecond = temporal.get(ChronoField.NANO_OF_SECOND);
             return Instant.ofEpochSecond(instantSecs, nanoOfSecond);
         } catch (ex) {
-            throw new DateTimeException(`Unable to obtain Instant from TemporalAccessor: ${ 
+            throw new DateTimeException(`Unable to obtain Instant from TemporalAccessor: ${
                 temporal}, type ${typeof temporal}`, ex);
         }
     }
@@ -268,6 +268,10 @@ export class Instant extends Temporal {
         Instant._validate(seconds, nanoOfSecond);
         this._seconds = MathUtil.safeToInt(seconds);
         this._nanos = MathUtil.safeToInt(nanoOfSecond);
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'Instant';
     }
 
     /**

--- a/packages/core/src/LocalDate.js
+++ b/packages/core/src/LocalDate.js
@@ -1309,8 +1309,7 @@ export class LocalDate extends ChronoLocalDate{
         } else if (time instanceof OffsetTime) {
             return this._atTimeOffsetTime(time);
         } else {
-            throw new IllegalArgumentException(`time must be an instance of LocalTime or OffsetTime${
-                time && time.constructor && time.constructor.name ? `, but is ${time.constructor.name}` : ''}`);
+            throw new IllegalArgumentException(`time must be an instance of LocalTime or OffsetTime, but is ${Object.prototype.toString.call(time.constructor.name)}`);
         }
     }
 

--- a/packages/core/src/LocalDate.js
+++ b/packages/core/src/LocalDate.js
@@ -294,6 +294,10 @@ export class LocalDate extends ChronoLocalDate{
         LocalDate._validate(this._year, this._month, this._day);
     }
 
+    get [Symbol.toStringTag]() {
+        return 'LocalDate';
+    }
+
 
     /**
      *
@@ -1305,7 +1309,7 @@ export class LocalDate extends ChronoLocalDate{
         } else if (time instanceof OffsetTime) {
             return this._atTimeOffsetTime(time);
         } else {
-            throw new IllegalArgumentException(`time must be an instance of LocalTime or OffsetTime${ 
+            throw new IllegalArgumentException(`time must be an instance of LocalTime or OffsetTime${
                 time && time.constructor && time.constructor.name ? `, but is ${time.constructor.name}` : ''}`);
         }
     }

--- a/packages/core/src/LocalDateTime.js
+++ b/packages/core/src/LocalDateTime.js
@@ -308,6 +308,10 @@ implements Temporal, TemporalAdjuster, Serializable */ {
         this._time = time;
     }
 
+    get [Symbol.toStringTag]() {
+        return 'LocalDateTime';
+    }
+
     /**
      * Returns a copy of this date-time with the new date and time, checking
      * to see if a new object is in fact required.

--- a/packages/core/src/LocalTime.js
+++ b/packages/core/src/LocalTime.js
@@ -297,6 +297,10 @@ export class LocalTime extends Temporal /** implements Temporal, TemporalAdjuste
         this._nano = _nanoOfSecond;
     }
 
+    get [Symbol.toStringTag]() {
+        return 'LocalTime';
+    }
+
     static _validate(hour, minute, second, nanoOfSecond){
         ChronoField.HOUR_OF_DAY.checkValidValue(hour);
         ChronoField.MINUTE_OF_HOUR.checkValidValue(minute);

--- a/packages/core/src/Month.js
+++ b/packages/core/src/Month.js
@@ -48,7 +48,11 @@ export class Month extends TemporalAccessor {
         super();
         this._value = MathUtil.safeToInt(value);
         this._name = name;
-    }    
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'Month';
+    }
 
     /**
      *
@@ -57,7 +61,7 @@ export class Month extends TemporalAccessor {
     value() {
         return this._value;
     }
-    
+
     /**
      *
      * @returns {number}
@@ -72,7 +76,7 @@ export class Month extends TemporalAccessor {
      */
     name(){
         return this._name;
-    }  
+    }
 
     /**
      * Gets the textual representation, such as 'Jan' or 'December'.
@@ -482,7 +486,7 @@ export class Month extends TemporalAccessor {
         */
         return temporal.with(ChronoField.MONTH_OF_YEAR, this.value());
     }
-    
+
     /**
      * Compares this Month to another Month.
      *
@@ -491,18 +495,18 @@ export class Month extends TemporalAccessor {
      *
      * @param {Month} other  the other year to compare to, not null
      * @return {number} the comparator value, negative if less, positive if greater
-     */    
+     */
     compareTo(other) {
         requireNonNull(other, 'other');
         requireInstance(other, Month, 'other');
         return this._value - other._value;
-    }    
-    
+    }
+
     /**
      *
      * @returns {boolean}
      */
-    equals(other){    
+    equals(other){
         return this === other;
     }
 
@@ -520,7 +524,7 @@ export class Month extends TemporalAccessor {
         }
         return Month.of(ordinal+1);
     }
-    
+
 
     /**
      * replacement for enum values
@@ -571,7 +575,7 @@ export class Month extends TemporalAccessor {
             }*/
             return Month.of(temporal.get(ChronoField.MONTH_OF_YEAR));
         } catch (ex) {
-            throw new DateTimeException(`Unable to obtain Month from TemporalAccessor: ${ 
+            throw new DateTimeException(`Unable to obtain Month from TemporalAccessor: ${
                 temporal} of type ${temporal && temporal.constructor != null ? temporal.constructor.name : ''}`, ex);
         }
     }

--- a/packages/core/src/MonthDay.js
+++ b/packages/core/src/MonthDay.js
@@ -159,7 +159,7 @@ export class MonthDay extends TemporalAccessor {
         requireNonNull(month, 'month');
         ChronoField.DAY_OF_MONTH.checkValidValue(dayOfMonth);
         if (dayOfMonth > month.maxLength()) {
-            throw new DateTimeException(`Illegal value for DayOfMonth field, value ${dayOfMonth 
+            throw new DateTimeException(`Illegal value for DayOfMonth field, value ${dayOfMonth
             } is not valid for month ${month.toString()}`);
         }
         return new MonthDay(month.value(), dayOfMonth);
@@ -217,7 +217,7 @@ export class MonthDay extends TemporalAccessor {
             }*/
             return MonthDay.of(temporal.get(ChronoField.MONTH_OF_YEAR), temporal.get(ChronoField.DAY_OF_MONTH));
         } catch (ex) {
-            throw new DateTimeException(`Unable to obtain MonthDay from TemporalAccessor: ${ 
+            throw new DateTimeException(`Unable to obtain MonthDay from TemporalAccessor: ${
                 temporal}, type ${temporal && temporal.constructor != null ? temporal.constructor.name : ''}`);
         }
     }
@@ -284,6 +284,10 @@ export class MonthDay extends TemporalAccessor {
         super();
         this._month = MathUtil.safeToInt(month);
         this._day = MathUtil.safeToInt(dayOfMonth);
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'MonthDay';
     }
 
     //-----------------------------------------------------------------------

--- a/packages/core/src/OffsetDateTime.js
+++ b/packages/core/src/OffsetDateTime.js
@@ -147,6 +147,10 @@ export class OffsetDateTime extends Temporal {
         this._offset = offset;
     }
 
+    get [Symbol.toStringTag]() {
+        return 'OffsetDateTime';
+    }
+
     /**
      *
      * @param {Temporal} temporal

--- a/packages/core/src/OffsetDateTime.js
+++ b/packages/core/src/OffsetDateTime.js
@@ -68,7 +68,7 @@ export class OffsetDateTime extends Temporal {
                 const now = clockOrZone.instant(); // called once
                 return OffsetDateTime.ofInstant(now, clockOrZone.zone().rules().offset(now));
             } else {
-                throw new IllegalArgumentException('clockOrZone must be an instance of ZoneId or Clock');
+                throw new IllegalArgumentException(`clockOrZone must be an instance of ZoneId or Clock, but it is ${Object.prototype.toString.call(clockOrZone)}`);
             }
         }
     }

--- a/packages/core/src/OffsetTime.js
+++ b/packages/core/src/OffsetTime.js
@@ -149,6 +149,10 @@ export class OffsetTime extends Temporal {
         this._offset = offset;
     }
 
+    get [Symbol.toStringTag]() {
+        return 'OffsetTime';
+    }
+
 
     /**
      * @param {TemporalAdjuster} temporal - the target object to be adjusted, not null

--- a/packages/core/src/Period.js
+++ b/packages/core/src/Period.js
@@ -71,7 +71,7 @@ export class Period extends TemporalAmount /* extends ChronoPeriod */ {
      */
     constructor(years, months, days){
         super();
-        
+
         const _years = MathUtil.safeToInt(years);
         const _months =  MathUtil.safeToInt(months);
         const _days = MathUtil.safeToInt(days);
@@ -85,7 +85,7 @@ export class Period extends TemporalAmount /* extends ChronoPeriod */ {
             }
             return Period.ZERO;
         }
-        
+
         /**
          * The number of years.
          */
@@ -98,6 +98,10 @@ export class Period extends TemporalAmount /* extends ChronoPeriod */ {
          * The number of days.
          */
         this._days = _days;
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'Period';
     }
 
     //-----------------------------------------------------------------------

--- a/packages/core/src/Year.js
+++ b/packages/core/src/Year.js
@@ -78,6 +78,10 @@ export class Year extends Temporal {
         this._year = MathUtil.safeToInt(value);
     }
 
+    get [Symbol.toStringTag]() {
+        return 'Year';
+    }
+
     /**
      *
      * @return {number} gets the value
@@ -208,7 +212,7 @@ export class Year extends Temporal {
             }*/
             return Year.of(temporal.get(ChronoField.YEAR));
         } catch (ex) {
-            throw new DateTimeException(`Unable to obtain Year from TemporalAccessor: ${ 
+            throw new DateTimeException(`Unable to obtain Year from TemporalAccessor: ${
                 temporal}, type ${temporal && temporal.constructor != null ? temporal.constructor.name : ''}`);
         }
     }

--- a/packages/core/src/YearMonth.js
+++ b/packages/core/src/YearMonth.js
@@ -198,7 +198,7 @@ export class YearMonth extends Temporal {
             }*/
             return YearMonth.of(temporal.get(ChronoField.YEAR), temporal.get(ChronoField.MONTH_OF_YEAR));
         } catch (ex) {
-            throw new DateTimeException(`Unable to obtain YearMonth from TemporalAccessor: ${ 
+            throw new DateTimeException(`Unable to obtain YearMonth from TemporalAccessor: ${
                 temporal}, type ${temporal && temporal.constructor != null ? temporal.constructor.name : ''}`);
         }
     }
@@ -264,6 +264,10 @@ export class YearMonth extends Temporal {
         super();
         this._year = MathUtil.safeToInt(year);
         this._month = MathUtil.safeToInt(month);
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'YearMonth';
     }
 
     /**

--- a/packages/core/src/ZoneId.js
+++ b/packages/core/src/ZoneId.js
@@ -123,6 +123,10 @@ export class ZoneId {
         throw new DateTimeException(`not supported operation${temporal}`);
     }
 
+    get [Symbol.toStringTag]() {
+        return 'ZoneId';
+    }
+
     //-----------------------------------------------------------------------
     /**
      * Gets the unique time-zone ID.

--- a/packages/core/src/ZoneOffset.js
+++ b/packages/core/src/ZoneOffset.js
@@ -46,6 +46,10 @@ export class ZoneOffset extends ZoneId {
         this._id = ZoneOffset._buildId(totalSeconds);
     }
 
+    get [Symbol.toStringTag]() {
+        return 'ZoneOffset';
+    }
+
     /**
      *
      * @returns {number}
@@ -106,7 +110,7 @@ export class ZoneOffset extends ZoneId {
      */
     static _validate(hours, minutes, seconds) {
         if (hours < -18 || hours > 18) {
-            throw new DateTimeException(`Zone offset hours not in valid range: value ${hours 
+            throw new DateTimeException(`Zone offset hours not in valid range: value ${hours
             } is not in the range -18 to 18`);
         }
         if (hours > 0) {
@@ -121,11 +125,11 @@ export class ZoneOffset extends ZoneId {
             throw new DateTimeException('Zone offset minutes and seconds must have the same sign');
         }
         if (Math.abs(minutes) > 59) {
-            throw new DateTimeException(`Zone offset minutes not in valid range: abs(value) ${ 
+            throw new DateTimeException(`Zone offset minutes not in valid range: abs(value) ${
                 Math.abs(minutes)} is not in the range 0 to 59`);
         }
         if (Math.abs(seconds) > 59) {
-            throw new DateTimeException(`Zone offset seconds not in valid range: abs(value) ${ 
+            throw new DateTimeException(`Zone offset seconds not in valid range: abs(value) ${
                 Math.abs(seconds)} is not in the range 0 to 59`);
         }
         if (Math.abs(hours) === 18 && (Math.abs(minutes) > 0 || Math.abs(seconds) > 0)) {

--- a/packages/core/src/ZoneRegion.js
+++ b/packages/core/src/ZoneRegion.js
@@ -51,6 +51,10 @@ export class ZoneRegion extends ZoneId {
         this._rules = rules;
     }
 
+    get [Symbol.toStringTag]() {
+        return 'ZoneRegion';
+    }
+
     //-----------------------------------------------------------------------
     /**
      *

--- a/packages/core/src/ZonedDateTime.js
+++ b/packages/core/src/ZonedDateTime.js
@@ -378,11 +378,11 @@ export class ZonedDateTime extends ChronoZonedDateTime {
             if (trans != null && trans.isGap()) {
                 // error message says daylight savings for simplicity
                 // even though there are other kinds of gaps
-                throw new DateTimeException(`LocalDateTime ${localDateTime 
-                } does not exist in zone ${zone 
+                throw new DateTimeException(`LocalDateTime ${localDateTime
+                } does not exist in zone ${zone
                 } due to a gap in the local time-line, typically caused by daylight savings`);
             }
-            throw new DateTimeException(`ZoneOffset "${offset}" is not valid for LocalDateTime "${ 
+            throw new DateTimeException(`ZoneOffset "${offset}" is not valid for LocalDateTime "${
                 localDateTime}" in zone "${zone}"`);
         }
         return new ZonedDateTime(localDateTime, offset, zone);
@@ -513,6 +513,10 @@ export class ZonedDateTime extends ChronoZonedDateTime {
          * The time-zone.
          */
         this._zone = zone;
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'ZonedDateTime';
     }
 
     /**

--- a/packages/core/src/assert.js
+++ b/packages/core/src/assert.js
@@ -35,6 +35,17 @@ export function requireNonNull(value, parameterName) {
     return value;
 }
 
+// Use Object.prototype.toString to result in values such as `[object Instant]`,
+// honoring our Symbol.toStringTag, regardless of toString implementations.
+function getClassName(_class) {
+    return (_class.prototype && Object.prototype.toString.call(_class.prototype))
+        || _class.name
+        || _class;
+}
+function getValueName(value) {
+    return Object.prototype.toString.call(value);
+}
+
 /**
  * @private
  *
@@ -45,7 +56,7 @@ export function requireNonNull(value, parameterName) {
  */
 export function requireInstance(value, _class, parameterName) {
     if (!(value instanceof _class)) {
-        throw new IllegalArgumentException(`${parameterName} must be an instance of ${_class.name ? _class.name : _class}${value && value.constructor && value.constructor.name ? `, but is ${value.constructor.name}` : ''}`);
+        throw new IllegalArgumentException(`${parameterName} must be an instance of ${getClassName(_class)}, but is ${getValueName(value)}`);
     }
     return value;
 }

--- a/packages/core/src/chrono/ChronoLocalDate.js
+++ b/packages/core/src/chrono/ChronoLocalDate.js
@@ -181,6 +181,9 @@ import { LocalDate } from '../LocalDate';
  * Since there are no default methods in JDK 7, an abstract class is used.
  */
 export class ChronoLocalDate extends Temporal {
+    get [Symbol.toStringTag]() {
+        return 'ChronoLocalDate';
+    }
 
     isSupported(fieldOrUnit) {
         if (fieldOrUnit instanceof ChronoField) {

--- a/packages/core/src/chrono/ChronoLocalDateTime.js
+++ b/packages/core/src/chrono/ChronoLocalDateTime.js
@@ -50,6 +50,10 @@ import { TemporalQueries } from '../temporal/TemporalQueries';
  * @param D the date type
  */
 export class ChronoLocalDateTime extends Temporal {
+    get [Symbol.toStringTag]() {
+        return 'ChronoLocalDateTime';
+    }
+
     /* <D extends ChronoLocalDate>
         extends DefaultInterfaceTemporal
         implements Temporal, TemporalAdjuster, Comparable<ChronoLocalDateTime<?>> */

--- a/packages/core/src/chrono/ChronoZonedDateTime.js
+++ b/packages/core/src/chrono/ChronoZonedDateTime.js
@@ -14,6 +14,10 @@ import { Temporal } from '../temporal/Temporal';
 import { TemporalQueries } from '../temporal/TemporalQueries';
 
 export class ChronoZonedDateTime extends Temporal {
+    get [Symbol.toStringTag]() {
+        return 'ChronoZonedDateTime';
+    }
+
     query(query) {
         if (query === TemporalQueries.zoneId() || query === TemporalQueries.zone()) {
             return this.zone();

--- a/packages/core/src/chrono/IsoChronology.js
+++ b/packages/core/src/chrono/IsoChronology.js
@@ -42,6 +42,10 @@ export class IsoChronology extends Enum{
         return ((prolepticYear & 3) === 0) && ((prolepticYear % 100) !== 0 || (prolepticYear % 400) === 0);
     }
 
+    get [Symbol.toStringTag]() {
+        return 'IsoChronology';
+    }
+
     /**
      * Updates the map of field-values during resolution.
      *

--- a/packages/core/src/convert.js
+++ b/packages/core/src/convert.js
@@ -36,7 +36,7 @@ class ToNativeJsConverter {
                 zonedDateTime = temporal.withZoneSameInstant(zone);
             }
         } else {
-            throw new IllegalArgumentException(`unsupported instance for convert operation:${temporal}`);
+            throw new IllegalArgumentException(`unsupported instance for convert operation:${Object.prototype.toString.call(temporal)}`);
         }
 
         this.instant = zonedDateTime.toInstant();

--- a/packages/core/src/convert.js
+++ b/packages/core/src/convert.js
@@ -42,6 +42,10 @@ class ToNativeJsConverter {
         this.instant = zonedDateTime.toInstant();
     }
 
+    get [Symbol.toStringTag]() {
+        return 'ToNativeJsConverter';
+    }
+
     /**
      *
      * @returns {Date}
@@ -63,11 +67,11 @@ class ToNativeJsConverter {
  * converts a LocalDate, LocalDateTime or ZonedDateTime to a native Javascript Date.
  *
  * In a first step the temporal is converted to an Instant by adding implicit values.
- * 
- * A LocalDate is implicit set to a LocalDateTime at start of day. 
- * A LocalDateTime is implicit set to a ZonedDateTime with 
- * the passed zone or if null, with the system default time zone. 
- * A ZonedDateTime is converted to an Instant, if a zone is specified the zonedDateTime is adjusted to this 
+ *
+ * A LocalDate is implicit set to a LocalDateTime at start of day.
+ * A LocalDateTime is implicit set to a ZonedDateTime with
+ * the passed zone or if null, with the system default time zone.
+ * A ZonedDateTime is converted to an Instant, if a zone is specified the zonedDateTime is adjusted to this
  * zone, keeping the same Instant.
  *
  * In a second step the instant is converted to a native Javascript Date

--- a/packages/core/src/format/DateTimeBuilder.js
+++ b/packages/core/src/format/DateTimeBuilder.js
@@ -87,6 +87,10 @@ export class DateTimeBuilder extends TemporalAccessor {
         this.excessDays = null;
     }
 
+    get [Symbol.toStringTag]() {
+        return 'DateTimeBuilder';
+    }
+
     /**
      *
      * @param {TemporalField} field

--- a/packages/core/src/format/DateTimeFormatter.js
+++ b/packages/core/src/format/DateTimeFormatter.js
@@ -305,6 +305,10 @@ export class DateTimeFormatter {
         this._zone = zone;
     }
 
+    get [Symbol.toStringTag]() {
+        return 'DateTimeFormatter';
+    }
+
     locale() {
         return this._locale;
     }
@@ -534,10 +538,10 @@ export class DateTimeFormatter {
                 abbr = text;
             }
             if (pos.getErrorIndex() >= 0) {
-                throw new DateTimeParseException(`Text '${abbr}' could not be parsed at index ${ 
+                throw new DateTimeParseException(`Text '${abbr}' could not be parsed at index ${
                     pos.getErrorIndex()}`, text, pos.getErrorIndex());
             } else {
-                throw new DateTimeParseException(`Text '${abbr}' could not be parsed, unparsed text found at index ${ 
+                throw new DateTimeParseException(`Text '${abbr}' could not be parsed, unparsed text found at index ${
                     pos.getIndex()}`, text, pos.getIndex());
             }
         }

--- a/packages/core/src/format/DateTimeFormatterBuilder.js
+++ b/packages/core/src/format/DateTimeFormatterBuilder.js
@@ -74,6 +74,10 @@ export class DateTimeFormatterBuilder {
         this._valueParserIndex = -1;
     }
 
+    get [Symbol.toStringTag]() {
+        return 'DateTimeFormatterBuilder';
+    }
+
     /**
      * Private static factory, replaces private threeten constructor
      * Returns a new instance of the builder.
@@ -1436,6 +1440,10 @@ class InstantPrinterParser  {
         this.fractionalDigits = fractionalDigits;
     }
 
+    get [Symbol.toStringTag]() {
+        return 'InstantPrinterParser';
+    }
+
     print(context, buf) {
         // use INSTANT_SECONDS, thus this code is not bound by Instant.MAX
         const inSecs = context.getValue(ChronoField.INSTANT_SECONDS);
@@ -1567,12 +1575,16 @@ class InstantPrinterParser  {
  */
 class DefaultingParser {
     /**
-     * @param {TemporalField} field 
-     * @param {number} value 
+     * @param {TemporalField} field
+     * @param {number} value
      */
     constructor(field, value) {
         this._field = field;
         this._value = value;
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'DefaultingParser';
     }
 
     /**
@@ -1585,10 +1597,10 @@ class DefaultingParser {
     }
 
 
-    /** 
-     * @param {DateTimeParseContext} context 
+    /**
+     * @param {DateTimeParseContext} context
      * @param {string} text
-     * @param {number} position 
+     * @param {number} position
      * @returns {number}
      */
     parse(context, text, position) {

--- a/packages/core/src/format/DateTimeParseContext.js
+++ b/packages/core/src/format/DateTimeParseContext.js
@@ -35,6 +35,10 @@ export class DateTimeParseContext{
         this._parsed = [new Parsed(this)];
     }
 
+    get [Symbol.toStringTag]() {
+        return 'DateTimeParseContext';
+    }
+
     _constructorParam(locale, symbols, chronology){
         this._locale = locale;
         this._symbols = symbols;
@@ -245,6 +249,10 @@ class Parsed extends Temporal {
         this.fieldValues = new EnumMap();
         this.leapSecond = false;
         this.dateTimeParseContext = dateTimeParseContext;
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'Parsed';
     }
 
     copy() {

--- a/packages/core/src/format/DateTimePrintContext.js
+++ b/packages/core/src/format/DateTimePrintContext.js
@@ -31,6 +31,10 @@ export class DateTimePrintContext{
         this._optional = 0;
     }
 
+    get [Symbol.toStringTag]() {
+        return 'DateTimePrintContext';
+    }
+
     /**
      *
      * @param {TemporalAccessor} temporal

--- a/packages/core/src/format/DecimalStyle.js
+++ b/packages/core/src/format/DecimalStyle.js
@@ -21,6 +21,10 @@ export class DecimalStyle {
         this._decimalSeparator = decimalPointChar;
     }
 
+    get [Symbol.toStringTag]() {
+        return 'DecimalStyle';
+    }
+
     positiveSign(){
         return this._positiveSign;
     }

--- a/packages/core/src/format/EnumMap.js
+++ b/packages/core/src/format/EnumMap.js
@@ -11,6 +11,10 @@ export class EnumMap {
         this._map = {};
     }
 
+    get [Symbol.toStringTag]() {
+        return 'EnumMap';
+    }
+
     putAll(otherMap){
         for(const key in otherMap._map){
             this._map[key] = otherMap._map[key];

--- a/packages/core/src/format/ParsePosition.js
+++ b/packages/core/src/format/ParsePosition.js
@@ -13,6 +13,10 @@ export class ParsePosition {
         this._errorIndex = -1;
     }
 
+    get [Symbol.toStringTag]() {
+        return 'ParsePosition';
+    }
+
     getIndex(){
         return this._index;
     }

--- a/packages/core/src/format/ResolverStyle.js
+++ b/packages/core/src/format/ResolverStyle.js
@@ -8,7 +8,7 @@ import { Enum } from '../Enum';
 
 /**
  * Enumeration of different ways to resolve dates and times.
- * 
+ *
  * Parsing a text string occurs in two phases.
  * Phase 1 is a basic text parse according to the fields added to the builder.
  * Phase 2 resolves the parsed field-value pairs into date and/or time objects.
@@ -53,15 +53,19 @@ import { Enum } from '../Enum';
  * For example, month 15 is treated as being 3 months after month 12.
  *
  */
-export class ResolverStyle extends Enum {}
+export class ResolverStyle extends Enum {
+    get [Symbol.toStringTag]() {
+        return 'ResolverStyle';
+    }
+}
 
 /**
  * Style to resolve dates and times strictly.
- * 
+ *
  * Using strict resolution will ensure that all parsed values are within
  * the outer range of valid values for the field. Individual fields may
  * be further processed for strictness.
- * 
+ *
  * For example, resolving year-month and day-of-month in the ISO calendar
  * system using strict mode will ensure that the day-of-month is valid
  * for the year-month, rejecting invalid values.
@@ -69,11 +73,11 @@ export class ResolverStyle extends Enum {}
 ResolverStyle.STRICT = new ResolverStyle('STRICT');
 /**
  * Style to resolve dates and times in a smart, or intelligent, manner.
- * 
+ *
  * Using smart resolution will perform the sensible default for each
  * field, which may be the same as strict, the same as lenient, or a third
  * behavior. Individual fields will interpret this differently.
- * 
+ *
  * For example, resolving year-month and day-of-month in the ISO calendar
  * system using smart mode will ensure that the day-of-month is from
  * 1 to 31, converting any value beyond the last valid day-of-month to be
@@ -82,10 +86,10 @@ ResolverStyle.STRICT = new ResolverStyle('STRICT');
 ResolverStyle.SMART = new ResolverStyle('SMART');
 /**
  * Style to resolve dates and times leniently.
- * 
+ *
  * Using lenient resolution will resolve the values in an appropriate
  * lenient manner. Individual fields will interpret this differently.
- * 
+ *
  * For example, lenient mode allows the month in the ISO calendar system
  * to be outside the range 1 to 12.
  * For example, month 15 is treated as being 3 months after month 12.

--- a/packages/core/src/format/SignStyle.js
+++ b/packages/core/src/format/SignStyle.js
@@ -7,6 +7,10 @@
 import { Enum } from '../Enum';
 
 export class SignStyle extends Enum{
+    get [Symbol.toStringTag]() {
+        return 'SignStyle';
+    }
+
     /**
      * Parse helper.
      *

--- a/packages/core/src/format/StringBuilder.js
+++ b/packages/core/src/format/StringBuilder.js
@@ -11,6 +11,10 @@ export class StringBuilder {
         this._str = '';
     }
 
+    get [Symbol.toStringTag]() {
+        return 'StringBuilder';
+    }
+
     append(str){
         this._str += str;
         return this;

--- a/packages/core/src/format/TextStyle.js
+++ b/packages/core/src/format/TextStyle.js
@@ -27,6 +27,10 @@ import { Enum } from '../Enum';
  * This is immutable and thread-safe enum.
  */
 export class TextStyle extends Enum {
+    get [Symbol.toStringTag]() {
+        return 'TextStyle';
+    }
+
     /**
      * Checks if the style is stand-alone.
      *

--- a/packages/core/src/format/parser/CharLiteralPrinterParser.js
+++ b/packages/core/src/format/parser/CharLiteralPrinterParser.js
@@ -19,6 +19,10 @@ export class CharLiteralPrinterParser {
         this._literal = literal;
     }
 
+    get [Symbol.toStringTag]() {
+        return 'CharLiteralPrinterParser';
+    }
+
     print(context, buf) {
         buf.append(this._literal);
         return true;

--- a/packages/core/src/format/parser/CompositePrinterParser.js
+++ b/packages/core/src/format/parser/CompositePrinterParser.js
@@ -14,6 +14,10 @@ export class CompositePrinterParser {
         this._optional = optional;
     }
 
+    get [Symbol.toStringTag]() {
+        return 'CompositePrinterParser';
+    }
+
     /**
      * Returns a copy of this printer-parser with the optional flag changed.
      *

--- a/packages/core/src/format/parser/FractionPrinterParser.js
+++ b/packages/core/src/format/parser/FractionPrinterParser.js
@@ -36,13 +36,17 @@ export class FractionPrinterParser {
             throw new IllegalArgumentException(`Maximum width must be from 1 to 9 inclusive but was ${maxWidth}`);
         }
         if (maxWidth < minWidth) {
-            throw new IllegalArgumentException(`Maximum width must exceed or equal the minimum width but ${ 
+            throw new IllegalArgumentException(`Maximum width must exceed or equal the minimum width but ${
                 maxWidth} < ${minWidth}`);
         }
         this.field = field;
         this.minWidth = minWidth;
         this.maxWidth = maxWidth;
         this.decimalPoint = decimalPoint;
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'FractionPrinterParser';
     }
 
     print(context, buf) {

--- a/packages/core/src/format/parser/NumberPrinterParser.js
+++ b/packages/core/src/format/parser/NumberPrinterParser.js
@@ -51,6 +51,10 @@ export class NumberPrinterParser {
         this._subsequentWidth = subsequentWidth;
     }
 
+    get [Symbol.toStringTag]() {
+        return 'NumberPrinterParser';
+    }
+
     field(){ return this._field;}
     minWidth(){ return this._minWidth;}
     maxWidth(){ return this._maxWidth;}
@@ -81,8 +85,8 @@ export class NumberPrinterParser {
         const symbols = context.symbols();
         let str = `${Math.abs(value)}`;
         if (str.length > this._maxWidth) {
-            throw new DateTimeException(`Field ${this._field 
-            } cannot be printed as the value ${value 
+            throw new DateTimeException(`Field ${this._field
+            } cannot be printed as the value ${value
             } exceeds the maximum print width of ${this._maxWidth}`);
         }
         str = symbols.convertNumberToI18N(str);
@@ -106,8 +110,8 @@ export class NumberPrinterParser {
                     buf.append(symbols.negativeSign());
                     break;
                 case SignStyle.NOT_NEGATIVE:
-                    throw new DateTimeException(`Field ${this._field 
-                    } cannot be printed as the value ${value 
+                    throw new DateTimeException(`Field ${this._field
+                    } cannot be printed as the value ${value
                     } cannot be negative according to the SignStyle`);
             }
         }
@@ -276,6 +280,10 @@ export class ReducedPrinterParser extends NumberPrinterParser {
         }
         this._baseValue = baseValue;
         this._baseDate = baseDate;
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'ReducedPrinterParser';
     }
 
     /**

--- a/packages/core/src/format/parser/OffsetIdPrinterParser.js
+++ b/packages/core/src/format/parser/OffsetIdPrinterParser.js
@@ -33,6 +33,10 @@ export class OffsetIdPrinterParser  {
         this.type = this._checkPattern(pattern);
     }
 
+    get [Symbol.toStringTag]() {
+        return 'OffsetIdPrinterParser';
+    }
+
     /**
      * @param {String} pattern
      * @return {number}

--- a/packages/core/src/format/parser/PadPrinterParserDecorator.js
+++ b/packages/core/src/format/parser/PadPrinterParserDecorator.js
@@ -28,6 +28,10 @@ export class PadPrinterParserDecorator {
         this._padChar = padChar;
     }
 
+    get [Symbol.toStringTag]() {
+        return 'PadPrinterParserDecorator';
+    }
+
     print(context, buf) {
         const preLen = buf.length();
         if (this._printerParser.print(context, buf) === false) {

--- a/packages/core/src/format/parser/SettingsParser.js
+++ b/packages/core/src/format/parser/SettingsParser.js
@@ -10,6 +10,9 @@ import { Enum } from '../../Enum';
  * @private
  */
 export class SettingsParser extends Enum {
+    get [Symbol.toStringTag]() {
+        return 'SettingsParser';
+    }
 
     print(/*context, buf*/) {
         return true;  // nothing to do here

--- a/packages/core/src/format/parser/StringLiteralPrinterParser.js
+++ b/packages/core/src/format/parser/StringLiteralPrinterParser.js
@@ -16,6 +16,10 @@ export class StringLiteralPrinterParser {
         this._literal = literal;
     }
 
+    get [Symbol.toStringTag]() {
+        return 'StringLiteralPrinterParser';
+    }
+
     print(context, buf) {
         buf.append(this._literal);
         return true;

--- a/packages/core/src/format/parser/ZoneIdPrinterParser.js
+++ b/packages/core/src/format/parser/ZoneIdPrinterParser.js
@@ -30,6 +30,10 @@ export class ZoneIdPrinterParser {
         this.description = description;
     }
 
+    get [Symbol.toStringTag]() {
+        return 'ZoneIdPrinterParser';
+    }
+
     //-----------------------------------------------------------------------
     /**
      *
@@ -186,6 +190,10 @@ class ZoneIdTree {
         this.size = size;
         this.treeMap = treeMap;
     }
+
+    get [Symbol.toStringTag]() {
+        return 'ZoneIdTree';
+    }
 }
 
 class ZoneIdTreeMap {
@@ -193,6 +201,10 @@ class ZoneIdTreeMap {
         this.length = length;
         this.isLeaf = isLeaf;
         this._treeMap = {};
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'ZoneIdTreeMap';
     }
 
     add(zoneId){

--- a/packages/core/src/nativeJs.js
+++ b/packages/core/src/nativeJs.js
@@ -21,5 +21,5 @@ export function nativeJs(date, zone = ZoneId.systemDefault()) {
     } else if(typeof date.toDate === 'function' &&  date.toDate() instanceof Date) {
         return Instant.ofEpochMilli(date.toDate().getTime()).atZone(zone);
     }
-    throw new IllegalArgumentException('date must be a javascript Date or a moment instance');
+    throw new IllegalArgumentException(`date must be a javascript Date or a moment instance, but it is ${Object.prototype.toString.call(date)}`);
 }

--- a/packages/core/src/temporal/ChronoField.js
+++ b/packages/core/src/temporal/ChronoField.js
@@ -27,163 +27,163 @@ import { YearConstants } from '../YearConstants';
  * - `ChronoField.ALIGNED_DAY_OF_WEEK_IN_MONTH`: This represents concept of the count of
  * days within the period of a week where the weeks are aligned to the start of the month.
  * This field is typically used with `ALIGNED_WEEK_OF_MONTH`.
- * 
+ *
  * - `ChronoField.ALIGNED_DAY_OF_WEEK_IN_YEAR`: This represents concept of the count of days
  * within the period of a week where the weeks are aligned to the start of the year.
  * This field is typically used with `ALIGNED_WEEK_OF_YEAR`.
- * 
+ *
  * - `ChronoField.ALIGNED_WEEK_OF_MONTH`: This represents concept of the count of weeks within
  * the period of a month where the weeks are aligned to the start of the month. This field
  * is typically used with `ALIGNED_DAY_OF_WEEK_IN_MONTH`.
- * 
+ *
  * - `ChronoField.ALIGNED_WEEK_OF_YEAR`: This represents concept of the count of weeks within
  * the period of a year where the weeks are aligned to the start of the year. This field
  * is typically used with `ALIGNED_DAY_OF_WEEK_IN_YEAR`.
- * 
+ *
  * - `ChronoField.AMPM_OF_DAY`: This counts the AM/PM within the day, from 0 (AM) to 1 (PM).
- * 
+ *
  * - `ChronoField.CLOCK_HOUR_OF_AMPM`: This counts the hour within the AM/PM, from 1 to 12.
  * This is the hour that would be observed on a standard 12-hour analog wall clock.
- * 
+ *
  * - `ChronoField.CLOCK_HOUR_OF_DAY`: This counts the hour within the AM/PM, from 1 to 24.
  * This is the hour that would be observed on a 24-hour analog wall clock.
- * 
+ *
  * - `ChronoField.DAY_OF_MONTH`: This represents the concept of the day within the month.
  * In the default ISO calendar system, this has values from 1 to 31 in most months.
  * April, June, September, November have days from 1 to 30, while February has days from
  * 1 to 28, or 29 in a leap year.
- * 
+ *
  * - `ChronoField.DAY_OF_WEEK`: This represents the standard concept of the day of the week.
  * In the default ISO calendar system, this has values from Monday (1) to Sunday (7).
  * The {@link DayOfWeek} class can be used to interpret the result.
- * 
+ *
  * - `ChronoField.DAY_OF_YEAR`: This represents the concept of the day within the year.
  * In the default ISO calendar system, this has values from 1 to 365 in standard years and
  * 1 to 366 in leap years.
- * 
+ *
  * - `ChronoField.EPOCH_DAY`: This field is the sequential count of days where
  * 1970-01-01 (ISO) is zero. Note that this uses the local time-line, ignoring offset and
  * time-zone.
- * 
+ *
  * - `ChronoField.ERA`: This represents the concept of the era, which is the largest
  * division of the time-line. This field is typically used with `YEAR_OF_ERA`.
- * 
+ *
  *     In the default ISO calendar system, there are two eras defined, 'BCE' and 'CE'. The era
  * 'CE' is the one currently in use and year-of-era runs from 1 to the maximum value.
  * The era 'BCE' is the previous era, and the year-of-era runs backwards.
- * 
+ *
  * - `ChronoField.HOUR_OF_AMPM`: This counts the hour within the AM/PM, from 0 to 11.
  * This is the hour that would be observed on a standard 12-hour digital clock.
- * 
+ *
  * - `ChronoField.HOUR_OF_DAY`: This counts the hour within the day, from 0 to 23. This is
  * the hour that would be observed on a standard 24-hour digital clock.
- * 
+ *
  * - `ChronoField.INSTANT_SECONDS`: This represents the concept of the sequential count of
  * seconds where 1970-01-01T00:00Z (ISO) is zero. This field may be used with `NANO_OF_DAY`
  * to represent the fraction of the day.
- * 
+ *
  *     An Instant represents an instantaneous point on the time-line. On their own they have
  * no elements which allow a local date-time to be obtained. Only when paired with an offset
  * or time-zone can the local date or time be found. This field allows the seconds part of
  * the instant to be queried.
- * 
+ *
  * - `ChronoField.MICRO_OF_DAY`: This counts the microsecond within the day, from 0 to
  * (24 * 60 * 60 * 1,000,000) - 1.
- * 
+ *
  *     This field is used to represent the micro-of-day handling any fraction of the second.
  * Implementations of {@link TemporalAccessor} should provide a value for this field if they
  * can return a value for `SECOND_OF_DAY` filling unknown precision with zero.
- * 
+ *
  *     When this field is used for setting a value, it should behave in the same way as
  * setting `NANO_OF_DAY` with the value multiplied by 1,000.
- * 
+ *
  * - `ChronoField.MICRO_OF_SECOND`: This counts the microsecond within the second, from 0
  * to 999,999.
- * 
+ *
  *     This field is used to represent the micro-of-second handling any fraction of the second.
  * Implementations of {@link TemporalAccessor} should provide a value for this field if they
  * can return a value for `SECOND_OF_MINUTE`, `SECOND_OF_DAY` or `INSTANT_SECONDS` filling
  * unknown precision with zero.
- * 
+ *
  * - `ChronoField.MILLI_OF_DAY`: This counts the millisecond within the day, from 0 to
  * (24 * 60 * 60 * 1,000) - 1.
- * 
+ *
  *     This field is used to represent the milli-of-day handling any fraction of the second.
  * Implementations of {@link TemporalAccessor} should provide a value for this field if they
  * can return a value for `SECOND_OF_DAY` filling unknown precision with zero.
- * 
+ *
  *     When this field is used for setting a value, it should behave in the same way as
  * setting `NANO_OF_DAY` with the value multiplied by 1,000,000.
- * 
+ *
  * - `ChronoField.MILLI_OF_SECOND`: This counts the millisecond within the second, from 0 to
  * 999.
- * 
+ *
  *     This field is used to represent the milli-of-second handling any fraction of the second.
  * Implementations of {@link TemporalAccessor} should provide a value for this field if they can
  * return a value for `SECOND_OF_MINUTE`, `SECOND_OF_DAY` or `INSTANT_SECONDS` filling unknown
  * precision with zero.
- * 
+ *
  *     When this field is used for setting a value, it should behave in the same way as
  * setting `NANO_OF_SECOND` with the value multiplied by 1,000,000.
- * 
+ *
  * - `ChronoField.MINUTE_OF_DAY`: This counts the minute within the day, from 0 to (24 * 60) - 1.
- * 
+ *
  * - `ChronoField.MINUTE_OF_HOUR`: This counts the minute within the hour, from 0 to 59.
- * 
+ *
  * - `ChronoField.MONTH_OF_YEAR`: The month-of-year, such as March. This represents the concept
  * of the month within the year. In the default ISO calendar system, this has values from
  * January (1) to December (12).
- * 
+ *
  * - `ChronoField.NANO_OF_DAY`: This counts the nanosecond within the day, from 0 to
  * (24 * 60 * 60 * 1,000,000,000) - 1.
- * 
+ *
  *     This field is used to represent the nano-of-day handling any fraction of the second.
  * Implementations of {@link TemporalAccessor} should provide a value for this field if they
  * can return a value for `SECOND_OF_DAY` filling unknown precision with zero.
- * 
+ *
  * - `ChronoField.NANO_OF_SECOND`: This counts the nanosecond within the second, from 0
  * to 999,999,999.
- * 
+ *
  *     This field is used to represent the nano-of-second handling any fraction of the second.
  * Implementations of {@link TemporalAccessor} should provide a value for this field if they
  * can return a value for `SECOND_OF_MINUTE`, `SECOND_OF_DAY` or `INSTANT_SECONDS` filling
  * unknown precision with zero.
- * 
+ *
  *     When this field is used for setting a value, it should set as much precision as the
  * object stores, using integer division to remove excess precision. For example, if the
  * {@link TemporalAccessor} stores time to millisecond precision, then the nano-of-second must
  * be divided by 1,000,000 before replacing the milli-of-second.
- * 
+ *
  * - `ChronoField.OFFSET_SECONDS`: This represents the concept of the offset in seconds of
  * local time from UTC/Greenwich.
- * 
+ *
  *     A {@link ZoneOffset} represents the period of time that local time differs from
  * UTC/Greenwich. This is usually a fixed number of hours and minutes. It is equivalent to
  * the total amount of the offset in seconds. For example, during the winter Paris has an
  * offset of +01:00, which is 3600 seconds.
- * 
+ *
  * - `ChronoField.PROLEPTIC_MONTH`: The proleptic-month, which counts months sequentially
  * from year 0.
- * 
+ *
  *     The first month in year zero has the value zero. The value increase for later months
  * and decrease for earlier ones. Note that this uses the local time-line, ignoring offset
  * and time-zone.
- * 
+ *
  * - `ChronoField.SECOND_OF_DAY`: This counts the second within the day, from 0 to
  * (24 * 60 * 60) - 1.
- * 
+ *
  * - `ChronoField.SECOND_OF_MINUTE`: This counts the second within the minute, from 0 to 59.
- * 
+ *
  * - `ChronoField.YEAR`: The proleptic year, such as 2012. This represents the concept of
  * the year, counting sequentially and using negative numbers. The proleptic year is not
  * interpreted in terms of the era.
- * 
+ *
  *     The standard mental model for a date is based on three concepts - year, month and day.
  * These map onto the `YEAR`, `MONTH_OF_YEAR` and `DAY_OF_MONTH` fields. Note that there is no
  * reference to eras. The full model for a date requires four concepts - era, year, month and
  * day. These map onto the `ERA`, `YEAR_OF_ERA`, `MONTH_OF_YEAR` and `DAY_OF_MONTH` fields.
  * Whether this field or `YEAR_OF_ERA` is used depends on which mental model is being used.
- * 
+ *
  * - `ChronoField.YEAR_OF_ERA`: This represents the concept of the year within the era. This
  * field is typically used with `ERA`. The standard mental model for a date is based on three
  * concepts - year, month and day. These map onto the `YEAR`, `MONTH_OF_YEAR` and
@@ -191,17 +191,17 @@ import { YearConstants } from '../YearConstants';
  * requires four concepts - era, year, month and day. These map onto the `ERA`, `YEAR_OF_ERA`,
  * `MONTH_OF_YEAR` and `DAY_OF_MONTH` fields. Whether this field or `YEAR` is used depends on
  * which mental model is being used.
- * 
+ *
  *     In the default ISO calendar system, there are two eras defined, 'BCE' and 'CE'.
  * The era 'CE' is the one currently in use and year-of-era runs from 1 to the maximum value.
  * The era 'BCE' is the previous era, and the year-of-era runs backwards.
- * 
+ *
  *     For example, subtracting a year each time yield the following:
  *    - year-proleptic 2 = 'CE' year-of-era 2
  *    - year-proleptic 1 = 'CE' year-of-era 1
  *    - year-proleptic 0 = 'BCE' year-of-era 1
  *    - year-proleptic -1 = 'BCE' year-of-era 2
- * 
+ *
  *     Note that the ISO-8601 standard does not actually define eras. Note also that the
  * ISO eras do not align with the well-known AD/BC eras due to the change between the Julian
  * and Gregorian calendar systems.
@@ -239,6 +239,10 @@ export class ChronoField extends TemporalField {
         this._baseUnit = baseUnit;
         this._rangeUnit = rangeUnit;
         this._range = range;
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'ChronoField';
     }
 
     /**
@@ -360,7 +364,7 @@ export class ChronoField extends TemporalField {
         return temporal.range(this);
     }
 
-    
+
 
     /**
      * @param {!TemporalAccesor} temporal the temporal object to query.

--- a/packages/core/src/temporal/ChronoUnit.js
+++ b/packages/core/src/temporal/ChronoUnit.js
@@ -22,56 +22,56 @@ import { TemporalUnit } from './TemporalUnit';
  * The documentation of each unit explains how it operates.
  *
  * ### Static properties:
- * 
+ *
  * - `ChronoUnit.CENTURIES`: Unit that represents the concept of a century. For the ISO calendar
  * system, it is equal to 100 years.
- * 
+ *
  * - `ChronoUnit.DAYS`: Unit that represents the concept of a day. For the ISO calendar system, it
  * is the standard day from midnight to midnight. The estimated duration of a day is 24 Hours.
- * 
+ *
  * - `ChronoUnit.DECADES`: Unit that represents the concept of a decade. For the ISO calendar system,
  * it is equal to 10 years.
- * 
+ *
  * - `ChronoUnit.ERAS`: Unit that represents the concept of an era. The ISO calendar system doesn't
  * have eras thus it is impossible to add an era to a date or date-time. The estimated duration of the
  * era is artificially defined as 1,000,000,000 Years.
- * 
+ *
  * - `ChronoUnit.FOREVER`: Artificial unit that represents the concept of forever. This is primarily
  * used with {@link TemporalField} to represent unbounded fields such as the year or era. The
  * estimated duration of the era is artificially defined as the largest duration supported by
  * {@link Duration}.
- * 
+ *
  * - `ChronoUnit.HALF_DAYS`: Unit that represents the concept of half a day, as used in AM/PM. For
  * the ISO calendar system, it is equal to 12 hours.
  *
  * - `ChronoUnit.HOURS`: Unit that represents the concept of an hour. For the ISO calendar system,
  * it is equal to 60 minutes.
- * 
+ *
  * - `ChronoUnit.MICROS`: Unit that represents the concept of a microsecond. For the ISO calendar
  * system, it is equal to the 1,000,000th part of the second unit.
- * 
+ *
  * - `ChronoUnit.MILLENNIA`: Unit that represents the concept of a millennium. For the ISO calendar
  * system, it is equal to 1,000 years.
- * 
+ *
  * - `ChronoUnit.MILLIS`: Unit that represents the concept of a millisecond. For the ISO calendar
  * system, it is equal to the 1000th part of the second unit.
- * 
+ *
  * - `ChronoUnit.MINUTES`: Unit that represents the concept of a minute. For the ISO calendar system,
  * it is equal to 60 seconds.
- * 
+ *
  * - `ChronoUnit.MONTHS`: Unit that represents the concept of a month. For the ISO calendar system,
  * the length of the month varies by month-of-year. The estimated duration of a month is one twelfth
  * of 365.2425 Days.
- * 
+ *
  * - `ChronoUnit.NANOS`: Unit that represents the concept of a nanosecond, the smallest supported unit
  * of time. For the ISO calendar system, it is equal to the 1,000,000,000th part of the second unit.
- * 
+ *
  * - `ChronoUnit.SECONDS`: Unit that represents the concept of a second. For the ISO calendar system,
  * it is equal to the second in the SI system of units, except around a leap-second.
- * 
+ *
  * - `ChronoUnit.WEEKS`: Unit that represents the concept of a week. For the ISO calendar system,
  * it is equal to 7 Days.
- * 
+ *
  * - `ChronoUnit.YEARS`: Unit that represents the concept of a year. For the ISO calendar system, it
  * is equal to 12 months. The estimated duration of a year is 365.2425 Days.
  */
@@ -87,6 +87,10 @@ export class ChronoUnit extends TemporalUnit {
         super();
         this._name = name;
         this._duration = estimatedDuration;
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'ChronoUnit';
     }
 
     //-----------------------------------------------------------------------

--- a/packages/core/src/temporal/IsoFields.js
+++ b/packages/core/src/temporal/IsoFields.js
@@ -54,7 +54,7 @@ import { ResolverStyle } from '../format/ResolverStyle';
  * * `ChronoField.DAY_OF_WEEK` - the standard field defining the
  *   day-of-week from Monday (1) to Sunday (7) (see {@link ChronoField})
  * * `WEEK_OF_WEEK_BASED_YEAR` - the week within the week-based-year
- * * `WEEK_BASED_YEAR` - the week-based-year 
+ * * `WEEK_BASED_YEAR` - the week-based-year
  *
  * The week-based-year itself is defined relative to the standard ISO proleptic year.
  * It differs from the standard year in that it always starts on a Monday.
@@ -125,7 +125,7 @@ import { ResolverStyle } from '../format/ResolverStyle';
  * @property {TemporalField} QUARTER_YEARS Unit that represents the concept of a quarter-year.
  * For the ISO calendar system, it is equal to 3 months.
  * The estimated duration of a quarter-year is one quarter of 365.2425 days.
- * 
+ *
  * @typedef {Object} IsoFields
  * @type {Object}
  */
@@ -140,6 +140,9 @@ const QUARTER_DAYS = [0, 90, 181, 273, 0, 91, 182, 274];
  * @private
  */
 class Field extends TemporalField{
+    get [Symbol.toStringTag]() {
+        return 'Field';
+    }
 
     /**
      *
@@ -731,6 +734,10 @@ class Unit extends TemporalUnit {
         super();
         this._name = name;
         this._duration = estimatedDuration;
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'Unit';
     }
 
     /**

--- a/packages/core/src/temporal/Temporal.js
+++ b/packages/core/src/temporal/Temporal.js
@@ -65,6 +65,10 @@ import { TemporalUnit } from './TemporalUnit';
  * @interface
  */
 export class Temporal extends TemporalAccessor {
+    get [Symbol.toStringTag]() {
+        return 'Temporal';
+    }
+
     /**
      * Checks if the specified unit is supported.
      * This checks if the date-time can be queried for the specified unit. If false, then calling the plus and minus methods will throw an exception.

--- a/packages/core/src/temporal/TemporalAccessor.js
+++ b/packages/core/src/temporal/TemporalAccessor.js
@@ -11,6 +11,10 @@ import { ChronoField } from './ChronoField';
 import { TemporalQueries } from './TemporalQueries';
 
 export class TemporalAccessor {
+    get [Symbol.toStringTag]() {
+        return 'TemporalAccessor';
+    }
+
     /**
      * Queries this date-time.
      *

--- a/packages/core/src/temporal/TemporalAdjuster.js
+++ b/packages/core/src/temporal/TemporalAdjuster.js
@@ -38,6 +38,9 @@ import { abstractMethodFail } from '../assert';
  * @interface
  */
 export class TemporalAdjuster {
+    get [Symbol.toStringTag]() {
+        return 'TemporalAdjuster';
+    }
 
     /**
      * Adjusts the specified temporal object.

--- a/packages/core/src/temporal/TemporalAdjusters.js
+++ b/packages/core/src/temporal/TemporalAdjusters.js
@@ -410,6 +410,10 @@ class DayOfWeekInMonth extends TemporalAdjuster {
         this._dowValue = dow.value();
     }
 
+    get [Symbol.toStringTag]() {
+        return 'DayOfWeekInMonth';
+    }
+
     adjustInto(temporal) {
         if (this._ordinal >= 0) {
             const temp = temporal.with(ChronoField.DAY_OF_MONTH, 1);
@@ -446,6 +450,10 @@ class RelativeDayOfWeek extends TemporalAdjuster {
         this._relative = relative;
         /** The day-of-week value, from 1 to 7. */
         this._dowValue = dayOfWeek.value();
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'RelativeDayOfWeek';
     }
 
     adjustInto(temporal) {

--- a/packages/core/src/temporal/TemporalAmount.js
+++ b/packages/core/src/temporal/TemporalAmount.js
@@ -33,6 +33,10 @@ import { abstractMethodFail } from '../assert';
  * @interface
  */
 export class TemporalAmount {
+    get [Symbol.toStringTag]() {
+        return 'TemporalAmount';
+    }
+
     /**
      * Returns the value of the requested unit.
      * The units returned from {@link getUnits} uniquely define the
@@ -53,7 +57,7 @@ export class TemporalAmount {
     get(unit) {
         abstractMethodFail('get');
     }
-    
+
     /**
      * Returns the list of units uniquely defining the value of this TemporalAmount.
      * The list of {@link TemporalUnits} is defined by the implementation class.
@@ -72,7 +76,7 @@ export class TemporalAmount {
     units() {
         abstractMethodFail('units');
     }
-    
+
     /**
      * Adds to the specified temporal object.
      *
@@ -117,7 +121,7 @@ export class TemporalAmount {
     addTo(temporal) {
         abstractMethodFail('addTo');
     }
-    
+
     /**
      * Subtracts this object from the specified temporal object.
      *
@@ -162,7 +166,7 @@ export class TemporalAmount {
     subtractFrom(temporal) {
         abstractMethodFail('subtractFrom');
     }
-    
+
 }
 
 if (typeof Symbol !== 'undefined' && Symbol.toPrimitive) {

--- a/packages/core/src/temporal/TemporalField.js
+++ b/packages/core/src/temporal/TemporalField.js
@@ -24,6 +24,10 @@ import { abstractMethodFail } from '../assert';
  * @interface
  */
 export class TemporalField {
+    get [Symbol.toStringTag]() {
+        return 'TemporalField';
+    }
+
     /**
      * Checks if this field represents a component of a date.
      *
@@ -57,11 +61,11 @@ export class TemporalField {
 
     /**
      * Gets the range that the field is bound by.
-     * 
+     *
      * The range of the field is the period that the field varies within.
      * For example, in the field 'MonthOfYear', the range is 'Years'.
      * See also {@link baseUnit}.
-     * 
+     *
      * The range is never null. For example, the 'Year' field is shorthand for
      * 'YearOfForever'. It therefore has a unit of 'Years' and a range of 'Forever'.
      *
@@ -117,7 +121,7 @@ export class TemporalField {
      * @param {!TemporalAccessor} temporal the temporal object used to refine the result.
      * @return {ValueRange} the range of valid values for this field.
      * @throws {DateTimeException} if the range for the field cannot be obtained.
-     * 
+     *
      */
     // eslint-disable-next-line no-unused-vars
     rangeRefinedBy(temporal) {

--- a/packages/core/src/temporal/TemporalQuery.js
+++ b/packages/core/src/temporal/TemporalQuery.js
@@ -44,7 +44,11 @@ import { Enum } from '../Enum';
  *
  * @interface
  */
-export class TemporalQuery  extends Enum {
+export class TemporalQuery extends Enum {
+    get [Symbol.toStringTag]() {
+        return 'TemporalQuery';
+    }
+
     /**
      * Queries the specified temporal object.
      *

--- a/packages/core/src/temporal/TemporalUnit.js
+++ b/packages/core/src/temporal/TemporalUnit.js
@@ -27,6 +27,10 @@ import { abstractMethodFail } from '../assert';
  * @interface
  */
 export class TemporalUnit {
+    get [Symbol.toStringTag]() {
+        return 'TemporalUnit';
+    }
+
     /**
      * Gets the duration of this unit, which may be an estimate.
      *

--- a/packages/core/src/temporal/ValueRange.js
+++ b/packages/core/src/temporal/ValueRange.js
@@ -34,17 +34,21 @@ export class ValueRange {
      * @private
      */
     constructor(minSmallest, minLargest, maxSmallest, maxLargest) {
-        assert(!(minSmallest > minLargest), `Smallest minimum value '${minSmallest 
+        assert(!(minSmallest > minLargest), `Smallest minimum value '${minSmallest
         }' must be less than largest minimum value '${minLargest}'`, IllegalArgumentException);
-        assert(!(maxSmallest > maxLargest), `Smallest maximum value '${maxSmallest 
+        assert(!(maxSmallest > maxLargest), `Smallest maximum value '${maxSmallest
         }' must be less than largest maximum value '${maxLargest}'`, IllegalArgumentException);
-        assert(!(minLargest > maxLargest), `Minimum value '${minLargest 
+        assert(!(minLargest > maxLargest), `Minimum value '${minLargest
         }' must be less than maximum value '${maxLargest}'`, IllegalArgumentException);
 
         this._minSmallest = minSmallest;
         this._minLargest = minLargest;
         this._maxLargest = maxLargest;
         this._maxSmallest = maxSmallest;
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'ValueRange';
     }
 
     /**

--- a/packages/core/src/zone/SystemDefaultZoneId.js
+++ b/packages/core/src/zone/SystemDefaultZoneId.js
@@ -13,6 +13,10 @@ export class SystemDefaultZoneId extends ZoneId {
         this._rules = new SystemDefaultZoneRules();
     }
 
+    get [Symbol.toStringTag]() {
+        return 'SystemDefaultZoneId';
+    }
+
     rules(){
         return this._rules;
     }

--- a/packages/core/src/zone/SystemDefaultZoneRules.js
+++ b/packages/core/src/zone/SystemDefaultZoneRules.js
@@ -8,6 +8,9 @@ import { ZoneOffset } from '../ZoneOffset';
 import { DateTimeException } from '../errors';
 
 export class SystemDefaultZoneRules extends ZoneRules {
+    get [Symbol.toStringTag]() {
+        return 'SystemDefaultZoneRules';
+    }
 
     isFixedOffset(){
         return false;

--- a/packages/core/src/zone/ZoneOffsetTransition.js
+++ b/packages/core/src/zone/ZoneOffsetTransition.js
@@ -75,6 +75,10 @@ export class ZoneOffsetTransition {
         this._offsetAfter = offsetAfter;
     }
 
+    get [Symbol.toStringTag]() {
+        return 'ZoneOffsetTransition';
+    }
+
     //-----------------------------------------------------------------------
     /**
      * Gets the transition instant.
@@ -281,8 +285,8 @@ export class ZoneOffsetTransition {
      * @return {string} a string for debugging, not null
      */
     toString() {
-        return `Transition[${this.isGap() ? 'Gap' : 'Overlap' 
-        } at ${this._transition.toString()}${this._offsetBefore.toString() 
+        return `Transition[${this.isGap() ? 'Gap' : 'Overlap'
+        } at ${this._transition.toString()}${this._offsetBefore.toString()
         } to ${this._offsetAfter}]`;
     }
 

--- a/packages/core/src/zone/ZoneRules.js
+++ b/packages/core/src/zone/ZoneRules.js
@@ -24,6 +24,10 @@ export class ZoneRules {
         return new Fixed(offset);
     }
 
+    get [Symbol.toStringTag]() {
+        return 'ZoneRules';
+    }
+
 
     //-----------------------------------------------------------------------
     /**
@@ -373,6 +377,10 @@ class Fixed extends ZoneRules{
     constructor(offset){
         super();
         this._offset = offset;
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'Fixed';
     }
 
     isFixedOffset(){

--- a/packages/core/test/YearMonthTest.js
+++ b/packages/core/test/YearMonthTest.js
@@ -20,17 +20,17 @@ import { YearMonth } from '../src/YearMonth';
 /* these are not covered by the threetenbp ported tests */
 describe('js-joda YearMonth', () => {
     describe('from', () => {
-        
+
         it('should return the same YearMonth it has been called with', () => {
             const yearMonth = new YearMonth(2016, 1);
             const newYearMonth = YearMonth.from(yearMonth);
             expect(newYearMonth).to.equal(yearMonth);
         });
-        
+
     });
-    
+
     describe('isSupported', () => {
-        
+
         it('should return true for supported ChronoUnits', () => {
             const yearMonth = new YearMonth(2016, 1);
             expect(yearMonth.isSupported(ChronoUnit.MONTHS)).to.be.true;
@@ -40,21 +40,21 @@ describe('js-joda YearMonth', () => {
             expect(yearMonth.isSupported(ChronoUnit.MILLENNIA)).to.be.true;
             expect(yearMonth.isSupported(ChronoUnit.ERAS)).to.be.true;
         });
-        
+
         it('should return false for unsupported ChronoUnits', () => {
             const yearMonth = new YearMonth(2016, 1);
             expect(yearMonth.isSupported(ChronoUnit.HOUR_OF_DAY)).to.be.false;
             expect(yearMonth.isSupported(ChronoUnit.DAY_OF_YEAR)).to.be.false;
             expect(yearMonth.isSupported(null)).to.be.false;
         });
-        
+
         it('should return false for unsupported ChronoFields', () => {
             const yearMonth = new YearMonth(2016, 1);
             expect(yearMonth.isSupported(ChronoField.HOUR_OF_DAY)).to.be.false;
             expect(yearMonth.isSupported(ChronoField.DAY_OF_YEAR)).to.be.false;
             expect(yearMonth.isSupported(null)).to.be.false;
         });
-        
+
         it('should return corresponding value of isSupportedBy for TemporalFields', () => {
             const yearMonth = new YearMonth(2016, 1);
             let field = new TemporalField();
@@ -68,7 +68,7 @@ describe('js-joda YearMonth', () => {
             };
             expect(yearMonth.isSupported(field)).to.be.true;
         });
-        
+
         it('should return corresponding value of isSupportedBy for TemporalUnits', () => {
             const yearMonth = new YearMonth(2016, 1);
             let unit = new TemporalUnit();
@@ -82,7 +82,7 @@ describe('js-joda YearMonth', () => {
             };
             expect(yearMonth.isSupported(unit)).to.be.true;
         });
-        
+
     });
 
     describe('with(TemporalField, value)', () => {
@@ -97,7 +97,7 @@ describe('js-joda YearMonth', () => {
             expect(test.with(ChronoField.ERA, 0)).to.eql(YearMonth.of(-2014, 12));
             expect(test.with(ChronoField.ERA, 1)).to.eql(YearMonth.of(2015, 12));
         });
-        
+
         it('should return corresponding value of adjustInto for TemporalField', () => {
             const yearMonth = new YearMonth(2016, 1);
             const field = new TemporalField();
@@ -106,30 +106,30 @@ describe('js-joda YearMonth', () => {
             };
             expect(yearMonth.with(field, 1)).to.eql('Test Value');
         });
-        
+
         it('should fail if field is null', () => {
             expect(() => {
                 const test = YearMonth.of(2016, 1);
                 test.with(null, 1);
             }).to.throw(NullPointerException);
         });
-        
+
         it('should fail for unsupported ChronoField', () => {
             expect(() => {
                 const test = YearMonth.of(2016, 1);
                 test.with(ChronoField.HOUR_OF_DAY, 1);
             }).to.throw(UnsupportedTemporalTypeException);
         });
-        
+
         it('should fail if field is not a TemporalField', () => {
             expect(() => {
                 const test = YearMonth.of(2016, 1);
                 test.with({}, 1);
-            }).to.throw(IllegalArgumentException);
+            }).to.throw(IllegalArgumentException, 'field must be an instance of [object TemporalField], but is [object Object]');
         });
-        
+
     });
-    
+
     describe('plus', () => {
         it('should add the given values', () => {
             const test = YearMonth.of(2015, 12);
@@ -142,7 +142,7 @@ describe('js-joda YearMonth', () => {
             assertEquals(test.plus(1, ChronoUnit.MILLENNIA), YearMonth.of(3015, 12));
             assertEquals(test.plus(0, ChronoUnit.ERAS), YearMonth.of(2015, 12));
         });
-        
+
         it('should return corresponding value of addTo for TemporalUnit', () => {
             const yearMonth = new YearMonth(2016, 1);
             const unit = new TemporalUnit();
@@ -151,21 +151,21 @@ describe('js-joda YearMonth', () => {
             };
             expect(yearMonth.plus(1, unit)).to.eql('Test Value');
         });
-        
+
         it('should fail if first argument is null', () => {
             expect(() => {
                 const test = YearMonth.of(2016, 1);
                 test.plus(null);
             }).to.throw(NullPointerException);
         });
-        
+
         it('should fail if second argument is null', () => {
             expect(() => {
                 const test = YearMonth.of(2016, 1);
                 test.plus(1, null);
             }).to.throw(NullPointerException);
         });
-        
+
         it('should fail for unsupported ChronoUnit', () => {
             expect(() => {
                 const test = YearMonth.of(2016, 1);
@@ -173,7 +173,7 @@ describe('js-joda YearMonth', () => {
             }).to.throw(UnsupportedTemporalTypeException);
         });
     });
-    
+
     describe('minus', () => {
         it('should subtract the given values', () => {
             const test = YearMonth.of(2015, 12);
@@ -186,14 +186,14 @@ describe('js-joda YearMonth', () => {
             assertEquals(test.minus(1, ChronoUnit.MILLENNIA), YearMonth.of(1015, 12));
             assertEquals(test.minus(1, ChronoUnit.ERAS), YearMonth.of(-2014, 12));
         });
-        
+
         it('should fail if first argument is null', () => {
             expect(() => {
                 const test = YearMonth.of(2016, 1);
                 test.minus(null);
             }).to.throw(NullPointerException);
         });
-        
+
         it('should fail if second argument is null', () => {
             expect(() => {
                 const test = YearMonth.of(2016, 1);
@@ -201,7 +201,7 @@ describe('js-joda YearMonth', () => {
             }).to.throw(NullPointerException);
         });
     });
-    
+
     describe('until', () => {
         it('should return result for the given values', () => {
             const test = YearMonth.of(2015, 12);
@@ -213,7 +213,7 @@ describe('js-joda YearMonth', () => {
             assertEquals(test.until(end, ChronoUnit.MILLENNIA), 0);
             assertEquals(test.until(end, ChronoUnit.ERAS), 0);
         });
-        
+
         it('should return corresponding value of addTo for TemporalUnit', () => {
             const test = YearMonth.of(2015, 12);
             const end = YearMonth.of(2016, 12);
@@ -223,14 +223,14 @@ describe('js-joda YearMonth', () => {
             };
             expect(test.until(end, unit)).to.eql('Test Value');
         });
-        
+
         it('should fail if first argument is null', () => {
             expect(() => {
                 const test = YearMonth.of(2015, 12);
                 test.until(null, ChronoUnit.YEARS);
             }).to.throw(NullPointerException);
         });
-        
+
         it('should fail if second argument is null', () => {
             expect(() => {
                 const test = YearMonth.of(2015, 12);
@@ -238,7 +238,7 @@ describe('js-joda YearMonth', () => {
                 test.until(end, null);
             }).to.throw(NullPointerException);
         });
-        
+
         it('should fail for unsupported ChronoUnit', () => {
             expect(() => {
                 const test = YearMonth.of(2015, 12);
@@ -247,7 +247,7 @@ describe('js-joda YearMonth', () => {
             }).to.throw(UnsupportedTemporalTypeException);
         });
     });
-    
+
     describe('atEndOfMonth', () => {
         it('should return end of month', () => {
             assertEquals(YearMonth.of(2016, 1).atEndOfMonth(), LocalDate.of(2016, 1, 31));
@@ -264,9 +264,9 @@ describe('js-joda YearMonth', () => {
             assertEquals(YearMonth.of(2016, 12).atEndOfMonth(), LocalDate.of(2016, 12, 31));
         });
     });
-    
+
     describe('query', () => {
-        
+
         it('should return corresponding value of queryFrom for TemporalQuery', () => {
             const test = YearMonth.of(2015, 12);
             const query = new TemporalQuery();
@@ -276,5 +276,5 @@ describe('js-joda YearMonth', () => {
             expect(test.query(query)).to.eql('Test Value');
         });
     });
-    
+
 });

--- a/packages/core/test/YearTest.js
+++ b/packages/core/test/YearTest.js
@@ -21,18 +21,18 @@ import { Year } from '../src/Year';
 /* these are not covered by the threetenbp ported tests */
 describe('js-joda Year', () => {
     const testYear = new Year(2016);
-    
+
     describe('from', () => {
-        
+
         it('should return the same Year it has been called with', () => {
             const newYear = Year.from(testYear);
             expect(newYear).to.equal(testYear);
         });
-        
+
     });
-    
+
     describe('isSupported', () => {
-        
+
         it('should return true for supported ChronoUnits', () => {
             expect(testYear.isSupported(ChronoUnit.YEARS)).to.be.true;
             expect(testYear.isSupported(ChronoUnit.DECADES)).to.be.true;
@@ -40,21 +40,21 @@ describe('js-joda Year', () => {
             expect(testYear.isSupported(ChronoUnit.MILLENNIA)).to.be.true;
             expect(testYear.isSupported(ChronoUnit.ERAS)).to.be.true;
         });
-        
+
         it('should return false for unsupported ChronoUnits', () => {
             expect(testYear.isSupported(ChronoUnit.HOUR_OF_DAY)).to.be.false;
             expect(testYear.isSupported(ChronoUnit.DAY_OF_YEAR)).to.be.false;
             expect(testYear.isSupported(ChronoUnit.MONTHS)).to.be.false;
             expect(testYear.isSupported(null)).to.be.false;
         });
-        
+
         it('should return false for unsupported ChronoFields', () => {
             expect(testYear.isSupported(ChronoField.HOUR_OF_DAY)).to.be.false;
             expect(testYear.isSupported(ChronoField.DAY_OF_YEAR)).to.be.false;
             expect(testYear.isSupported(ChronoField.MONTH_OF_YEAR)).to.be.false;
             expect(testYear.isSupported(null)).to.be.false;
         });
-        
+
         it('should return corresponding value of isSupportedBy for TemporalFields', () => {
             let field = new TemporalField();
             field.isSupportedBy = () => {
@@ -67,7 +67,7 @@ describe('js-joda Year', () => {
             };
             expect(testYear.isSupported(field)).to.be.true;
         });
-        
+
         it('should return corresponding value of isSupportedBy for TemporalUnits', () => {
             let unit = new TemporalUnit();
             unit.isSupportedBy = () => {
@@ -80,15 +80,15 @@ describe('js-joda Year', () => {
             };
             expect(testYear.isSupported(unit)).to.be.true;
         });
-        
+
     });
-    
+
     describe('range', () => {
-        
+
         it('should return the range of YEAR_OF_ERA', () => {
             assertEquals(testYear.range(ChronoField.YEAR_OF_ERA), ChronoField.YEAR_OF_ERA.range());
         });
-        
+
         it('should return corresponding value of rangeRefindeBy for TemporalField', () => {
             const field = new TemporalField();
             field.rangeRefinedBy = () => {
@@ -99,15 +99,15 @@ describe('js-joda Year', () => {
             };
             expect(testYear.range(field)).to.eql('Test Value');
         });
-        
+
         it('should throw exception for unsupported ChronoFields', () => {
             expect(() => {
                 testYear.range(ChronoField.DAY_OF_MONTH);
             }).to.throw(UnsupportedTemporalTypeException);
         });
-        
+
     });
-    
+
     describe('get', () => {
         it('should return corresponding value of getFrom for TemporalField', () => {
             const field = new TemporalField();
@@ -122,28 +122,28 @@ describe('js-joda Year', () => {
             };
             expect(testYear.get(field)).to.eql(1234);
         });
-        
+
         it('should throw exception for unsupported ChronoFields', () => {
             expect(() => {
                 testYear.get(ChronoField.DAY_OF_MONTH);
             }).to.throw(UnsupportedTemporalTypeException);
         });
-        
+
     });
-    
+
     describe('with(Year)', () => {
         it('should set the given value', () => {
             expect(testYear.with(Year.of(2015)).value()).to.eql(2015);
             expect(testYear.with(Year.of(0)).value()).to.eql(0);
         });
-        
+
         it('should fail if year is null', () => {
             expect(() => {
                 testYear.with(null);
             }).to.throw(NullPointerException);
         });
     });
-    
+
     describe('with(TemporalField, value)', () => {
         it('should set the given values', () => {
             const test = Year.of(2015, 12);
@@ -154,7 +154,7 @@ describe('js-joda Year', () => {
             expect(test.with(ChronoField.ERA, 0)).to.eql(Year.of(-2014, 12));
             expect(test.with(ChronoField.ERA, 1)).to.eql(Year.of(2015, 12));
         });
-        
+
         it('should return corresponding value of adjustInto for TemporalField', () => {
             const field = new TemporalField();
             field.adjustInto = () => {
@@ -162,27 +162,27 @@ describe('js-joda Year', () => {
             };
             expect(testYear.with(field, 1)).to.eql('Test Value');
         });
-        
+
         it('should fail if field is null', () => {
             expect(() => {
                 testYear.with(null, 1);
             }).to.throw(NullPointerException);
         });
-        
+
         it('should fail for unsupported ChronoField', () => {
             expect(() => {
                 testYear.with(ChronoField.HOUR_OF_DAY, 1);
             }).to.throw(UnsupportedTemporalTypeException);
         });
-        
+
         it('should fail if field is not a TemporalField', () => {
             expect(() => {
                 testYear.with({}, 1);
-            }).to.throw(IllegalArgumentException);
+            }).to.throw(IllegalArgumentException, 'field must be an instance of [object TemporalField], but is [object Object]');
         });
-        
+
     });
-    
+
     describe('plus', () => {
         it('should add the given values', () => {
             // plus(TemporalAmount)
@@ -193,7 +193,7 @@ describe('js-joda Year', () => {
             assertEquals(testYear.plus(1, ChronoUnit.MILLENNIA), Year.of(3016));
             assertEquals(testYear.plus(0, ChronoUnit.ERAS), Year.of(2016));
         });
-        
+
         it('should return corresponding value of addTo for TemporalUnit', () => {
             const unit = new TemporalUnit();
             unit.addTo = () => {
@@ -201,26 +201,26 @@ describe('js-joda Year', () => {
             };
             expect(testYear.plus(1, unit)).to.eql('Test Value');
         });
-        
+
         it('should fail if first argument is null', () => {
             expect(() => {
                 testYear.plus(null);
             }).to.throw(NullPointerException);
         });
-        
+
         it('should fail if second argument is null', () => {
             expect(() => {
                 testYear.plus(1, null);
             }).to.throw(NullPointerException);
         });
-        
+
         it('should fail for unsupported ChronoUnit', () => {
             expect(() => {
                 testYear.plus(1, ChronoUnit.SECONDS);
             }).to.throw(UnsupportedTemporalTypeException);
         });
     });
-    
+
     describe('minus', () => {
         it('should subtract the given values', () => {
             // minus(TemporalAmount)
@@ -231,22 +231,22 @@ describe('js-joda Year', () => {
             assertEquals(testYear.minus(1, ChronoUnit.MILLENNIA), Year.of(1016));
             assertEquals(testYear.minus(1, ChronoUnit.ERAS), Year.of(-2015));
         });
-        
+
         it('should fail if first argument is null', () => {
             expect(() => {
                 testYear.minus(null);
             }).to.throw(NullPointerException);
         });
-        
+
         it('should fail if second argument is null', () => {
             expect(() => {
                 testYear.minus(1, null);
             }).to.throw(NullPointerException);
         });
     });
-    
+
     describe('query', () => {
-        
+
         it('should return corresponding value of queryFrom for TemporalQuery', () => {
             const query = new TemporalQuery();
             query.queryFrom = () => {
@@ -255,6 +255,6 @@ describe('js-joda Year', () => {
             expect(testYear.query(query)).to.eql('Test Value');
         });
     });
-    
-    
+
+
 });

--- a/packages/core/test/assertTest.js
+++ b/packages/core/test/assertTest.js
@@ -35,15 +35,23 @@ describe('assert.js', () => {
     });
 
     it('requireInstance', function () {
-        class Bar {}
-        class Foo {}
+        class Bar {
+            get [Symbol.toStringTag]() {
+                return 'Bar';
+            }
+        }
+        class Foo {
+            get [Symbol.toStringTag]() {
+                return 'Foo';
+            }
+        }
 
         requireInstance(new Foo(), Foo, 'foo');
 
-        expect(() => {requireInstance({}, Foo, 'nameOfObject');}).to.throw(IllegalArgumentException);
-        expect(() => {requireInstance(Foo, Foo, 'nameOfObject');}).to.throw(IllegalArgumentException);
-        expect(() => {requireInstance(new Bar(), Foo, 'nameOfObject');}).to.throw(IllegalArgumentException);
-        expect(() => {requireInstance(null, Foo, 'nameOfObject');}).to.throw(IllegalArgumentException);
-        expect(() => {requireInstance(undefined, Foo, 'nameOfObject');}).to.throw(IllegalArgumentException);
+        expect(() => {requireInstance({}, Foo, 'nameOfObject');}).to.throw(IllegalArgumentException, 'nameOfObject must be an instance of [object Foo], but is [object Object]');
+        expect(() => {requireInstance(Foo, Foo, 'nameOfObject');}).to.throw(IllegalArgumentException, 'nameOfObject must be an instance of [object Foo], but is [object Function]');
+        expect(() => {requireInstance(new Bar(), Foo, 'nameOfObject');}).to.throw(IllegalArgumentException, 'nameOfObject must be an instance of [object Foo], but is [object Bar]');
+        expect(() => {requireInstance(null, Foo, 'nameOfObject');}).to.throw(IllegalArgumentException, 'nameOfObject must be an instance of [object Foo], but is [object Null]');
+        expect(() => {requireInstance(undefined, Foo, 'nameOfObject');}).to.throw(IllegalArgumentException, 'nameOfObject must be an instance of [object Foo], but is [object Undefined]');
     });
 });

--- a/packages/core/test/convertTest.js
+++ b/packages/core/test/convertTest.js
@@ -68,7 +68,7 @@ describe('convert', () => {
     it('should fail if temporal is not an instance of LocalDate, LocalDateTime or ZonedDateTime', () => {
         expect(()=>{
             convert(new Date()).toDate();
-        }).to.throw(IllegalArgumentException);
+        }).to.throw(IllegalArgumentException, 'unsupported instance for convert operation:[object Date]');
     });
 
 });

--- a/packages/core/test/reference/InstantTest.js
+++ b/packages/core/test/reference/InstantTest.js
@@ -803,9 +803,9 @@ describe('org.threeten.bp.TestInstant', () => {
         it('instant to UTC zdt and back are equal', () => {
             const base = Instant.now();
             expect(base.equals(base.atZone(ZoneOffset.UTC).toInstant()));
-        });    
+        });
     });
-    
+
     describe('plusSeconds', () => {
         let dataProviderPlus;
         beforeEach(() => {
@@ -1996,7 +1996,7 @@ describe('org.threeten.bp.TestInstant', () => {
             expect(() => {
                 const c = Instant.ofEpochSecond(0);
                 c.compareTo({});
-            }).to.throw(IllegalArgumentException);
+            }).to.throw(IllegalArgumentException, 'otherInstant must be an instance of [object Instant], but is [object Object]');
         });
 
     });

--- a/packages/core/test/reference/LocalDateTest.js
+++ b/packages/core/test/reference/LocalDateTest.js
@@ -1615,7 +1615,7 @@ describe('org.threeten.bp.TestLocalDate', () => {
             expect(() => {
                 const t = LocalDate.of(2008, 6, 30);
                 t.atTime('string');
-            }).to.throw(IllegalArgumentException);
+            }).to.throw(IllegalArgumentException, 'time must be an instance of LocalTime or OffsetTime, but is [object String]');
         });
 
         it('test_atTime_int_int', () => {
@@ -1890,7 +1890,7 @@ describe('org.threeten.bp.TestLocalDate', () => {
         it('compareToNonLocalDate', function () {
             expect(() => {
                 TEST_2007_07_15.compareTo({});
-            }).to.throw(IllegalArgumentException);
+            }).to.throw(IllegalArgumentException, 'other must be an instance of [object LocalDate], but is [object Object]');
         });
 
 

--- a/packages/core/test/reference/LocalTimeTest.js
+++ b/packages/core/test/reference/LocalTimeTest.js
@@ -1943,7 +1943,7 @@ describe('org.threeten.bp.TestLocalTime', function () {
         it('compareToNonLocalTime', () => {
             expect(() => {
                 TEST_12_30_40_987654321.compareTo({});
-            }).to.throw(IllegalArgumentException);
+            }).to.throw(IllegalArgumentException, 'other must be an instance of [object LocalTime], but is [object Object]');
         });
 
     });

--- a/packages/core/test/reference/OffsetDateTimeTest.js
+++ b/packages/core/test/reference/OffsetDateTimeTest.js
@@ -60,7 +60,7 @@ describe('org.threeten.bp.TestOffsetDateTime', () => {
         [2008, 6, 30, 23, 59, 59, 999999999, OFFSET_PONE],
         [-1, 1, 1, 0, 0, 0, 0, OFFSET_PONE],
     ];
-    
+
     let TEST_2008_6_30_11_30_59_000000500;
 
     beforeEach(() => {
@@ -944,7 +944,7 @@ describe('org.threeten.bp.TestOffsetDateTime', () => {
             expect(() => {
                 const c = TEST_2008_6_30_11_30_59_000000500;
                 c.compareTo(new Object());
-            }).to.throw(IllegalArgumentException);
+            }).to.throw(IllegalArgumentException, 'other must be an instance of [object OffsetDateTime], but is [object Object]');
         });
     });
 });

--- a/packages/core/test/reference/OffsetTimeTest.js
+++ b/packages/core/test/reference/OffsetTimeTest.js
@@ -538,7 +538,7 @@ describe('org.threeten.bp.TestOffsetTime', () => {
             assertEquals(test, base);
         });
     });
-    
+
     describe('withMinute', () => {
         it('normal', function () {
             const base = OffsetTime.of(LocalTime.of(11, 30, 59), OFFSET_PONE);
@@ -819,7 +819,7 @@ describe('org.threeten.bp.TestOffsetTime', () => {
             expect(() => {
                 const c = TEST_11_30_59_500_PONE;
                 c.compareTo(new Object());
-            }).to.throw(IllegalArgumentException); // ClassCastException
+            }).to.throw(IllegalArgumentException, 'other must be an instance of [object OffsetTime], but is [object Object]'); // ClassCastException
         });
 
         function convertInstant(ot) {

--- a/packages/extra/src/DayOfMonth.js
+++ b/packages/extra/src/DayOfMonth.js
@@ -14,11 +14,11 @@ const MathUtil = jodaInternal.MathUtil;
 
 /**
  * A day-of-month in the ISO-8601 calendar system.
- * 
+ *
  * {@link DayOfMonth} is an immutable date-time object that represents a day-of-month.
  * It is a type-safe way of representing a day-of-month in an application.
  * Any field that can be derived from a day-of-month can be obtained.
- * 
+ *
  * This class does not store or represent a year, month, time or time-zone.
  * For example, the value '21' can be stored in a {@link DayOfMonth} and
  * would represent the 21st day of any month.
@@ -31,7 +31,7 @@ export class DayOfMonth extends TemporalAccessor {
      * - if called with an instance of {@link ZoneId}, then {@link DayOfMonth._nowZoneId} is executed;
      * - if called with an instance of {@link Clock}, then {@link DayOfMonth._nowClock} is executed;
      * - otherwise {@link IllegalArgumentException} is thrown.
-     * 
+     *
      * @param {?(ZoneId|Clock)} zoneIdOrClock
      * @return {DayOfMonth}
      */
@@ -55,11 +55,11 @@ export class DayOfMonth extends TemporalAccessor {
 
     /**
      * Obtains the current day-of-month from the system clock in the default time-zone.
-     * 
+     *
      * This will query the {@link Clock.systemDefaultZone} system clock in the default
      * time-zone to obtain the current day-of-month.
      * The zone and offset will be set based on the time-zone in the clock.
-     * 
+     *
      * Using this method will prevent the ability to use an alternate clock for testing
      * because the clock is hard-coded.
      *
@@ -72,10 +72,10 @@ export class DayOfMonth extends TemporalAccessor {
 
     /**
      * Obtains the current day-of-month from the system clock in the specified time-zone.
-     * 
+     *
      * This will query the {@link Clock#system(java.time.ZoneId) system clock} to obtain the current day-of-month.
      * Specifying the time-zone avoids dependence on the default time-zone.
-     * 
+     *
      * Using this method will prevent the ability to use an alternate clock for testing
      * because the clock is hard-coded.
      *
@@ -89,7 +89,7 @@ export class DayOfMonth extends TemporalAccessor {
 
     /**
      * Obtains the current day-of-month from the specified clock.
-     * 
+     *
      * This will query the specified clock to obtain the current day-of-month.
      * Using this method allows the use of an alternate clock for testing.
      * The alternate clock may be introduced using {@link Clock dependency injection}.
@@ -106,7 +106,7 @@ export class DayOfMonth extends TemporalAccessor {
     //-----------------------------------------------------------------------
     /**
      * Obtains an instance of {@link DayOfMonth}.
-     * 
+     *
      * A day-of-month object represents one of the 31 days of the month, from 1 to 31.
      *
      * @param {number} dayOfMonth - the day-of-month to represent, from 1 to 31
@@ -124,15 +124,15 @@ export class DayOfMonth extends TemporalAccessor {
     //-----------------------------------------------------------------------
     /**
      * Obtains an instance of {@link DayOfMonth} from a date-time object.
-     * 
+     *
      * This obtains a day-of-month based on the specified temporal.
      * A {@link TemporalAccessor} represents an arbitrary set of date and time information,
      * which this factory converts to an instance of {@link DayOfMonth}.
-     * 
+     *
      * The conversion extracts the {@link ChronoField#DAY_OF_MONTH} day-of-month field.
      * The extraction is only permitted if the temporal object has an ISO
      * chronology, or can be converted to a {@link LocalDate}.
-     * 
+     *
      * This method matches the signature of the functional interface {@link TemporalQuery}
      * allowing it to be used in queries via method reference, {@link DayOfMonth.from}.
      *
@@ -168,6 +168,10 @@ export class DayOfMonth extends TemporalAccessor {
         this._day = MathUtil.safeToInt(dayOfMonth);
     }
 
+    get [Symbol.toStringTag]() {
+        return 'DayOfMonth';
+    }
+
     //-----------------------------------------------------------------------
     /**
      * Gets the day-of-month value.
@@ -181,19 +185,19 @@ export class DayOfMonth extends TemporalAccessor {
     //-----------------------------------------------------------------------
     /**
      * Checks if the specified field is supported.
-     * 
+     *
      * This checks if this day-of-month can be queried for the specified field.
      * If false, then calling the {@link DayOfMonth.range} range,
      * {@link DayOfMonth.get} get and {@link DayOfMonth.getLong} getLong
      * methods will throw an exception.
-     * 
+     *
      * If the field is a {@link ChronoField} then the query is implemented here.
      * The supported fields are:
      * <ul>
      * <li>{@link ChronoField.DAY_OF_MONTH}
      * </ul>
      * All other {@link ChronoField} instances will return false.
-     * 
+     *
      * If the field is not a {@link ChronoField}, then the result of this method
      * is obtained by invoking {@link TemporalField.isSupportedBy}
      * passing this as the argument.
@@ -212,17 +216,17 @@ export class DayOfMonth extends TemporalAccessor {
     //-----------------------------------------------------------------------
     /**
      * Gets the range of valid values for the specified field.
-     * 
+     *
      * The range object expresses the minimum and maximum valid values for a field.
      * This day-of-month is used to enhance the accuracy of the returned range.
      * If it is not possible to return the range, because the field is not supported
      * or for some other reason, an exception is thrown.
-     * 
+     *
      * If the field is a {@link ChronoField} then the query is implemented here.
      * The {@link DayOfMonth.isSupported} supported fields will return
      * appropriate range instances.
      * All other {@link ChronoField} instances will throw an {@link UnsupportedTemporalTypeException}.
-     * 
+     *
      * If the field is not a {@link ChronoField}, then the result of this method
      * is obtained by invoking {@link TemporalField.rangeRefinedBy}
      * passing this as the argument.
@@ -243,17 +247,17 @@ export class DayOfMonth extends TemporalAccessor {
 
     /**
      * Gets the value of the specified field from this day-of-month as an `int`.
-     * 
+     *
      * This queries this day-of-month for the value for the specified field.
      * The returned value will always be within the valid range of values for the field.
      * If it is not possible to return the value, because the field is not supported
      * or for some other reason, an exception is thrown.
-     * 
+     *
      * If the field is a {@link ChronoField} then the query is implemented here.
      * The {@link DayOfMonth.isSupported} supported fields will return valid
      * values based on this day-of-month.
      * All other {@link ChronoField} instances will throw an {@link UnsupportedTemporalTypeException}.
-     * 
+     *
      * If the field is not a {@link ChronoField}, then the result of this method
      * is obtained by invoking {@link TemporalField.getFrom}
      * passing this as the argument. Whether the value can be obtained,
@@ -273,16 +277,16 @@ export class DayOfMonth extends TemporalAccessor {
 
     /**
      * Gets the value of the specified field from this day-of-month as a `long`.
-     * 
+     *
      * This queries this day-of-month for the value for the specified field.
      * If it is not possible to return the value, because the field is not supported
      * or for some other reason, an exception is thrown.
-     * 
+     *
      * If the field is a {@link ChronoField} then the query is implemented here.
      * The {@link DayOfMonth.isSupported(TemporalField) supported fields} will return valid
      * values based on this day-of-month.
      * All other {@link ChronoField} instances will throw an {@link UnsupportedTemporalTypeException}.
-     * 
+     *
      * If the field is not a {@link ChronoField}, then the result of this method
      * is obtained by invoking {@link TemporalField.getFrom}
      * passing this as the argument. Whether the value can be obtained,
@@ -307,7 +311,7 @@ export class DayOfMonth extends TemporalAccessor {
     //-----------------------------------------------------------------------
     /**
      * Checks if the year-month is valid for this year.
-     * 
+     *
      * This method checks whether this day and the input year and month form
      * a valid date.
      *
@@ -321,12 +325,12 @@ export class DayOfMonth extends TemporalAccessor {
     //-----------------------------------------------------------------------
     /**
      * Queries this day-of-month using the specified query.
-     * 
+     *
      * This queries this day-of-month using the specified query strategy object.
      * The {@link TemporalQuery} object defines the logic to be used to
      * obtain the result. Read the documentation of the query to understand
      * what the result of this method will be.
-     * 
+     *
      * The result of this method is obtained by invoking the
      * {@link TemporalQuery.queryFrom} method on the
      * specified query passing this as the argument.
@@ -347,15 +351,15 @@ export class DayOfMonth extends TemporalAccessor {
 
     /**
      * Adjusts the specified temporal object to have this day-of-month.
-     * 
+     *
      * This returns a temporal object of the same observable type as the input
      * with the day-of-month changed to be the same as this.
-     * 
+     *
      * The adjustment is equivalent to using {@link Temporal.with}
      * passing {@link ChronoField.DAY_OF_MONTH} as the field.
      * If the specified temporal object does not use the ISO calendar system then
      * a {@link DateTimeException} is thrown.
-     * 
+     *
      * In most cases, it is clearer to reverse the calling pattern by using
      * {@link Temporal.with}:
      * ```
@@ -363,7 +367,7 @@ export class DayOfMonth extends TemporalAccessor {
      *   temporal = thisDay.adjustInto(temporal);
      *   temporal = temporal.with(thisDay);
      * ```
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
      *
      * @param {Temporal} temporal - the target object to be adjusted, not null
@@ -383,14 +387,14 @@ export class DayOfMonth extends TemporalAccessor {
     //-----------------------------------------------------------------------
     /**
      * Combines this day-of-month with a month to create a {@link MonthDay}.
-     * 
+     *
      * This returns a {@link MonthDay} formed from this day and the specified month.
-     * 
+     *
      * This method can be used as part of a chain to produce a date:
      * ```
      *  LocalDate date = day.atMonth(month).atYear(year);
      * ```
-     * 
+     *
      * If this day-of-month is invalid for the month then it will be changed
      * to the last valid date for the month.
      *
@@ -408,9 +412,9 @@ export class DayOfMonth extends TemporalAccessor {
 
     /**
      * Combines this day-of-month with a year-month to create a {@link LocalDate}.
-     * 
+     *
      * This returns a {@link LocalDate} formed from this year and the specified year-month.
-     * 
+     *
      * If this day-of-month is invalid for the year-month then it will be changed
      * to the last valid date for the month.
      *
@@ -425,7 +429,7 @@ export class DayOfMonth extends TemporalAccessor {
     //-----------------------------------------------------------------------
     /**
      * Compares this day-of-month to another.
-     * 
+     *
      * The comparison is based on the value of the day.
      * It is 'consistent with equals', as defined by {@link Comparable}.
      *

--- a/packages/extra/src/DayOfYear.js
+++ b/packages/extra/src/DayOfYear.js
@@ -14,11 +14,11 @@ const MathUtil = jodaInternal.MathUtil;
 
 /**
  * A day-of-year in the ISO-8601 calendar system.
- * 
+ *
  * {@link DayOfYear} is an immutable date-time object that represents a day-of-year.
  * It is a type-safe way of representing a day-of-year in an application.
  * Any field that can be derived from a day-of-year can be obtained.
- * 
+ *
  * This class does not store or represent a year, month, time or time-zone.
  * For example, the value "51" can be stored in a {@link DayOfYear} and
  * would represent the 51st day of any year.
@@ -30,7 +30,7 @@ export class DayOfYear extends TemporalAccessor {
      * - if called with an instance of {@link ZoneId}, then {@link DayOfYear._nowZoneId} is executed;
      * - if called with an instance of {@link Clock}, then {@link DayOfYear._nowClock} is executed;
      * - otherwise {@link IllegalArgumentException} is thrown.
-     * 
+     *
      * @param {?(ZoneId|Clock)} zoneIdOrClock
      * @return {DayOfYear}
      */
@@ -55,11 +55,11 @@ export class DayOfYear extends TemporalAccessor {
     //-----------------------------------------------------------------------
     /**
      * Obtains the current day-of-year from the system clock in the default time-zone.
-     * 
+     *
      * This will query the {@link Clock.systemDefaultZone} system clock in the default
      * time-zone to obtain the current day-of-year.
      * The zone and offset will be set based on the time-zone in the clock.
-     * 
+     *
      * Using this method will prevent the ability to use an alternate clock for testing
      * because the clock is hard-coded.
      *
@@ -72,10 +72,10 @@ export class DayOfYear extends TemporalAccessor {
 
     /**
      * Obtains the current day-of-year from the system clock in the specified time-zone.
-     * 
+     *
      * This will query the {@link Clock.system} system clock to obtain the current day-of-year.
      * Specifying the time-zone avoids dependence on the default time-zone.
-     * 
+     *
      * Using this method will prevent the ability to use an alternate clock for testing
      * because the clock is hard-coded.
      *
@@ -89,7 +89,7 @@ export class DayOfYear extends TemporalAccessor {
 
     /**
      * Obtains the current day-of-year from the specified clock.
-     * 
+     *
      * This will query the specified clock to obtain the current day-of-year.
      * Using this method allows the use of an alternate clock for testing.
      * The alternate clock may be introduced using {@link Clock} dependency injection.
@@ -106,7 +106,7 @@ export class DayOfYear extends TemporalAccessor {
     //-----------------------------------------------------------------------
     /**
      * Obtains an instance of {@link DayOfYear}.
-     * 
+     *
      * A day-of-year object represents one of the 366 days of the year, from 1 to 366.
      *
      * @param {number} dayOfYear - the day-of-year to represent, from 1 to 366
@@ -124,15 +124,15 @@ export class DayOfYear extends TemporalAccessor {
     //-----------------------------------------------------------------------
     /**
      * Obtains an instance of {@link DayOfYear} from a date-time object.
-     * 
+     *
      * This obtains a day-of-year based on the specified temporal.
      * A {@link TemporalAccessor} represents an arbitrary set of date and time information,
      * which this factory converts to an instance of {@link DayOfYear}.
-     * 
+     *
      * The conversion extracts the {@link ChronoField.DAY_OF_YEAR} day-of-year field.
      * The extraction is only permitted if the temporal object has an ISO
      * chronology, or can be converted to a {@link LocalDate}.
-     * 
+     *
      * This method matches the signature of the functional interface {@link TemporalQuery}
      * allowing it to be used in queries via method reference, {@link DayOfYear.from}.
      *
@@ -157,7 +157,7 @@ export class DayOfYear extends TemporalAccessor {
         }
     }
 
-    
+
     //-----------------------------------------------------------------------
     /**
      * Constructor, previously validated.
@@ -168,6 +168,10 @@ export class DayOfYear extends TemporalAccessor {
     constructor(dayOfYear) {
         super();
         this._day = MathUtil.safeToInt(dayOfYear);
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'DayOfYear';
     }
 
     //-----------------------------------------------------------------------
@@ -183,18 +187,18 @@ export class DayOfYear extends TemporalAccessor {
     //-----------------------------------------------------------------------
     /**
      * Checks if the specified field is supported.
-     * 
+     *
      * This checks if this day-of-year can be queried for the specified field.
      * If false, then calling the {@link DayOfYear.range} range,
      * {@link DayOfYear.get} get and {@link DayOfYear.getLong} getLong
      * methods will throw an exception.
-     * 
+     *
      * If the field is a {@link ChronoField} then the query is implemented here.
      * The supported fields are:
      * - {@link ChronoField.DAY_OF_YEAR}
-     * 
+     *
      * All other {@link ChronoField} instances will return false.
-     * 
+     *
      * If the field is not a {@link ChronoField}, then the result of this method
      * is obtained by invoking {@link TemporalField.isSupportedBy}
      * passing this as the argument.
@@ -213,17 +217,17 @@ export class DayOfYear extends TemporalAccessor {
     //-----------------------------------------------------------------------
     /**
      * Gets the range of valid values for the specified field.
-     * 
+     *
      * The range object expresses the minimum and maximum valid values for a field.
      * This day-of-year is used to enhance the accuracy of the returned range.
      * If it is not possible to return the range, because the field is not supported
      * or for some other reason, an exception is thrown.
-     * 
+     *
      * If the field is a {@link ChronoField} then the query is implemented here.
      * The {@link DayOfYear.isSupported} supported fields will return
      * appropriate range instances.
      * All other {@code ChronoField} instances will throw an {@link UnsupportedTemporalTypeException}.
-     * 
+     *
      * If the field is not a {@link ChronoField}, then the result of this method
      * is obtained by invoking {@link TemporalField.rangeRefinedBy}
      * passing this as the argument.
@@ -244,17 +248,17 @@ export class DayOfYear extends TemporalAccessor {
 
     /**
      * Gets the value of the specified field from this day-of-year as an `int`.
-     * 
+     *
      * This queries this day-of-year for the value for the specified field.
      * The returned value will always be within the valid range of values for the field.
      * If it is not possible to return the value, because the field is not supported
      * or for some other reason, an exception is thrown.
-     * 
+     *
      * If the field is a {@link ChronoField} then the query is implemented here.
      * The {@link DayOfYear.isSupported} supported fields will return valid
      * values based on this day-of-year.
      * All other {@link ChronoField} instances will throw an {@link UnsupportedTemporalTypeException}.
-     * 
+     *
      * If the field is not a {@link ChronoField}, then the result of this method
      * is obtained by invoking {@link TemporalField.getFrom}
      * passing this as the argument. Whether the value can be obtained,
@@ -274,16 +278,16 @@ export class DayOfYear extends TemporalAccessor {
 
     /**
      * Gets the value of the specified field from this day-of-year as a `long`.
-     * 
+     *
      * This queries this day-of-year for the value for the specified field.
      * If it is not possible to return the value, because the field is not supported
      * or for some other reason, an exception is thrown.
-     * 
+     *
      * If the field is a {@link ChronoField} then the query is implemented here.
      * The {@link DayOfYear.isSupported} supported fields will return valid
      * values based on this day-of-year.
      * All other {@code ChronoField} instances will throw an {@link UnsupportedTemporalTypeException}.
-     * 
+     *
      * If the field is not a {@link ChronoField}, then the result of this method
      * is obtained by invoking {@link TemporalField.getFrom}
      * passing this as the argument. Whether the value can be obtained,
@@ -308,7 +312,7 @@ export class DayOfYear extends TemporalAccessor {
     //-----------------------------------------------------------------------
     /**
      * Checks if the year is valid for this day-of-year.
-     * 
+     *
      * This method checks whether this day-of-yearand the input year form
      * a valid date. This can only return false for day-of-year 366.
      *
@@ -322,12 +326,12 @@ export class DayOfYear extends TemporalAccessor {
     //-----------------------------------------------------------------------
     /**
      * Queries this day-of-year using the specified query.
-     * 
+     *
      * This queries this day-of-year using the specified query strategy object.
      * The {@link TemporalQuery} object defines the logic to be used to
      * obtain the result. Read the documentation of the query to understand
      * what the result of this method will be.
-     * 
+     *
      * The result of this method is obtained by invoking the
      * {@link TemporalQuery.queryFrom} method on the
      * specified query passing this as the argument.
@@ -348,15 +352,15 @@ export class DayOfYear extends TemporalAccessor {
 
     /**
      * Adjusts the specified temporal object to have this day-of-year.
-     * 
+     *
      * This returns a temporal object of the same observable type as the input
      * with the day-of-year changed to be the same as this.
-     * 
+     *
      * The adjustment is equivalent to using {@link Temporal.with}
      * passing {@link ChronoField.DAY_OF_YEAR} as the field.
      * If the specified temporal object does not use the ISO calendar system then
      * a {@link DateTimeException} is thrown.
-     * 
+     *
      * In most cases, it is clearer to reverse the calling pattern by using
      * {@link Temporal.with}:
      * ```
@@ -364,7 +368,7 @@ export class DayOfYear extends TemporalAccessor {
      *   temporal = thisDay.adjustInto(temporal);
      *   temporal = temporal.with(thisDay);
      * ```
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
      *
      * @param {Temporal} temporal - the target object to be adjusted, not null
@@ -384,14 +388,14 @@ export class DayOfYear extends TemporalAccessor {
     //-----------------------------------------------------------------------
     /**
      * Combines this day-of-year with a year to create a {@link LocalDate}.
-     * 
+     *
      * This returns a {@link LocalDate} formed from this day and the specified year.
-     * 
+     *
      * This method can be used as part of a chain to produce a date:
      * ```
      *  LocalDate date = day.atYear(year);
      * ```
-     * 
+     *
      * The day-of-year value 366 is only valid in a leap year.
      *
      * @param {Year|number} year - the year to use ({@link Year} or `int`), not null
@@ -410,7 +414,7 @@ export class DayOfYear extends TemporalAccessor {
     //-----------------------------------------------------------------------
     /**
      * Compares this day-of-year to another.
-     * 
+     *
      * The comparison is based on the value of the day.
      * It is "consistent with equals", as defined by {@link Comparable}.
      *

--- a/packages/extra/src/Interval.js
+++ b/packages/extra/src/Interval.js
@@ -11,14 +11,14 @@ import { requireNonNull, requireInstance } from './assert';
 
 /**
  * An immutable interval of time between two instants.
- * 
+ *
  * An interval represents the time on the time-line between two {@link Instant}s.
  * The class stores the start and end instants, with the start inclusive and the end exclusive.
  * The end instant is always greater than or equal to the start instant.
- * 
+ *
  * The {@link Duration} of an interval can be obtained, but is a separate concept.
  * An interval is connected to the time-line, whereas a duration is not.
- * 
+ *
  * Intervals are not comparable. To compare the length of two intervals, it is
  * generally recommended to compare their durations.
  *
@@ -45,7 +45,7 @@ export class Interval {
 
     /**
      * Obtains an instance of `Interval` from the start and end instant.
-     * 
+     *
      * The end instant must not be before the start instant.
      *
      * @param {Instant} startInclusive - the start instant, inclusive, MIN_DATE treated as unbounded, not null
@@ -67,7 +67,7 @@ export class Interval {
 
     /**
      * Obtains an instance of `Interval` from the start and a duration.
-     * 
+     *
      * The end instant is calculated as the start plus the duration.
      * The duration must not be negative.
      *
@@ -95,7 +95,7 @@ export class Interval {
     /**
      * Obtains an instance of `Interval` from a text string such as
      * `2007-12-03T10:15:30Z/2007-12-04T10:15:30Z`, where the end instant is exclusive.
-     * 
+     *
      * The string must consist of one of the following three formats:
      * - a representations of an {@link ZonedDateTime}, followed by a forward slash,
      *  followed by a representation of a {@link ZonedDateTime}
@@ -154,10 +154,14 @@ export class Interval {
         this._end = endExclusive;
     }
 
+    get [Symbol.toStringTag]() {
+        return 'Interval';
+    }
+
     //-----------------------------------------------------------------------
     /**
      * Gets the start of this time interval, inclusive.
-     * 
+     *
      * This will return {@link Instant#MIN} if the range is unbounded at the start.
      * In this case, the range includes all dates into the far-past.
      *
@@ -169,7 +173,7 @@ export class Interval {
 
     /**
      * Gets the end of this time interval, exclusive.
-     * 
+     *
      * This will return {@link Instant#MAX} if the range is unbounded at the end.
      * In this case, the range includes all dates into the far-future.
      *
@@ -182,7 +186,7 @@ export class Interval {
     //-----------------------------------------------------------------------
     /**
      * Checks if the range is empty.
-     * 
+     *
      * An empty range occurs when the start date equals the inclusive end date.
      *
      * @return {boolean} true if the range is empty
@@ -235,7 +239,7 @@ export class Interval {
     //-----------------------------------------------------------------------
     /**
      * Checks if this interval contains the specified instant.
-     * 
+     *
      * This checks if the specified instant is within the bounds of this interval.
      * If this range has an unbounded start then `contains(Instant.MIN)` returns true.
      * If this range has an unbounded end then `contains(Instant.MAX)` returns true.
@@ -252,7 +256,7 @@ export class Interval {
 
     /**
      * Checks if this interval encloses the specified interval.
-     * 
+     *
      * This checks if the bounds of the specified interval are within the bounds of this interval.
      * An empty interval encloses itself.
      *
@@ -267,7 +271,7 @@ export class Interval {
 
     /**
      * Checks if this interval abuts the specified interval.
-     * 
+     *
      * The result is true if the end of this interval is the start of the other, or vice versa.
      * An empty interval does not abut itself.
      *
@@ -282,10 +286,10 @@ export class Interval {
 
     /**
      * Checks if this interval is connected to the specified interval.
-     * 
+     *
      * The result is true if the two intervals have an enclosed interval in common, even if that interval is empty.
      * An empty interval is connected to itself.
-     * 
+     *
      * This is equivalent to `(overlaps(other) || abuts(other))`.
      *
      * @param {Interval} other - the other interval, not null
@@ -299,10 +303,10 @@ export class Interval {
 
     /**
      * Checks if this interval overlaps the specified interval.
-     * 
+     *
      * The result is true if the the two intervals share some part of the time-line.
      * An empty interval overlaps itself.
-     * 
+     *
      * This is equivalent to `(isConnected(other) && !abuts(other))`.
      *
      * @param {Interval} other - the time interval to compare to, null means a zero length interval now
@@ -317,7 +321,7 @@ export class Interval {
     //-----------------------------------------------------------------------
     /**
      * Calculates the interval that is the intersection of this interval and the specified interval.
-     * 
+     *
      * This finds the intersection of two intervals.
      * This throws an exception if the two intervals are not {@linkplain #isConnected(Interval) connected}.
      *
@@ -346,7 +350,7 @@ export class Interval {
 
     /**
      * Calculates the interval that is the union of this interval and the specified interval.
-     * 
+     *
      * This finds the union of two intervals.
      * This throws an exception if the two intervals are not {@linkplain #isConnected(Interval) connected}.
      *
@@ -375,7 +379,7 @@ export class Interval {
 
     /**
      * Calculates the smallest interval that encloses this interval and the specified interval.
-     * 
+     *
      * The result of this method will {@linkplain #encloses(Interval) enclose}
      * this interval and the specified interval.
      *
@@ -427,7 +431,7 @@ export class Interval {
 
     /**
      * Checks if this interval is after the specified instant.
-     * 
+     *
      * The result is true if the this instant starts after the specified instant.
      * An empty interval behaves as though it is an instant for comparison purposes.
      *
@@ -440,7 +444,7 @@ export class Interval {
 
     /**
      * Checks if this interval is before the specified instant.
-     * 
+     *
      * The result is true if the this instant ends before the specified instant.
      * Since intervals do not include their end points, this will return true if the
      * instant equals the end of the interval.
@@ -456,7 +460,7 @@ export class Interval {
     //-------------------------------------------------------------------------
     /**
      * Checks if this interval is after the specified interval.
-     * 
+     *
      * The result is true if the this instant starts after the end of the specified interval.
      * Since intervals do not include their end points, this will return true if the
      * instant equals the end of the interval.
@@ -471,7 +475,7 @@ export class Interval {
 
     /**
      * Checks if this interval is before the specified interval.
-     * 
+     *
      * The result is true if the this instant ends before the start of the specified interval.
      * Since intervals do not include their end points, this will return true if the
      * two intervals abut.
@@ -487,7 +491,7 @@ export class Interval {
     //-----------------------------------------------------------------------
     /**
      * Obtains the duration of this interval.
-     * 
+     *
      * An `Interval` is associated with two specific instants on the time-line.
      * A `Duration` is simply an amount of time, separate from the time-line.
      *
@@ -501,7 +505,7 @@ export class Interval {
     //-----------------------------------------------------------------------
     /**
      * Checks if this interval is equal to another interval.
-     * 
+     *
      * Compares this `Interval` with another ensuring that the two instants are the same.
      * Only objects of type `Interval` are compared, other types return false.
      *
@@ -531,7 +535,7 @@ export class Interval {
     //-----------------------------------------------------------------------
     /**
      * Outputs this interval as a `String`, such as `2007-12-03T10:15:30/2007-12-04T10:15:30`.
-     * 
+     *
      * The output will be the ISO-8601 format formed by combining the
      * `toString()` methods of the two instants, separated by a forward slash.
      *

--- a/packages/extra/src/LocalDateRange.js
+++ b/packages/extra/src/LocalDateRange.js
@@ -20,21 +20,21 @@ const MAXM1 = LocalDate.MAX.minusDays(1);
 
 /**
  * A range of local dates.
- * 
+ *
  * A `LocalDateRange` represents a range of dates, from a start date to an end date.
  * Instances can be constructed from either a half-open or a closed range of dates.
  * Internally, the class stores the start and end dates, with the start inclusive and the end exclusive.
  * The end date is always greater than or equal to the start date.
- * 
+ *
  * The constants `LocalDate.MIN` and `LocalDate.MAX` can be used
  * to indicate an unbounded far-past or far-future. Note that there is no difference
  * between a half-open and a closed range when the end is `LocalDate.MAX`.
  * Empty ranges are allowed.
- * 
+ *
  * No range can end at `LocalDate.MIN` or `LocalDate.MIN.plusDays(1)`.
  * No range can start at `LocalDate.MAX` or `LocalDate.MAX.minusDays(1)`.
  * No empty range can exist at `LocalDate.MIN` or `LocalDate.MAX`.
- * 
+ *
  * Date ranges are not comparable. To compare the length of two ranges, it is
  * generally recommended to compare the number of days they contain.
  *
@@ -70,14 +70,14 @@ export class LocalDateRange {
     //-----------------------------------------------------------------------
     /**
      * Obtains a half-open range of dates, including the start and excluding the end.
-     * 
+     *
      * The range includes the start date and excludes the end date, unless the end is `LocalDate.MAX`.
      * The end date must be equal to or after the start date.
      * This definition permits an empty range located at a specific date.
-     * 
+     *
      * The constants `LocalDate.MIN` and `LocalDate.MAX` can be used
      * to indicate an unbounded far-past or far-future.
-     * 
+     *
      * The start inclusive date must not be `LocalDate.MAX` or `LocalDate.MAX.minusDays(1)`.
      * The end inclusive date must not be `LocalDate.MIN` or `LocalDate.MIN.plusDays(1)`.
      * No empty range can exist at `LocalDate.MIN` or `LocalDate.MAX`.
@@ -100,12 +100,12 @@ export class LocalDateRange {
 
     /**
      * Obtains an instance of `LocalDateRange` from the start and a period.
-     * 
+     *
      * The end date is calculated as the start plus the duration.
      * The period must not be negative.
-     * 
+     *
      * The constant `LocalDate.MIN` can be used to indicate an unbounded far-past.
-     * 
+     *
      * The period must not be zero or one day when the start date is `LocalDate.MIN`.
      *
      * @param {LocalDate} startInclusive - the inclusive start date, not null
@@ -129,17 +129,17 @@ export class LocalDateRange {
 
     /**
      * Obtains a closed range of dates, including the start and end.
-     * 
+     *
      * The range includes the start date and the end date.
      * The end date must be equal to or after the start date.
-     * 
+     *
      * The constants `LocalDate.MIN` and `LocalDate.MAX` can be used
      * to indicate an unbounded far-past or far-future. In addition, an end date of
      * `LocalDate.MAX.minusDays(1)` will also create an unbounded far-future range.
-     * 
+     *
      * The start inclusive date must not be `LocalDate.MAX` or `LocalDate.MAX.minusDays(1)`.
      * The end inclusive date must not be `LocalDate.MIN`.
-     * 
+     *
      * @param {LocalDate} startInclusive - the inclusive start date, not null
      * @param {LocalDate} endInclusive - the inclusive end date, not null
      * @return {LocalDateRange} the closed range
@@ -161,7 +161,7 @@ export class LocalDateRange {
 
     /**
      * Obtains an empty date range located at the specified date.
-     * 
+     *
      * The empty range has zero length and contains no other dates or ranges.
      * An empty range cannot be located at `LocalDate.MIN`, `LocalDate.MIN.plusDays(1)`,
      * `LocalDate.MAX` or `LocalDate.MAX.minusDays(1)`.
@@ -179,7 +179,7 @@ export class LocalDateRange {
 
     /**
      * Obtains a range that is unbounded at the start and end.
-     * 
+     *
      * @return {LocalDateRange} the range, with an unbounded start and unbounded end
      */
     static ofUnbounded() {
@@ -188,10 +188,10 @@ export class LocalDateRange {
 
     /**
      * Obtains a range up to, but not including, the specified end date.
-     * 
+     *
      * The range includes all dates from the unbounded start, denoted by `LocalDate.MIN`, to the end date.
      * The end date is exclusive and cannot be `LocalDate.MIN` or `LocalDate.MIN.plusDays(1)`.
-     * 
+     *
      * @param {LocalDate} endExclusive - the exclusive end date, `LocalDate.MAX` treated as unbounded, not null
      * @return {LocalDateRange} the range, with an unbounded start
      * @throws {DateTimeException} if the end date is `LocalDate.MIN` or  `LocalDate.MIN.plusDays(1)`
@@ -204,10 +204,10 @@ export class LocalDateRange {
 
     /**
      * Obtains a range from and including the specified start date.
-     * 
+     *
      * The range includes all dates from the start date to the unbounded end, denoted by `LocalDate.MAX`.
      * The start date is inclusive and cannot be `LocalDate.MAX` or `LocalDate.MAX.minusDays(1)`.
-     * 
+     *
      * @param {LocalDate} startInclusive - the inclusive start date, `LocalDate.MIN` treated as unbounded, not null
      * @return {LocalDateRange} the range, with an unbounded end
      * @throws {DateTimeException} if the start date is `LocalDate.MAX` or `LocalDate.MAX.minusDays(1)`
@@ -220,7 +220,7 @@ export class LocalDateRange {
     /**
      * Obtains an instance of `LocalDateRange` from a text string such as
      * `2007-12-03/2007-12-04`, where the end date is exclusive.
-     * 
+     *
      * The string must consist of one of the following three formats:
      * <ul>
      * <li>a representations of an {@link LocalDate}, followed by a forward slash,
@@ -292,13 +292,17 @@ export class LocalDateRange {
         this._end = endExclusive;
     }
 
+    get [Symbol.toStringTag]() {
+        return 'LocalDateRange';
+    }
+
     //-----------------------------------------------------------------------
     /**
      * Gets the start date of this range, inclusive.
-     * 
+     *
      * This will return `LocalDate#MIN` if the range is unbounded at the start.
      * In this case, the range includes all dates into the far-past.
-     * 
+     *
      * This never returns `LocalDate.MAX` or `LocalDate.MAX.minusDays(1)`.
      *
      * @return {LocalDate} the start date
@@ -309,10 +313,10 @@ export class LocalDateRange {
 
     /**
      * Gets the end date of this range, exclusive.
-     * 
+     *
      * This will return `LocalDate.MAX` if the range is unbounded at the end.
      * In this case, the range includes all dates into the far-future.
-     * 
+     *
      * This never returns `LocalDate.MIN` or `LocalDate.MIN.plusDays(1)`.
      *
      * @return {LocalDate} the end date, exclusive
@@ -323,14 +327,14 @@ export class LocalDateRange {
 
     /**
      * Gets the end date of this range, inclusive.
-     * 
+     *
      * This will return `LocalDate.MAX` if the range is unbounded at the end.
      * In this case, the range includes all dates into the far-future.
-     * 
+     *
      * This returns the date before the end date.
-     * 
+     *
      * This never returns `LocalDate.MIN`.
-     * 
+     *
      * @return {LocalDate} the end date, inclusive
      */
     endInclusive() {
@@ -343,11 +347,11 @@ export class LocalDateRange {
     //-----------------------------------------------------------------------
     /**
      * Checks if the range is empty.
-     * 
+     *
      * An empty range occurs when the start date equals the end date.
-     * 
+     *
      * An empty range is never unbounded.
-     * 
+     *
      * @return {boolean} true if the range is empty
      */
     isEmpty() {
@@ -356,9 +360,9 @@ export class LocalDateRange {
 
     /**
      * Checks if the start of the range is unbounded.
-     * 
+     *
      * An unbounded range is never empty.
-     * 
+     *
      * @return {boolean} true if start is unbounded
      */
     isUnboundedStart() {
@@ -367,9 +371,9 @@ export class LocalDateRange {
 
     /**
      * Checks if the end of the range is unbounded.
-     * 
+     *
      * An unbounded range is never empty.
-     * 
+     *
      * @return {boolean} true if end is unbounded
      */
     isUnboundedEnd() {
@@ -379,16 +383,16 @@ export class LocalDateRange {
     //-----------------------------------------------------------------------
     /**
      * Returns a copy of this range with the start date adjusted.
-     * 
+     *
      * This returns a new instance with the start date altered.
      * Since `LocalDate` implements `TemporalAdjuster` any
      * local date can simply be passed in.
-     * 
+     *
      * For example, to adjust the start to one week earlier:
      * <pre>
      *  range = range.withStart(date -&gt; date.minus(1, ChronoUnit.WEEKS));
      * </pre>
-     * 
+     *
      * @param {TemporalAdjuster} adjuster - the adjuster to use, not null
      * @return {LocalDateRange} a copy of this range with the start date adjusted
      * @throws {DateTimeException} if the new start date is after the current end date
@@ -399,16 +403,16 @@ export class LocalDateRange {
 
     /**
      * Returns a copy of this range with the end date adjusted.
-     * 
+     *
      * This returns a new instance with the exclusive end date altered.
      * Since `LocalDate` implements `TemporalAdjuster` any
      * local date can simply be passed in.
-     * 
+     *
      * For example, to adjust the end to one week later:
      * <pre>
      *  range = range.withEnd(date -&gt; date.plus(1, ChronoUnit.WEEKS));
      * </pre>
-     * 
+     *
      * @param {TemporalAdjuster} adjuster - the adjuster to use, not null
      * @return {LocalDateRange} a copy of this range with the end date adjusted
      * @throws {DateTimeException} if the new end date is before the current start date
@@ -420,12 +424,12 @@ export class LocalDateRange {
     //-----------------------------------------------------------------------
     /**
      * Checks if this range contains the specified date.
-     * 
+     *
      * This checks if the specified date is within the bounds of this range.
      * If this range is empty then this method always returns false.
      * Else if this range has an unbounded start then `contains(LocalDate#MIN)` returns true.
      * Else if this range has an unbounded end then `contains(LocalDate#MAX)` returns true.
-     * 
+     *
      * @param {LocalDate} date - the date to check for, not null
      * @return {boolean} true if this range contains the date
      */
@@ -436,10 +440,10 @@ export class LocalDateRange {
 
     /**
      * Checks if this range encloses the specified range.
-     * 
+     *
      * This checks if the bounds of the specified range are within the bounds of this range.
      * An empty range encloses itself.
-     * 
+     *
      * @param {LocalDateRange} other - the other range to check for, not null
      * @return {boolean} true if this range contains all dates in the other range
      */
@@ -450,7 +454,7 @@ export class LocalDateRange {
 
     /**
      * Checks if this range abuts the specified range.
-     * 
+     *
      * The result is true if the end of this range is the start of the other, or vice versa.
      * An empty range does not abut itself.
      *
@@ -464,10 +468,10 @@ export class LocalDateRange {
 
     /**
      * Checks if this range is connected to the specified range.
-     * 
+     *
      * The result is true if the two ranges have an enclosed range in common, even if that range is empty.
      * An empty range is connected to itself.
-     * 
+     *
      * This is equivalent to `(overlaps(other) || abuts(other))`.
      *
      * @param {LocalDateRange} other - the other range, not null
@@ -480,10 +484,10 @@ export class LocalDateRange {
 
     /**
      * Checks if this range overlaps the specified range.
-     * 
+     *
      * The result is true if the two ranges share some part of the time-line.
      * An empty range overlaps itself.
-     * 
+     *
      * This is equivalent to `(isConnected(other) && !abuts(other))`.
      *
      * @param {LocalDateRange} other - the time range to compare to, null means a zero length range now
@@ -497,10 +501,10 @@ export class LocalDateRange {
     //-----------------------------------------------------------------------
     /**
      * Calculates the range that is the intersection of this range and the specified range.
-     * 
+     *
      * This finds the intersection of two ranges.
      * This throws an exception if the two ranges are not {@linkplain #isConnected(LocalDateRange) connected}.
-     * 
+     *
      * @param {LocalDateRange} other - the other range to check for, not null
      * @return {LocalDateRange} the range that is the intersection of the two ranges
      * @throws {DateTimeException} if the ranges do not connect
@@ -525,10 +529,10 @@ export class LocalDateRange {
 
     /**
      * Calculates the range that is the union of this range and the specified range.
-     * 
+     *
      * This finds the union of two ranges.
      * This throws an exception if the two ranges are not {@linkplain #isConnected(LocalDateRange) connected}.
-     * 
+     *
      * @param {LocalDateRange} other - the other range to check for, not null
      * @return {LocalDateRange} the range that is the union of the two ranges
      * @throws {DateTimeException} if the ranges do not connect
@@ -553,10 +557,10 @@ export class LocalDateRange {
 
     /**
      * Calculates the smallest range that encloses this range and the specified range.
-     * 
+     *
      * The result of this method will {@linkplain #encloses(LocalDateRange) enclose}
      * this range and the specified range.
-     * 
+     *
      * @param {LocalDateRange} other - the other range to check for, not null
      * @return {LocalDateRange} the range that spans the two ranges
      */
@@ -610,7 +614,7 @@ export class LocalDateRange {
     //-----------------------------------------------------------------------
     /**
      * Checks if this range is after the specified date.
-     * 
+     *
      * The result is true if every date in this range is after the specified date.
      * An empty range behaves as though it is a date for comparison purposes.
      *
@@ -624,7 +628,7 @@ export class LocalDateRange {
 
     /**
      * Checks if this range is before the specified date.
-     * 
+     *
      * The result is true if every date in this range is before the specified date.
      * An empty range behaves as though it is a date for comparison purposes.
      *
@@ -639,7 +643,7 @@ export class LocalDateRange {
     //-----------------------------------------------------------------------
     /**
      * Checks if this range is after the specified range.
-     * 
+     *
      * The result is true if every date in this range is after every date in the specified range.
      * An empty range behaves as though it is a date for comparison purposes.
      *
@@ -653,7 +657,7 @@ export class LocalDateRange {
 
     /**
      * Checks if this range is before the specified range.
-     * 
+     *
      * The result is true if every date in this range is before every date in the specified range.
      * An empty range behaves as though it is a date for comparison purposes.
      *
@@ -668,7 +672,7 @@ export class LocalDateRange {
     //-----------------------------------------------------------------------
     /**
      * Obtains the length of this range in days.
-     * 
+     *
      * This returns the number of days between the start and end dates.
      * Unbounded ranges return `Number.POSITIVE_INFINITY`.
      *
@@ -683,7 +687,7 @@ export class LocalDateRange {
 
     /**
      * Obtains the length of this range as a period.
-     * 
+     *
      * This returns the {@link Period} between the start and end dates.
      * Unbounded ranges throw {@link ArithmeticException}.
      *
@@ -701,7 +705,7 @@ export class LocalDateRange {
     //-----------------------------------------------------------------------
     /**
      * Checks if this range is equal to another range.
-     * 
+     *
      * Compares this `LocalDateRange` with another ensuring that the two dates are the same.
      * Only objects of type `LocalDateRange` are compared, other types return false.
      *
@@ -731,7 +735,7 @@ export class LocalDateRange {
     //-----------------------------------------------------------------------
     /**
      * Outputs this range as a `String`, such as `2007-12-03/2007-12-04`.
-     * 
+     *
      * The output will be the ISO-8601 format formed by combining the
      * `toString()` methods of the two dates, separated by a forward slash.
      *

--- a/packages/extra/src/OffsetDate.js
+++ b/packages/extra/src/OffsetDate.js
@@ -20,11 +20,11 @@ const SECONDS_PER_DAY = 86400;
 /**
  * A date with an offset from UTC/Greenwich in the ISO-8601 calendar system,
  * such as `2007-12-03+01:00`.
- * 
+ *
  * `OffsetDate` is an immutable date-time object that represents a date, often viewed
  * as year-month-day-offset. This object can also access other date fields such as
  * day-of-year, day-of-week and week-of-year.
- * 
+ *
  * This class does not store or represent a time.
  * For example, the value '2nd October 2007 +02:00' can be stored
  * in an `OffsetDate`.
@@ -54,11 +54,11 @@ export class OffsetDate extends Temporal {
     //-----------------------------------------------------------------------
     /**
      * Obtains the current date from the system clock in the default time-zone.
-     * 
+     *
      * This will query the {@link Clock.systemDefaultZone} system clock in the default
      * time-zone to obtain the current date.
      * The offset will be calculated from the time-zone in the clock.
-     * 
+     *
      * Using this method will prevent the ability to use an alternate clock for testing
      * because the clock is hard-coded.
      *
@@ -71,11 +71,11 @@ export class OffsetDate extends Temporal {
 
     /**
      * Obtains the current date from the system clock in the specified time-zone.
-     * 
+     *
      * This will query the {@link Clock.system} system clock to obtain the current date.
      * Specifying the time-zone avoids dependence on the default time-zone.
      * The offset will be calculated from the specified time-zone.
-     * 
+     *
      * Using this method will prevent the ability to use an alternate clock for testing
      * because the clock is hard-coded.
      *
@@ -89,10 +89,10 @@ export class OffsetDate extends Temporal {
 
     /**
      * Obtains the current date from the specified clock.
-     * 
+     *
      * This will query the specified clock to obtain the current date - today.
      * The offset will be calculated from the time-zone in the clock.
-     * 
+     *
      * Using this method allows the use of an alternate clock for testing.
      * The alternate clock may be introduced using {@link Clock} dependency injection.
      *
@@ -138,9 +138,9 @@ export class OffsetDate extends Temporal {
     /**
      * Obtains an instance of `OffsetDate` from a year, month, day
      * and offset.
-     * 
+     *
      * This creates an offset date with the four specified fields.
-     * 
+     *
      * This method exists primarily for writing test cases.
      * Non test-code will typically use other methods to create an offset time.
      *
@@ -161,7 +161,7 @@ export class OffsetDate extends Temporal {
     //-----------------------------------------------------------------------
     /**
      * Obtains an instance of `OffsetDate` from an `Instant` and zone ID.
-     * 
+     *
      * This creates an offset date with the same instant as midnight at the
      * start of day of the instant specified.
      * Finding the offset from UTC/Greenwich is simple as there is only one valid
@@ -185,12 +185,12 @@ export class OffsetDate extends Temporal {
     //-----------------------------------------------------------------------
     /**
      * Obtains an instance of `OffsetDate` from a temporal object.
-     * 
+     *
      * A `TemporalAccessor` represents some form of date and time information.
      * This factory converts the arbitrary temporal object to an instance of `OffsetDate`.
-     * 
+     *
      * The conversion extracts and combines `LocalDate` and `ZoneOffset`.
-     * 
+     *
      * This method matches the signature of the functional interface {@link TemporalQuery}
      * allowing it to be used in queries via method reference, `OffsetDate.FROM`.
      *
@@ -214,7 +214,7 @@ export class OffsetDate extends Temporal {
 
     /**
      * Obtains an instance of `OffsetDate` from a text string using a specific formatter.
-     * 
+     *
      * The text is parsed using the formatter, returning a date.
      *
      * @param {CharSequence} text - the text to parse, not null
@@ -239,6 +239,10 @@ export class OffsetDate extends Temporal {
         super();
         this._date = requireNonNull(date, 'date');
         this._offset = requireNonNull(offset, 'offset');
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'OffsetDate';
     }
 
     /**
@@ -280,15 +284,15 @@ export class OffsetDate extends Temporal {
     //-----------------------------------------------------------------------
     /**
      * Checks if the specified field is supported.
-     * 
+     *
      * This checks if this date can be queried for the specified field.
      * If false, then calling the {@link OffsetDate.range},
      * {@link OffsetDate.get} and {@link OffsetDate.with}
      * methods will throw an exception.
-     * 
+     *
      * If the field is a {@link ChronoField} then the query is implemented here.
      * The supported fields are:
-     * 
+     *
      * - `DAY_OF_WEEK`
      * - `ALIGNED_DAY_OF_WEEK_IN_MONTH`
      * - `ALIGNED_DAY_OF_WEEK_IN_YEAR`
@@ -303,9 +307,9 @@ export class OffsetDate extends Temporal {
      * - `YEAR`
      * - `ERA`
      * - `OFFSET_SECONDS`
-     * 
+     *
      * All other `ChronoField` instances will return false.
-     * 
+     *
      * If the field is not a `ChronoField`, then the result of this method
      * is obtained by invoking `TemporalField.isSupportedBy(TemporalAccessor)`
      * passing `this` as the argument.
@@ -324,11 +328,11 @@ export class OffsetDate extends Temporal {
 
     /**
      * Checks if the specified unit is supported.
-     * 
+     *
      * This checks if the specified unit can be added to, or subtracted from, this date.
      * If false, then calling the {@link OffsetDate.plus(long, TemporalUnit)} and
      * {@link OffsetDate.minus(long, TemporalUnit) minus} methods will throw an exception.
-     * 
+     *
      * If the unit is a {@link ChronoUnit} then the query is implemented here.
      * The supported units are:
      * <ul>
@@ -342,7 +346,7 @@ export class OffsetDate extends Temporal {
      * - `ERAS`
      * </ul>
      * All other `ChronoUnit` instances will return false.
-     * 
+     *
      * If the unit is not a `ChronoUnit`, then the result of this method
      * is obtained by invoking `TemporalUnit.isSupportedBy(Temporal)`
      * passing `this` as the argument.
@@ -362,17 +366,17 @@ export class OffsetDate extends Temporal {
     //-----------------------------------------------------------------------
     /**
      * Gets the range of valid values for the specified field.
-     * 
+     *
      * The range object expresses the minimum and maximum valid values for a field.
      * This date is used to enhance the accuracy of the returned range.
      * If it is not possible to return the range, because the field is not supported
      * or for some other reason, an exception is thrown.
-     * 
+     *
      * If the field is a {@link ChronoField} then the query is implemented here.
      * The {@link OffsetDate.isSupported} supported fields will return
      * appropriate range instances.
      * All other `ChronoField` instances will throw an `UnsupportedTemporalTypeException`.
-     * 
+     *
      * If the field is not a `ChronoField`, then the result of this method
      * is obtained by invoking `TemporalField.rangeRefinedBy(TemporalAccessor)`
      * passing `this` as the argument.
@@ -397,18 +401,18 @@ export class OffsetDate extends Temporal {
 
     /**
      * Gets the value of the specified field from this date as an `int`.
-     * 
+     *
      * This queries this date for the value for the specified field.
      * The returned value will always be within the valid range of values for the field.
      * If it is not possible to return the value, because the field is not supported
      * or for some other reason, an exception is thrown.
-     * 
+     *
      * If the field is a {@link ChronoField} then the query is implemented here.
      * The {@link OffsetDate.isSupported} supported fields will return valid
      * values based on this date, except `EPOCH_DAY` and `PROLEPTIC_MONTH`
      * which are too large to fit in an `int` and throw a `DateTimeException`.
      * All other `ChronoField` instances will throw a `DateTimeException`.
-     * 
+     *
      * If the field is not a `ChronoField`, then the result of this method
      * is obtained by invoking `TemporalField.getFrom(TemporalAccessor)`
      * passing `this` as the argument. Whether the value can be obtained,
@@ -430,16 +434,16 @@ export class OffsetDate extends Temporal {
 
     /**
      * Gets the value of the specified field from this date as a `long`.
-     * 
+     *
      * This queries this date for the value for the specified field.
      * If it is not possible to return the value, because the field is not supported
      * or for some other reason, an exception is thrown.
-     * 
+     *
      * If the field is a {@link ChronoField} then the query is implemented here.
      * The {@link OffsetDate.isSupported} supported fields will return valid
      * values based on this date.
      * All other `ChronoField` instances will throw an `UnsupportedTemporalTypeException`.
-     * 
+     *
      * If the field is not a `ChronoField`, then the result of this method
      * is obtained by invoking `TemporalField.getFrom(TemporalAccessor)`
      * passing `this` as the argument. Whether the value can be obtained,
@@ -466,7 +470,7 @@ export class OffsetDate extends Temporal {
     //-----------------------------------------------------------------------
     /**
      * Gets the zone offset, such as '+01:00'.
-     * 
+     *
      * This is the offset of the local date from UTC/Greenwich.
      *
      * @return {ZoneOffset} the zone offset, not null
@@ -478,12 +482,12 @@ export class OffsetDate extends Temporal {
     /**
      * Returns a copy of this `OffsetDate` with the specified offset ensuring
      * that the result has the same local date.
-     * 
+     *
      * This method returns an object with the same `LocalDate` and the specified `ZoneOffset`.
      * No calculation is needed or performed.
      * For example, if this time represents `2007-12-03+02:00` and the offset specified is
      * `+03:00`, then this method will return `2007-12-03+03:00`.
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
      *
      * @param {ZoneOffset} offset - the zone offset to change to, not null
@@ -497,7 +501,7 @@ export class OffsetDate extends Temporal {
     //-----------------------------------------------------------------------
     /**
      * Gets the `LocalDate` part of this date.
-     * 
+     *
      * This returns a `LocalDate` with the same year, month and day
      * as this date.
      *
@@ -510,9 +514,9 @@ export class OffsetDate extends Temporal {
     //-----------------------------------------------------------------------
     /**
      * Gets the year field.
-     * 
+     *
      * This method returns the primitive `int` value for the year.
-     * 
+     *
      * The year returned by this method is proleptic as per `get(YEAR)`.
      * To obtain the year-of-era, use `get(YEAR_OF_ERA)`.
      *
@@ -524,7 +528,7 @@ export class OffsetDate extends Temporal {
 
     /**
      * Gets the month-of-year field from 1 to 12.
-     * 
+     *
      * This method returns the month as an `int` from 1 to 12.
      * Application code is frequently clearer if the enum {@link Month}
      * is used by calling {@link OffsetDate.month}.
@@ -538,7 +542,7 @@ export class OffsetDate extends Temporal {
 
     /**
      * Gets the month-of-year field using the `Month` enum.
-     * 
+     *
      * This method returns the enum {@link Month} for the month.
      * This avoids confusion as to what `int` values mean.
      * If you need access to the primitive `int` value then the enum
@@ -553,7 +557,7 @@ export class OffsetDate extends Temporal {
 
     /**
      * Gets the day-of-month field.
-     * 
+     *
      * This method returns the primitive `int` value for the day-of-month.
      *
      * @return {number} the day-of-month, from 1 to 31
@@ -564,7 +568,7 @@ export class OffsetDate extends Temporal {
 
     /**
      * Gets the day-of-year field.
-     * 
+     *
      * This method returns the primitive `int` value for the day-of-year.
      *
      * @return {number} the day-of-year, from 1 to 365, or 366 in a leap year
@@ -575,12 +579,12 @@ export class OffsetDate extends Temporal {
 
     /**
      * Gets the day-of-week field, which is an enum `DayOfWeek`.
-     * 
+     *
      * This method returns the enum {@link DayOfWeek} for the day-of-week.
      * This avoids confusion as to what `int` values mean.
      * If you need access to the primitive `int` value then the enum
      * provides the {@link DayOfWeek.value} int value.
-     * 
+     *
      * Additional information can be obtained from the `DayOfWeek`.
      * This includes textual names of the values.
      *
@@ -593,11 +597,11 @@ export class OffsetDate extends Temporal {
     //-----------------------------------------------------------------------
     /**
      * Returns an adjusted copy of this date.
-     * 
+     *
      * This returns an `OffsetDate` based on this one, with the date adjusted.
      * The adjustment takes place using the specified adjuster strategy object.
      * Read the documentation of the adjuster to understand what adjustment will be made.
-     * 
+     *
      * A simple adjuster might simply set the one of the fields, such as the year field.
      * A more complex adjuster might set the date to the last day of the month.
      * A selection of common adjustments is provided in {@link TemporalAdjusters}.
@@ -606,7 +610,7 @@ export class OffsetDate extends Temporal {
      * such as {@link Month} and {@link MonthDay}.
      * The adjuster is responsible for handling special cases, such as the varying
      * lengths of month and leap years.
-     * 
+     *
      * For example this code returns a date on the last day of July:
      * <pre>
      *  import static java.time.Month.*;
@@ -614,18 +618,18 @@ export class OffsetDate extends Temporal {
      *
      *  result = offsetDate.with(JULY).with(lastDayOfMonth());
      * </pre>
-     * 
+     *
      * The classes {@link LocalDate} and {@link ZoneOffset} implement `TemporalAdjuster`,
      * thus this method can be used to change the date or offset:
      * <pre>
      *  result = offsetDate.with(date);
      *  result = offsetDate.with(offset);
      * </pre>
-     * 
+     *
      * The result of this method is obtained by invoking the
      * {@link TemporalAdjuster.adjustInto} method on the
      * specified adjuster passing `this` as the argument.
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
      *
      * @param {TemporalAdjuster} adjuster - the adjuster to use, not null
@@ -647,35 +651,35 @@ export class OffsetDate extends Temporal {
 
     /**
      * Returns a copy of this date with the specified field set to a new value.
-     * 
+     *
      * This returns an `OffsetDate` based on this one, with the value
      * for the specified field changed.
      * This can be used to change any supported field, such as the year, month or day-of-month.
      * If it is not possible to set the value, because the field is not supported or for
      * some other reason, an exception is thrown.
-     * 
+     *
      * In some cases, changing the specified field can cause the resulting date to become invalid,
      * such as changing the month from 31st January to February would make the day-of-month invalid.
      * In cases like this, the field is responsible for resolving the date. Typically it will choose
      * the previous valid date, which would be the last valid day of February in this example.
-     * 
+     *
      * If the field is a {@link ChronoField} then the adjustment is implemented here.
-     * 
+     *
      * The `OFFSET_SECONDS` field will return a date with the specified offset.
      * The local date is unaltered. If the new offset value is outside the valid range
      * then a `DateTimeException` will be thrown.
-     * 
+     *
      * The other {@link OffsetDate.isSupported} supported fields will behave as per
      * the matching method on {@link LocalDate.with} LocalDate.
      * In this case, the offset is not part of the calculation and will be unchanged.
-     * 
+     *
      * All other `ChronoField` instances will throw an `UnsupportedTemporalTypeException`.
-     * 
+     *
      * If the field is not a `ChronoField`, then the result of this method
      * is obtained by invoking `TemporalField.adjustInto(Temporal, long)`
      * passing `this` as the argument. In this case, the field determines
      * whether and how to adjust the instant.
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
      *
      * @param {TemporalField} field - the field to set in the result, not null
@@ -701,10 +705,10 @@ export class OffsetDate extends Temporal {
     //-----------------------------------------------------------------------
     /**
      * Returns a copy of this `OffsetDate` with the year altered.
-     * 
+     *
      * The offset does not affect the calculation and will be the same in the result.
      * If the day-of-month is invalid for the year, it will be changed to the last valid day of the month.
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
      *
      * @param {OffsetDate} year - the year to set in the result, from MIN_YEAR to MAX_YEAR
@@ -717,10 +721,10 @@ export class OffsetDate extends Temporal {
 
     /**
      * Returns a copy of this `OffsetDate` with the month-of-year altered.
-     * 
+     *
      * The offset does not affect the calculation and will be the same in the result.
      * If the day-of-month is invalid for the year, it will be changed to the last valid day of the month.
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
      *
      * @param {number} month - the month-of-year to set in the result, from 1 (January) to 12 (December)
@@ -733,10 +737,10 @@ export class OffsetDate extends Temporal {
 
     /**
      * Returns a copy of this `OffsetDate` with the day-of-month altered.
-     * 
+     *
      * If the resulting date is invalid, an exception is thrown.
      * The offset does not affect the calculation and will be the same in the result.
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
      *
      * @param {number} dayOfMonth - the day-of-month to set in the result, from 1 to 28-31
@@ -750,9 +754,9 @@ export class OffsetDate extends Temporal {
 
     /**
      * Returns a copy of this `OffsetDate` with the day-of-year altered.
-     * 
+     *
      * If the resulting date is invalid, an exception is thrown.
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
      *
      * @param {number} dayOfYear - the day-of-year to set in the result, from 1 to 365-366
@@ -766,20 +770,20 @@ export class OffsetDate extends Temporal {
 
     /**
      * Returns a copy of this date with the specified amount added.
-     * 
+     *
      * This returns an `OffsetDate` based on this one, with the amount
      * in terms of the unit added. If it is not possible to add the amount, because the
      * unit is not supported or for some other reason, an exception is thrown.
-     * 
+     *
      * If the field is a {@link ChronoUnit} then the addition is implemented by
      * {@link LocalDate.plus}.
      * The offset is not part of the calculation and will be unchanged in the result.
-     * 
+     *
      * If the field is not a `ChronoUnit`, then the result of this method
      * is obtained by invoking `TemporalUnit.addTo(Temporal, long)`
      * passing `this` as the argument. In this case, the unit determines
      * whether and how to perform the addition.
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
      *
      * @param {number} amountToAdd - the amount of the unit to add to the result, may be negative
@@ -799,10 +803,10 @@ export class OffsetDate extends Temporal {
     //-----------------------------------------------------------------------
     /**
      * Returns a copy of this `OffsetDate` with the specified number of years added.
-     * 
+     *
      * This uses {@link LocalDate.plusYears} to add the years.
      * The offset does not affect the calculation and will be the same in the result.
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
      *
      * @param {number} years - the years to add, may be negative
@@ -815,10 +819,10 @@ export class OffsetDate extends Temporal {
 
     /**
      * Returns a copy of this `OffsetDate` with the specified number of months added.
-     * 
+     *
      * This uses {@link LocalDate.plusMonths} to add the months.
      * The offset does not affect the calculation and will be the same in the result.
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
      *
      * @param {number} months - the months to add, may be negative
@@ -831,10 +835,10 @@ export class OffsetDate extends Temporal {
 
     /**
      * Returns a copy of this `OffsetDate` with the specified number of weeks added.
-     * 
+     *
      * This uses {@link LocalDate.plusWeeks} to add the weeks.
      * The offset does not affect the calculation and will be the same in the result.
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
      *
      * @param {number} weeks - the weeks to add, may be negative
@@ -847,10 +851,10 @@ export class OffsetDate extends Temporal {
 
     /**
      * Returns a copy of this `OffsetDate` with the specified number of days added.
-     * 
+     *
      * This uses {@link LocalDate.plusDays)} to add the days.
      * The offset does not affect the calculation and will be the same in the result.
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
      *
      * @param {number} days - the days to add, may be negative
@@ -864,10 +868,10 @@ export class OffsetDate extends Temporal {
     //-----------------------------------------------------------------------
     /**
      * Returns a copy of this `OffsetDate` with the specified number of years subtracted.
-     * 
+     *
      * This uses {@link LocalDate.minusYears} to subtract the years.
      * The offset does not affect the calculation and will be the same in the result.
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
      *
      * @param {number} years - the years to subtract, may be negative
@@ -880,10 +884,10 @@ export class OffsetDate extends Temporal {
 
     /**
      * Returns a copy of this `OffsetDate` with the specified number of months subtracted.
-     * 
+     *
      * This uses {@link LocalDate.minusMonths} to subtract the months.
      * The offset does not affect the calculation and will be the same in the result.
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
      *
      * @param {number} months - the months to subtract, may be negative
@@ -896,10 +900,10 @@ export class OffsetDate extends Temporal {
 
     /**
      * Returns a copy of this `OffsetDate` with the specified number of weeks subtracted.
-     * 
+     *
      * This uses {@link LocalDate.minusWeeks} to subtract the weeks.
      * The offset does not affect the calculation and will be the same in the result.
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
      *
      * @param {number} weeks - the weeks to subtract, may be negative
@@ -912,10 +916,10 @@ export class OffsetDate extends Temporal {
 
     /**
      * Returns a copy of this `OffsetDate` with the specified number of days subtracted.
-     * 
+     *
      * This uses {@link LocalDate.minusDays} to subtract the days.
      * The offset does not affect the calculation and will be the same in the result.
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
      *
      * @param {number} days - the days to subtract, may be negative
@@ -929,12 +933,12 @@ export class OffsetDate extends Temporal {
     //-----------------------------------------------------------------------
     /**
      * Queries this date using the specified query.
-     * 
+     *
      * This queries this date using the specified query strategy object.
      * The `TemporalQuery` object defines the logic to be used to
      * obtain the result. Read the documentation of the query to understand
      * what the result of this method will be.
-     * 
+     *
      * The result of this method is obtained by invoking the
      * {@link TemporalQuery.queryFrom} method on the
      * specified query passing `this` as the argument.
@@ -960,14 +964,14 @@ export class OffsetDate extends Temporal {
     /**
      * Adjusts the specified temporal object to have the same offset and date
      * as this object.
-     * 
+     *
      * This returns a temporal object of the same observable type as the input
      * with the offset and date changed to be the same as this.
-     * 
+     *
      * The adjustment is equivalent to using {@link Temporal.with}
      * twice, passing {@link ChronoField.OFFSET_SECONDS} and
      * {@link ChronoField.EPOCH_DAY} as the fields.
-     * 
+     *
      * In most cases, it is clearer to reverse the calling pattern by using
      * {@link Temporal.with(TemporalAdjuster)}:
      * <pre>
@@ -975,7 +979,7 @@ export class OffsetDate extends Temporal {
      *   temporal = thisOffsetDate.adjustInto(temporal);
      *   temporal = temporal.with(thisOffsetDate);
      * </pre>
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
      *
      * @param {Temporal} temporal - the target object to be adjusted, not null
@@ -992,23 +996,23 @@ export class OffsetDate extends Temporal {
     /**
      * Calculates the period between this date and another date in
      * terms of the specified unit.
-     * 
+     *
      * This calculates the period between two dates in terms of a single unit.
      * The start and end points are `this` and the specified date.
      * The result will be negative if the end is before the start.
      * For example, the period in days between two dates can be calculated
      * using `startDate.until(endDate, DAYS)`.
-     * 
+     *
      * The `Temporal` passed to this method is converted to a
      * `OffsetDate` using {@link OffsetDate.from}.
      * If the offset differs between the two times, then the specified
      * end time is normalized to have the same offset as this time.
-     * 
+     *
      * The calculation returns a whole number, representing the number of
      * complete units between the two dates.
      * For example, the period in months between 2012-06-15Z and 2012-08-14Z
      * will only be one month as it is one day short of two months.
-     * 
+     *
      * There are two equivalent ways of using this method.
      * The first is to invoke this method.
      * The second is to use {@link TemporalUnit.between}:
@@ -1018,17 +1022,17 @@ export class OffsetDate extends Temporal {
      *   amount = DAYS.between(start, end);
      * </pre>
      * The choice should be made based on which makes the code more readable.
-     * 
+     *
      * The calculation is implemented in this method for {@link ChronoUnit}.
      * The units `DAYS`, `WEEKS`, `MONTHS`, `YEARS`,
      * `DECADES`, `CENTURIES`, `MILLENNIA` and `ERAS`
      * are supported. Other `ChronoUnit` values will throw an exception.
-     * 
+     *
      * If the unit is not a `ChronoUnit`, then the result of this method
      * is obtained by invoking `TemporalUnit.between(Temporal, Temporal)`
      * passing `this` as the first argument and the converted input temporal
      * as the second argument.
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
      *
      * @param {Temporal} endExclusive - the end time, exclusive, which is converted to an `OffsetDate`, not null
@@ -1051,7 +1055,7 @@ export class OffsetDate extends Temporal {
 
     /**
      * Formats this date using the specified formatter.
-     * 
+     *
      * This date will be passed to the formatter to produce a string.
      *
      * @param {DateTimeFormatter} formatter - the formatter to use, not null
@@ -1066,10 +1070,10 @@ export class OffsetDate extends Temporal {
     //-----------------------------------------------------------------------
     /**
      * Returns an offset date-time formed from this date at the specified time.
-     * 
+     *
      * This combines this date with the specified time to form an `OffsetDateTime`.
      * All possible combinations of date and time are valid.
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
      *
      * @param {LocalTime} time - the time to combine with, not null
@@ -1095,7 +1099,7 @@ export class OffsetDate extends Temporal {
     /**
      * Converts this `OffsetDate` to the number of seconds since the epoch
      * of 1970-01-01T00:00:00Z.
-     * 
+     *
      * This combines this offset date with the specified time
      * to calculate the epoch-second value, which is the
      * number of elapsed seconds from 1970-01-01T00:00:00Z.
@@ -1113,21 +1117,21 @@ export class OffsetDate extends Temporal {
     //-----------------------------------------------------------------------
     /**
      * Compares this `OffsetDate` to another date.
-     * 
+     *
      * The comparison is based first on the UTC equivalent instant, then on the local date.
      * It is 'consistent with equals', as defined by {@link Comparable}.
-     * 
+     *
      * For example, the following is the comparator order:
      * 1. 2008-06-29-11:00</li>
      * 2. 2008-06-29-12:00</li>
      * 3. 2008-06-30+12:00</li>
      * 4. 2008-06-29-13:00</li>
-     * 
+     *
      * Values #2 and #3 represent the same instant on the time-line.
      * When two values represent the same instant, the local date is compared
      * to distinguish them. This step is needed to make the ordering
      * consistent with `equals()`.
-     * 
+     *
      * To compare the underlying local date of two `TemporalAccessor` instances,
      * use {@link ChronoField.EPOCH_DAY} as a comparator.
      *
@@ -1151,7 +1155,7 @@ export class OffsetDate extends Temporal {
     /**
      * Checks if the instant of midnight at the start of this `OffsetDate`
      * is after midnight at the start of the specified date.
-     * 
+     *
      * This method differs from the comparison in {@link OffsetDate.compareTo} in that it
      * only compares the instant of the date. This is equivalent to using
      * `date1.toEpochSecond().isAfter(date2.toEpochSecond())`.
@@ -1168,7 +1172,7 @@ export class OffsetDate extends Temporal {
     /**
      * Checks if the instant of midnight at the start of this `OffsetDate`
      * is before midnight at the start of the specified date.
-     * 
+     *
      * This method differs from the comparison in {@link OffsetDate.compareTo} in that it
      * only compares the instant of the date. This is equivalent to using
      * `date1.toEpochSecond().isBefore(date2.toEpochSecond())`.
@@ -1185,7 +1189,7 @@ export class OffsetDate extends Temporal {
     /**
      * Checks if the instant of midnight at the start of this `OffsetDate`
      * equals midnight at the start of the specified date.
-     * 
+     *
      * This method differs from the comparison in {@link OffsetDate.compareTo} and {@link OffsetDate.equals}
      * in that it only compares the instant of the date. This is equivalent to using
      * `date1.toEpochSecond().equals(date2.toEpochSecond())`.
@@ -1202,10 +1206,10 @@ export class OffsetDate extends Temporal {
     //-----------------------------------------------------------------------
     /**
      * Checks if this date is equal to another date.
-     * 
+     *
      * The comparison is based on the local-date and the offset.
      * To compare for the same instant on the time-line, use {@link OffsetDate.isEqual}.
-     * 
+     *
      * Only objects of type `OffsetDate` are compared, other types return false.
      * To compare the underlying local date of two `TemporalAccessor` instances,
      * use {@link ChronoField.EPOCH_DAY} as a comparator.
@@ -1236,7 +1240,7 @@ export class OffsetDate extends Temporal {
     //-----------------------------------------------------------------------
     /**
      * Outputs this date as a `String`, such as `2007-12-03+01:00`.
-     * 
+     *
      * The output will be in the ISO-8601 format `yyyy-MM-ddXXXXX`.
      *
      * @return {String} a string representation of this date, not null

--- a/packages/extra/src/Quarter.js
+++ b/packages/extra/src/Quarter.js
@@ -157,6 +157,10 @@ export class Quarter extends TemporalAccessor {
         this._name = name;
     }
 
+    get [Symbol.toStringTag]() {
+        return 'Quarter';
+    }
+
     //-----------------------------------------------------------------------
     /**
      * Gets the quarter-of-year `int` value.

--- a/packages/extra/src/YearQuarter.js
+++ b/packages/extra/src/YearQuarter.js
@@ -263,6 +263,10 @@ export class YearQuarter extends Temporal {
         this._quarter = requireInstance(quarter, Quarter, 'Quarter');
     }
 
+    get [Symbol.toStringTag]() {
+        return 'YearQuarter';
+    }
+
     /**
      * Returns a copy of this year-quarter with the new year and quarter, checking
      * to see if a new object is in fact required.

--- a/packages/extra/src/YearWeek.js
+++ b/packages/extra/src/YearWeek.js
@@ -14,21 +14,21 @@ const MathUtil = jodaInternal.MathUtil;
 
 /**
  * A year-week in the ISO week date system such as `2015-W13`
- * 
+ *
  * {@link YearWeek} is an immutable date-time object that represents the combination
  * of a week-based-year and week-of-week-based-year.
  * Any field that can be derived from those two fields can be obtained.
- * 
+ *
  * This class does not store or represent a day, time or time-zone.
  * For example, the value '13th week of 2007' can be stored in a {@link YearWeek}.
- * 
+ *
  * The ISO-8601 calendar system is the modern civil calendar system used today
  * in most of the world. It is equivalent to the proleptic Gregorian calendar
  * system, in which today's rules for leap years are applied for all time.
  * For most applications written today, the ISO-8601 rules are entirely suitable.
  * However, any application that makes use of historical dates, and requires them
  * to be accurate will find the ISO-8601 approach unsuitable.
- * 
+ *
  * ISO-8601 defines the week as always starting with Monday.
  * The first week is the week which contains the first Thursday of the calendar year.
  * As such, the week-based-year used in this class does not align with the calendar year.
@@ -40,7 +40,7 @@ export class YearWeek extends Temporal {
      * - if called with an instance of {@link ZoneId}, then {@link YearWeek._nowZoneId} is executed;
      * - if called with an instance of {@link Clock}, then {@link YearWeek._nowClock} is executed;
      * - otherwise {@link IllegalArgumentException} is thrown.
-     * 
+     *
      * @param {?(ZoneId|Clock)} zoneIdOrClock
      * @return {YearWeek}
      */
@@ -65,11 +65,11 @@ export class YearWeek extends Temporal {
     //-----------------------------------------------------------------------
     /**
      * Obtains the current year-week from the system clock in the default time-zone.
-     * 
+     *
      * This will query the {@link Clock.systemDefaultZone} system clock in the default
      * time-zone to obtain the current year-week.
      * The zone and offset will be set based on the time-zone in the clock.
-     * 
+     *
      * Using this method will prevent the ability to use an alternate clock for testing
      * because the clock is hard-coded.
      *
@@ -82,10 +82,10 @@ export class YearWeek extends Temporal {
 
     /**
      * Obtains the current year-week from the system clock in the specified time-zone.
-     * 
+     *
      * This will query the {@link Clock.system} system clock to obtain the current year-week.
      * Specifying the time-zone avoids dependence on the default time-zone.
-     * 
+     *
      * Using this method will prevent the ability to use an alternate clock for testing
      * because the clock is hard-coded.
      *
@@ -99,7 +99,7 @@ export class YearWeek extends Temporal {
 
     /**
      * Obtains the current year-week from the specified clock.
-     * 
+     *
      * This will query the specified clock to obtain the current year-week.
      * Using this method allows the use of an alternate clock for testing.
      * The alternate clock may be introduced using {@link Clock} dependency injection.
@@ -119,7 +119,7 @@ export class YearWeek extends Temporal {
      * - if called with an instances of {@link Year} and `int`, then {@link YearWeek._ofYearWeek} is executed;
      * - if called with an instances of number and `int`, then {@link YearWeek._ofWeekBasedYear} is executed;
      * - otherwise {@link IllegalArgumentException} is thrown.
-     * 
+     *
      * @param {Year|number} year - the year to represent, not null
      * @param {number} week - the week-of-week-based-year to represent, from 1 to 53
      * @return {YearWeek} the year-week, not null
@@ -136,10 +136,10 @@ export class YearWeek extends Temporal {
 
     /**
      * Obtains an instance of {@link YearWeek} from a year and week.
-     * 
+     *
      * If the week is 53 and the year does not have 53 weeks, week one of the following
      * year is selected.
-     * 
+     *
      * Note that this class is based on the week-based-year which aligns to Monday to Sunday weeks,
      * whereas {@link Year} is intended to represent standard years aligned from January to December.
      * This difference may be seen at the start and/or end of the year.
@@ -160,7 +160,7 @@ export class YearWeek extends Temporal {
 
     /**
      * Obtains an instance of {@link YearWeek} from a week-based-year and week.
-     * 
+     *
      * If the week is 53 and the year does not have 53 weeks, week one of the following
      * year is selected.
      *
@@ -197,16 +197,16 @@ export class YearWeek extends Temporal {
     //-----------------------------------------------------------------------
     /**
      * Obtains an instance of {@link YearWeek} from a temporal object.
-     * 
+     *
      * This obtains a year-week based on the specified temporal.
      * A {@link TemporalAccessor} represents an arbitrary set of date and time information,
      * which this factory converts to an instance of {@link YearWeek}.
-     * 
+     *
      * The conversion extracts the {@link IsoFields.WEEK_BASED_YEAR} WEEK_BASED_YEAR and
      * {@link IsoFields.WEEK_OF_WEEK_BASED_YEAR} WEEK_OF_WEEK_BASED_YEAR fields.
      * The extraction is only permitted if the temporal object has an ISO
      * chronology, or can be converted to a {@link LocalDate}.
-     * 
+     *
      * This method matches the signature of the functional interface {@link TemporalQuery}
      * allowing it to be used in queries via method reference, {@link YearWeek.FROM}.
      *
@@ -236,13 +236,13 @@ export class YearWeek extends Temporal {
     //-----------------------------------------------------------------------
     /**
      * Obtains an instance of {@link YearWeek} from a text string using a specific formatter.
-     * 
+     *
      * The text is parsed using the formatter, returning a year-week.
      *
      * @param {string} text - the text to parse, not null
      * @param {DateTimeFormatter} [formatter=YearWeek.PARSER] - the formatter to use, default is
      * {@link YearWeek.PARSER}
-     * 
+     *
      * @return {YearWeek} the parsed year-week, not null
      * @throws {DateTimeParseException} if the text cannot be parsed
      */
@@ -263,6 +263,10 @@ export class YearWeek extends Temporal {
         super();
         this._year = weekBasedYear;
         this._week = week;
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'YearWeek';
     }
 
     /**
@@ -291,18 +295,18 @@ export class YearWeek extends Temporal {
     //-----------------------------------------------------------------------
     /**
      * Checks if the specified field is supported.
-     * 
+     *
      * This checks if this year-week can be queried for the specified field.
      * If false, then calling the {@link YearWeek.range} range and
      * {@link YearWeek.get} get methods will throw an exception.
-     * 
+     *
      * The supported fields are:
      * <ul>
      * <li>{@link IsoFields.WEEK_OF_WEEK_BASED_YEAR}
      * <li>{@link IsoFields.WEEK_BASED_YEAR}
      * </ul>
      * All other {@link ChronoField} instances will return false.
-     * 
+     *
      * If the field is not a {@link ChronoField}, then the result of this method
      * is obtained by invoking {@link TemporalField.isSupportedBy}
      * passing this as the argument.
@@ -323,17 +327,17 @@ export class YearWeek extends Temporal {
 
     /**
      * Checks if the specified unit is supported.
-     * 
+     *
      * This checks if the specified unit can be added to, or subtracted from, this date-time.
      * If false, then calling the {@link YearWeek.plus} and
      * {@link YearWeek.minus} minus methods will throw an exception.
-     * 
+     *
      * The supported units are:
      * - {@link ChronoUnit.WEEKS}
      * - {@link IsoFields.WEEK_BASED_YEARS}
-     * 
+     *
      * All other {@link ChronoUnit} instances will return false.
-     * 
+     *
      * If the unit is not a {@link ChronoUnit}, then the result of this method
      * is obtained by invoking {@link TemporalUnit.isSupportedBy}
      * passing this as the argument.
@@ -355,12 +359,12 @@ export class YearWeek extends Temporal {
     //-----------------------------------------------------------------------
     /**
      * Gets the range of valid values for the specified field.
-     * 
+     *
      * The range object expresses the minimum and maximum valid values for a field.
      * This year-week is used to enhance the accuracy of the returned range.
      * If it is not possible to return the range, because the field is not supported
      * or for some other reason, an exception is thrown.
-     * 
+     *
      * The range for the {@link IsoFields.WEEK_BASED_YEAR} WEEK_BASED_YEAR and
      * {@link IsoFields.WEEK_OF_WEEK_BASED_YEAR} WEEK_OF_WEEK_BASED_YEAR fields is returned.
      * All {@link ChronoField} instances will throw an {@link UnsupportedTemporalTypeException}.
@@ -383,12 +387,12 @@ export class YearWeek extends Temporal {
 
     /**
      * Gets the value of the specified field from this year-week as an `int`.
-     * 
+     *
      * This queries this year-week for the value for the specified field.
      * The returned value will always be within the valid range of values for the field.
      * If it is not possible to return the value, because the field is not supported
      * or for some other reason, an exception is thrown.
-     * 
+     *
      * The value for the {@link IsoFields.WEEK_BASED_YEAR} WEEK_BASED_YEAR and
      * {@link IsoFields.WEEK_OF_WEEK_BASED_YEAR} WEEK_OF_WEEK_BASED_YEAR fields is returned.
      * All {@link ChronoField} instances will throw an {@link UnsupportedTemporalTypeException}.
@@ -407,11 +411,11 @@ export class YearWeek extends Temporal {
 
     /**
      * Gets the value of the specified field from this year-week as a `long`.
-     * 
+     *
      * This queries this year-week for the value for the specified field.
      * If it is not possible to return the value, because the field is not supported
      * or for some other reason, an exception is thrown.
-     * 
+     *
      * The value for the {@link IsoFields.WEEK_BASED_YEAR} WEEK_BASED_YEAR and
      * {@link IsoFields.WEEK_OF_WEEK_BASED_YEAR} WEEK_OF_WEEK_BASED_YEAR fields is returned.
      * All {@link ChronoField} instances will throw an {@link UnsupportedTemporalTypeException}.
@@ -439,9 +443,9 @@ export class YearWeek extends Temporal {
     //-----------------------------------------------------------------------
     /**
      * Gets the week-based-year field.
-     * 
+     *
      * This method returns the primitive `int` value for the week-based-year.
-     * 
+     *
      * Note that the ISO week-based-year does not align with the standard Gregorian/ISO calendar year.
      *
      * @return {number} the week-based-year
@@ -452,7 +456,7 @@ export class YearWeek extends Temporal {
 
     /**
      * Gets the week-of-week-based-year field.
-     * 
+     *
      * This method returns the primitive `int` value for the week of the week-based-year.
      *
      * @return {number} the week-of-week-based-year
@@ -464,7 +468,7 @@ export class YearWeek extends Temporal {
     //-----------------------------------------------------------------------
     /**
      * Checks if the week-based-year has 53 weeks.
-     * 
+     *
      * This determines if the year has 53 weeks, returning true.
      * If false, the year has 52 weeks.
      *
@@ -476,7 +480,7 @@ export class YearWeek extends Temporal {
 
     /**
      * Returns the length of the week-based-year.
-     * 
+     *
      * This returns the length of the year in days, either 364 or 371.
      *
      * @return {number} 364 if the year has 52 weeks, 371 if it has 53 weeks
@@ -488,15 +492,15 @@ export class YearWeek extends Temporal {
     //-----------------------------------------------------------------------
     /**
      * Returns an adjusted copy of this year-week.
-     * 
+     *
      * This returns a {@link YearWeek}, based on this one, with the year-week adjusted.
      * The adjustment takes place using the specified adjuster strategy object.
      * Read the documentation of the adjuster to understand what adjustment will be made.
-     * 
+     *
      * The result of this method is obtained by invoking the
      * {@link TemporalAdjusteradjustInto} method on the
      * specified adjuster passing this as the argument.
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
      *
      * @param {TemporalAdjuster} adjuster - adjuster the adjuster to use, not null
@@ -514,25 +518,25 @@ export class YearWeek extends Temporal {
 
     /**
      * Returns a copy of this year-week with the specified field set to a new value.
-     * 
+     *
      * This returns a {@link YearWeek}, based on this one, with the value
      * for the specified field changed.
      * This can be used to change any supported field, such as the year or week.
      * If it is not possible to set the value, because the field is not supported or for
      * some other reason, an exception is thrown.
-     * 
+     *
      * If the field is a {@link ChronoField} then the adjustment is implemented here.
      * The supported fields behave as follows:
      * - {@link WEEK_OF_WEEK_BASED_YEAR} - Returns a {@link YearWeek} with the specified week-of-year set as per {@link YearWeek.withWeek}.
      * - {@link WEEK_BASED_YEAR} - Returns a {@link YearWeek} with the specified year set as per {@link YearWeek.withYear}.
-     * 
+     *
      * All {@link ChronoField} instances will throw an {@link UnsupportedTemporalTypeException}.
-     * 
+     *
      * If the field is not a {@link ChronoField}, then the result of this method
      * is obtained by invoking {@link TemporalField.adjustInto}
      * passing this as the argument. In this case, the field determines
      * whether and how to adjust the instant.
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
      *
      * @param {TemporalField} field - the field to set in the result, not null
@@ -555,11 +559,11 @@ export class YearWeek extends Temporal {
 
     /**
      * Returns a copy of this {@link YearWeek} with the week-based-year altered.
-     * 
+     *
      * This returns a year-week with the specified week-based-year.
      * If the week of this instance is 53 and the new year does not have 53 weeks,
      * the week will be adjusted to be 52.
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
      *
      * @param {number} weekBasedYear - the week-based-year to set in the returned year-week
@@ -575,11 +579,11 @@ export class YearWeek extends Temporal {
 
     /**
      * Returns a copy of this {@link YearWeek} with the week altered.
-     * 
+     *
      * This returns a year-week with the specified week-of-week-based-year.
      * If the new week is 53 and the year does not have 53 weeks, week one of the
      * following year is selected.
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
      *
      * @param {number} week - the week-of-week-based-year to set in the returned year-week
@@ -592,23 +596,23 @@ export class YearWeek extends Temporal {
 
     /**
      * Returns a copy of this year-week with the specified amount added.
-     * 
+     *
      * This returns a {@link YearWeek}, based on this one, with the amount
      * in terms of the unit added. If it is not possible to add the amount, because the
      * unit is not supported or for some other reason, an exception is thrown.
-     * 
+     *
      * If the field is a {@link ChronoUnit} then the addition is implemented here.
      * The supported fields behave as follows:
      * - {@link WEEKS} - Returns a {@link YearWeek} with the weeks added as per {@link YearWeek.plusWeeks}.
      * - {@link WEEK_BASED_YEARS} - Returns a {@link YearWeek} with the years added as per {@link YearWeek.plusYears}.
-     * 
+     *
      * All {@link ChronoUnit} instances will throw an {@link UnsupportedTemporalTypeException}.
-     * 
+     *
      * If the field is not a {@link ChronoUnit}, then the result of this method
      * is obtained by invoking {@link TemporalUnit.addTo}
      * passing this as the argument. In this case, the unit determines
      * whether and how to perform the addition.
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
      *
      * @param {number} amountToAdd - the amount of the unit to add to the result, may be negative
@@ -631,12 +635,12 @@ export class YearWeek extends Temporal {
 
     /**
      * Returns a copy of this year-week with the specified number of years added.
-     * 
+     *
      * If the week of this instance is 53 and the new year does not have 53 weeks,
      * the week will be adjusted to be 52.
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
-     * 
+     *
      * @param {number} yearsToAdd - the years to add, may be negative
      * @return {YearWeek} the year-week with the years added, not null
      */
@@ -650,9 +654,9 @@ export class YearWeek extends Temporal {
 
     /**
      * Returns a copy of this year-week with the specified number of weeks added.
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
-     * 
+     *
      * @param {number} weeksToAdd - the weeks to add, may be negative
      * @return {YearWeek} the year-week with the weeks added, not null
      */
@@ -666,14 +670,14 @@ export class YearWeek extends Temporal {
 
     /**
      * Returns a copy of this year-week with the specified amount subtracted.
-     * 
+     *
      * This returns a {@link YearWeek}, based on this one, with the amount
      * in terms of the unit subtracted. If it is not possible to subtract the amount,
      * because the unit is not supported or for some other reason, an exception is thrown.
-     * 
+     *
      * This method is equivalent to {@link YearWeek.plus} with the amount negated.
      * See that method for a full description of how addition, and thus subtraction, works.
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
      *
      * @param {number} amountToSubtract - the amount of the unit to subtract from the result, may be negative
@@ -691,12 +695,12 @@ export class YearWeek extends Temporal {
 
     /**
      * Returns a copy of this year-week with the specified number of years subtracted.
-     * 
+     *
      * If the week of this instance is 53 and the new year does not have 53 weeks,
      * the week will be adjusted to be 52.
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
-     * 
+     *
      * @param {number} yearsToSubtract - the years to subtract, may be negative
      * @return {YearWeek} the year-week with the years subtracted, not null
      */
@@ -710,9 +714,9 @@ export class YearWeek extends Temporal {
 
     /**
      * Returns a copy of this year-week with the specified number of weeks subtracted.
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
-     * 
+     *
      * @param {number} weeksToSubtract - the weeks to subtract, may be negative
      * @return {YearWeek} the year-week with the weeks subtracted, not null
      */
@@ -727,12 +731,12 @@ export class YearWeek extends Temporal {
     //-----------------------------------------------------------------------
     /**
      * Queries this year-week using the specified query.
-     * 
+     *
      * This queries this year-week using the specified query strategy object.
      * The {@link TemporalQuery} object defines the logic to be used to
      * obtain the result. Read the documentation of the query to understand
      * what the result of this method will be.
-     * 
+     *
      * The result of this method is obtained by invoking the
      * {@link TemporalQuery.queryFrom} method on the
      * specified query passing this as the argument.
@@ -753,16 +757,16 @@ export class YearWeek extends Temporal {
 
     /**
      * Adjusts the specified temporal object to have this year-week.
-     * 
+     *
      * This returns a temporal object of the same observable type as the input
      * with the week-based-year and week changed to be the same as this.
-     * 
+     *
      * The adjustment is equivalent to using {@link Temporal.with}
      * twice, passing {@link IsoFields.WEEK_BASED_YEAR} and
      * {@link IsoFields.WEEK_OF_WEEK_BASED_YEAR} as the fields.
      * If the specified temporal object does not use the ISO calendar system then
      * a {@link DateTimeException} is thrown.
-     * 
+     *
      * In most cases, it is clearer to reverse the calling pattern by using
      * {@link Temporal.with}:
      * ```
@@ -770,7 +774,7 @@ export class YearWeek extends Temporal {
      *   temporal = thisYearWeek.adjustInto(temporal);
      *   temporal = temporal.with(thisYearWeek);
      * ```
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
      *
      * @param {Temporal} temporal - the target object to be adjusted, not null
@@ -784,7 +788,7 @@ export class YearWeek extends Temporal {
 
     /**
      * Calculates the amount of time until another year-week in terms of the specified unit.
-     * 
+     *
      * This calculates the amount of time between two {@link YearWeek}
      * objects in terms of a single {@link TemporalUnit}.
      * The start and end points are this and the specified year-week.
@@ -793,12 +797,12 @@ export class YearWeek extends Temporal {
      * {@link YearWeek} using {@link YearWeek.from}.
      * For example, the period in years between two year-weeks can be calculated
      * using `startYearWeek.until(endYearWeek, YEARS)`.
-     * 
+     *
      * The calculation returns a whole number, representing the number of
      * complete units between the two year-weeks.
      * For example, the period in years between 2012-W23 and 2032-W22
      * will only be 9 years as it is one week short of 10 years.
-     * 
+     *
      * There are two equivalent ways of using this method.
      * The first is to invoke this method.
      * The second is to use {@link TemporalUnit.between}:
@@ -808,16 +812,16 @@ export class YearWeek extends Temporal {
      *   amount = WEEKS.between(start, end);
      * ```
      * The choice should be made based on which makes the code more readable.
-     * 
+     *
      * The calculation is implemented in this method for units {@link WEEKS}
      * and {@link WEEK_BASED_YEARS}.
      * Other {@link ChronoUnit} values will throw an exception.
-     * 
+     *
      * If the unit is not a {@link ChronoUnit}, then the result of this method
      * is obtained by invoking {@link TemporalUnit.between}
      * passing this as the first argument and the converted input temporal
      * as the second argument.
-     * 
+     *
      * This instance is immutable and unaffected by this method call.
      *
      * @param {Temporal} endExclusive - the end date, exclusive, which is converted to a {@link YearWeek}, not null
@@ -866,7 +870,7 @@ export class YearWeek extends Temporal {
 
     /**
      * Formats this year-week using the specified formatter.
-     * 
+     *
      * This year-week will be passed to the formatter to produce a string.
      *
      * @param {DateTimeFormatter} formatter - the formatter to use, not null
@@ -881,9 +885,9 @@ export class YearWeek extends Temporal {
     //-----------------------------------------------------------------------
     /**
      * Combines this year-week with a day-of-week to create a {@link LocalDate}.
-     * 
+     *
      * This returns a {@link LocalDate} formed from this year-week and the specified day-of-Week.
-     * 
+     *
      * This method can be used as part of a chain to produce a date:
      * ```
      *  LocalDate date = yearWeek.atDay(MONDAY);
@@ -911,7 +915,7 @@ export class YearWeek extends Temporal {
     //-----------------------------------------------------------------------
     /**
      * Compares this year-week to another
-     * 
+     *
      * The comparison is based first on the value of the year, then on the value of the week.
      * It is "consistent with equals", as defined by {@link Comparable}.
      *
@@ -927,7 +931,7 @@ export class YearWeek extends Temporal {
         }
         return cmp;
     }
- 
+
     /**
      * Is this year-week after the specified year-week.
      *
@@ -947,7 +951,7 @@ export class YearWeek extends Temporal {
     isBefore(other) {
         return this.compareTo(other) < 0;
     }
- 
+
     //-----------------------------------------------------------------------
     /**
      * Checks if this year-week is equal to another year-week.
@@ -964,7 +968,7 @@ export class YearWeek extends Temporal {
         }
         return false;
     }
- 
+
     /**
      * A hash code for this year-week.
      *
@@ -973,11 +977,11 @@ export class YearWeek extends Temporal {
     hashCode() {
         return this._year ^ (this._week << 25);
     }
- 
+
     //-----------------------------------------------------------------------
     /**
      * Outputs this year-week as a {@link String}, such as `2015-W13`.
-     * 
+     *
      * The output will be in the format `YYYY-'W'ww`:
      *
      * @return {string} a string representation of this year-week, not null

--- a/packages/locale/src/format/LocaleStore.js
+++ b/packages/locale/src/format/LocaleStore.js
@@ -64,6 +64,10 @@ export class LocaleStore {
         this._parsable = map;
     }
 
+    get [Symbol.toStringTag]() {
+        return 'LocaleStore';
+    }
+
     //-----------------------------------------------------------------------
     /**
      * Gets the text for the specified field value, locale and style

--- a/packages/locale/src/temporal/WeekFields.js
+++ b/packages/locale/src/temporal/WeekFields.js
@@ -55,7 +55,7 @@ export class ComputedDayOfField {
      * Returns a field to access the day of week,
      * computed based on a WeekFields.
      * <p>
-     * The WeekDefintion of the first day of the week is used with
+     * The WeekDefinition of the first day of the week is used with
      * the ISO DAY_OF_WEEK field to compute week boundaries.
      */
     static ofDayOfWeekField(weekDef) {
@@ -112,6 +112,10 @@ export class ComputedDayOfField {
         this._baseUnit = baseUnit;
         this._rangeUnit = rangeUnit;
         this._range = range;
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'ComputedDayOfField';
     }
 
     getFrom(temporal) {
@@ -663,6 +667,10 @@ export class WeekFields {
         this._weekOfWeekBasedYear = ComputedDayOfField.ofWeekOfWeekBasedYearField(this);
         this._weekBasedYear = ComputedDayOfField.ofWeekBasedYearField(this);
         Cldr.load(cldrData('supplemental/likelySubtags.json'));
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'WeekFields';
     }
 
     //-----------------------------------------------------------------------

--- a/packages/timezone/src/MomentZoneRules.js
+++ b/packages/timezone/src/MomentZoneRules.js
@@ -14,6 +14,11 @@ export class MomentZoneRules extends ZoneRules{
         this._tzdbInfo = tzdbInfo;
         this._ldtUntils = new LDTUntils(this._tzdbInfo.untils, this._tzdbInfo.offsets);
     }
+
+    get [Symbol.toStringTag]() {
+        return 'MomentZoneRules';
+    }
+
     /**
      * Checks of the zone rules are fixed, such that the offset never varies.
      *
@@ -381,6 +386,10 @@ class LDTUntils {
         this._tzdbOffsets = tzdbOffsets;
         this._ldtUntils = [];
         this.size = this._tzdbUntils.length * 2;
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'LDTUntils';
     }
 
 


### PR DESCRIPTION
This lets `requireInstance` and similar checks give more descriptive errors about what's passed in, even if class names are minified.

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag

I added exception messages to the automated tests to demonstrate and validate the new behavior.

This PR has some spurious changes due to my editor automatically removing trailing whitespace. I apologize for the spurious diffs. If that will be an issue, I can try reworking it. (Perhaps easier would be for me to open a separate PR that just removes trailing whitespace, then rebase this on top of that.)

Fixes #767 