### PR TITLE
fix: Instant.parse should accept an offset and resolve to the UTC instant (#731)

### DIFF
--- a/packages/core/src/format/DateTimeFormatterBuilder.js
+++ b/packages/core/src/format/DateTimeFormatterBuilder.js
@@ -1516,7 +1516,7 @@ class InstantPrinterParser  {
         const parser = new DateTimeFormatterBuilder()
             .append(DateTimeFormatter.ISO_LOCAL_DATE).appendLiteral('T')
             .appendValue(ChronoField.HOUR_OF_DAY, 2).appendLiteral(':').appendValue(ChronoField.MINUTE_OF_HOUR, 2).appendLiteral(':')
-            .appendValue(ChronoField.SECOND_OF_MINUTE, 2).appendFraction(ChronoField.NANO_OF_SECOND, minDigits, maxDigits, true).appendLiteral('Z')
+            .appendValue(ChronoField.SECOND_OF_MINUTE, 2).appendFraction(ChronoField.NANO_OF_SECOND, minDigits, maxDigits, true).appendOffsetId()
             .toFormatter()._toPrinterParser(false);
         const pos = parser.parse(newContext, text, position);
         if (pos < 0) {
@@ -1531,6 +1531,10 @@ class InstantPrinterParser  {
         const min = newContext.getParsed(ChronoField.MINUTE_OF_HOUR);
         const secVal = newContext.getParsed(ChronoField.SECOND_OF_MINUTE);
         const nanoVal = newContext.getParsed(ChronoField.NANO_OF_SECOND);
+        // The instant is parsed with an offset id (which also accepts 'Z' as
+        // zero), so resolve against the parsed offset rather than assuming UTC.
+        const offsetSecs = newContext.getParsed(ChronoField.OFFSET_SECONDS);
+        const offset = (offsetSecs != null ? offsetSecs : 0);
         let sec = (secVal != null ? secVal : 0);
         const nano = (nanoVal != null ? nanoVal : 0);
         const year = MathUtil.intMod(yearParsed, 10000);
@@ -1545,7 +1549,7 @@ class InstantPrinterParser  {
         let instantSecs;
         try {
             const ldt = LocalDateTime.of(year, month, day, hour, min, sec, 0).plusDays(days);
-            instantSecs = ldt.toEpochSecond(ZoneOffset.UTC);
+            instantSecs = ldt.toEpochSecond(ZoneOffset.ofTotalSeconds(offset));
             instantSecs += MathUtil.safeMultiply(MathUtil.intDiv(yearParsed, 10000), SECONDS_PER_10000_YEARS);
         } catch (ex) {
             return ~position;

--- a/packages/core/test/reference/InstantTest.js
+++ b/packages/core/test/reference/InstantTest.js
@@ -226,7 +226,13 @@ describe('org.threeten.bp.TestInstant', () => {
                 ['1970-01-01T00:01:01.000000001Z', 61, 1],
                 ['1970-01-01T01:00:00.000000000Z', 3600, 0],
                 ['1970-01-01T01:01:01.000000001Z', 3661, 1],
-                ['1970-01-02T01:01:01.100000000Z', 90061, 100000000]
+                ['1970-01-02T01:01:01.100000000Z', 90061, 100000000],
+
+                // A non-UTC offset is accepted and resolved to the UTC instant (gh-731)
+                ['1970-01-01T00:00:00+00:00', 0, 0],
+                ['1970-01-01T01:00:00+01:00', 0, 0],
+                ['1970-01-01T00:30:00+00:30', 0, 0],
+                ['1970-01-01T00:00:00-01:00', 3600, 0]
             ];
         }
 
@@ -252,6 +258,13 @@ describe('org.threeten.bp.TestInstant', () => {
             assertEquals(t.epochSecond(), expectedEpochSeconds);
             assertEquals(t.nano(), expectedNanoOfSecond);
         }
+
+        it('factory_parse_offset_resolvesToUtcInstant', function () {
+            // gh-731: Instant.parse must accept an offset (like java.time) and
+            // resolve it to the equivalent UTC instant, not throw.
+            assertEquals(Instant.parse('2024-03-07T15:30:00+08:00').toString(), '2024-03-07T07:30:00Z');
+            assertEquals(Instant.parse('2024-03-07T07:30:00-00:00').toString(), '2024-03-07T07:30:00Z');
+        });
 
         // TODO: should comma be accepted?
         //    @Test(dataProvider='Parse')


### PR DESCRIPTION
Fixes #731

## What was wrong

`Instant.parse` parses with a formatter that ends in a literal `Z`:

```js
.appendValue(SECOND_OF_MINUTE, 2).appendFraction(NANO_OF_SECOND, …).appendLiteral('Z')
```

So an ISO-8601 instant carrying a numeric offset throws instead of parsing:

```js
Instant.parse("2024-03-07T15:30:00+08:00");
// DateTimeParseException: … could not be parsed at index 19
```

`java.time.Instant.parse` (which this library mirrors) accepts an offset and resolves it to the equivalent UTC instant — the expected result here is `2024-03-07T07:30:00Z`.

## Fix

Mirror `java.time`'s `InstantPrinterParser`: append an **offset id** instead of a literal `Z` (`appendOffsetId()` still accepts `Z` as the zero offset), and resolve the local date-time against the parsed `OFFSET_SECONDS` rather than assuming UTC. Printing is unchanged (still emits `Z`).

## Tests

Adds offset cases to the `parse` data provider and a dedicated test for the reported example. Verified:
- `2024-03-07T15:30:00+08:00` → `2024-03-07T07:30:00Z` (was throwing on `master`);
- existing `Z` inputs and all `parseFailures` (bare date-times, partial offsets) still behave as before.