### PR TITLE
Fix toSecondsPart typo in Duration Flow type definition

### DIFF
--- a/packages/core/typings/js-joda.flow.js
+++ b/packages/core/typings/js-joda.flow.js
@@ -110,7 +110,7 @@ declare module "js-joda" {
         toNanos(): number;
         toHoursPart(): number;
         toMinutesPart(): number;
-        toSecondspart(): number;
+        toSecondsPart(): number;
         toMillisPart(): number;
         toString(): string;
         units(): any;


### PR DESCRIPTION
The Flow type definition for `Duration` declares `toSecondspart(): number;` with a lowercase `p`, but the method on the class is `toSecondsPart()`. Flow users get a type error when calling `duration.toSecondsPart()`, and the typing exposes a `toSecondspart` method that does not exist.

The three sibling part methods added in the same change (`toHoursPart`, `toMinutesPart`, `toMillisPart`) are spelled correctly in the same block, and `js-joda.d.ts` already declares `toSecondsPart`. This lines the Flow typing up with the implementation.

Introduced in #777.
