### PR TITLE
fix(core): correct Duration.toString for negative seconds on minute boundary

### DIFF
--- a/packages/core/src/Duration.js
+++ b/packages/core/src/Duration.js
@@ -1209,9 +1209,22 @@ export class Duration extends TemporalAmount /*implements TemporalAmount, Compar
         if (this === Duration.ZERO) {
             return 'PT0S';
         }
-        const hours = MathUtil.intDiv(this._seconds, LocalTime.SECONDS_PER_HOUR);
-        const minutes = MathUtil.intDiv(MathUtil.intMod(this._seconds, LocalTime.SECONDS_PER_HOUR), LocalTime.SECONDS_PER_MINUTE);
-        const secs = MathUtil.intMod(this._seconds, LocalTime.SECONDS_PER_MINUTE);
+        // A negative duration is stored as a negative second count plus a
+        // non-negative nano offset, e.g. -0.5s is held as seconds = -1,
+        // nanos = 500000000. To render ISO-8601 components that all carry the
+        // duration's sign, recover the signed whole-second part and the
+        // magnitude of the sub-second fraction separately: when the duration is
+        // negative and has a fractional offset, one second of that offset
+        // belongs to the whole part, and the remaining fraction is its
+        // complement against a full second.
+        const negativeFraction = this._seconds < 0 && this._nanos > 0;
+        const wholeSeconds = negativeFraction ? this._seconds + 1 : this._seconds;
+        const fractionNanos = negativeFraction ? LocalTime.NANOS_PER_SECOND - this._nanos : this._nanos;
+
+        const hours = MathUtil.intDiv(wholeSeconds, LocalTime.SECONDS_PER_HOUR);
+        const minutes = MathUtil.intDiv(MathUtil.intMod(wholeSeconds, LocalTime.SECONDS_PER_HOUR), LocalTime.SECONDS_PER_MINUTE);
+        const secs = MathUtil.intMod(wholeSeconds, LocalTime.SECONDS_PER_MINUTE);
+
         let rval = 'PT';
         if (hours !== 0) {
             rval += `${hours}H`;
@@ -1219,32 +1232,28 @@ export class Duration extends TemporalAmount /*implements TemporalAmount, Compar
         if (minutes !== 0) {
             rval += `${minutes}M`;
         }
-        if (secs === 0 && this._nanos === 0 && rval.length > 2) {
+        if (secs === 0 && fractionNanos === 0 && rval.length > 2) {
             return rval;
         }
-        if (secs < 0 && this._nanos > 0) {
-            if (secs === -1) {
-                rval += '-0';
-            } else {
-                rval += secs + 1;
-            }
+        // The seconds field needs an explicit minus sign when the whole-second
+        // part is zero but the duration is a negative fraction (e.g. -0.5s
+        // prints as "-0.5S", not "0.5S").
+        if (secs === 0 && negativeFraction) {
+            rval += '-0';
         } else {
-            rval += secs;
+            rval += `${secs}`;
         }
-        if (this._nanos > 0) {
-            rval += '.';
-            let nanoString;
-            if (secs < 0) {
-                nanoString = `${2 * LocalTime.NANOS_PER_SECOND - this._nanos}`;
-            } else {
-                nanoString = `${LocalTime.NANOS_PER_SECOND + this._nanos}`;
+        if (fractionNanos > 0) {
+            // fractionNanos is a magnitude in [1, 1e9); print it as a fixed
+            // nine-digit fraction with any trailing zeros removed.
+            let fraction = `${fractionNanos}`;
+            while (fraction.length < 9) {
+                fraction = `0${fraction}`;
             }
-            // remove the leading '1'
-            nanoString = nanoString.slice(1, nanoString.length);
-            rval += nanoString;
-            while (rval.charAt(rval.length - 1) === '0') {
-                rval = rval.slice(0, rval.length - 1);
+            while (fraction.charAt(fraction.length - 1) === '0') {
+                fraction = fraction.slice(0, fraction.length - 1);
             }
+            rval += `.${fraction}`;
         }
         rval += 'S';
         return rval;

--- a/packages/core/test/reference/DurationTest.js
+++ b/packages/core/test/reference/DurationTest.js
@@ -2323,6 +2323,18 @@ describe('org.threeten.bp.TestDuration', () => {
             [60, 0, 'PT1M'],
             [3600, 0, 'PT1H'],
             [7261, 0, 'PT2H1M1S'],
+
+            // negative seconds with non-zero nanos on a whole-minute boundary
+            [-60, 500000000, 'PT-59.5S'],
+            [-3600, 500000000, 'PT-59M-59.5S'],
+            [-86400, 500000000, 'PT-23H-59M-59.5S'],
+            [-120, 1, 'PT-1M-59.999999999S'],
+
+            // negative sub-second remainder where the seconds field is zero
+            [-1, 500000000, 'PT-0.5S'],
+            [-61, 500000000, 'PT-1M-0.5S'],
+            [-3601, 500000000, 'PT-1H-0.5S'],
+
             [MAX_SAFE_INTEGER, 0, 'PT2501999792983H36M31S'],
             [MIN_SAFE_INTEGER, 0, 'PT-2501999792983H-36M-31S']
         ];


### PR DESCRIPTION
## Problem

`Duration.toString()` produces a malformed, sign-inconsistent string for negative durations when `seconds < 0`, `nanos > 0`, and `seconds` is an exact multiple of 60 (a whole-minute boundary).

The current implementation derives `hours`/`minutes`/`secs` straight from the raw `this._seconds` field and gates its sign branches on the post-division `secs` value. When `seconds % 60 === 0`, the unadjusted `secs` is `0`, so the borrow across the minute/hour boundary is skipped and the output mixes a negative hour/minute term with a positive seconds term.

`Duration.toString` is documented to produce the canonical normalized ISO-8601 form in which every term carries the same sign (the long-standing `java.time.Duration` contract; the same defect is tracked upstream as JDK-8146278). The `PT-1H0.5S` style output (negative hour, positive seconds) is not a valid value of that form and does not round-trip cleanly.

Reproduced on `@js-joda/core@6.0.1` (current `main` has the same code); the expected column is the documented canonical form:

| input | js-joda | expected |
|---|---|---|
| `Duration.ofSeconds(-3600, 500000000)` | `PT-1H0.5S` | `PT-59M-59.5S` |
| `Duration.ofSeconds(-60, 500000000)` | `PT-1M0.5S` | `PT-59.5S` |
| `Duration.ofSeconds(-86400, 500000000)` | `PT-24H0.5S` | `PT-23H-59M-59.5S` |
| `Duration.ofSeconds(-120, 1)` | `PT-2M0.000000001S` | `PT-1M-59.999999999S` |

## Root cause

In `packages/core/src/Duration.js`, `toString()`:

1. computes hours/minutes/secs from the raw `this._seconds` instead of a value that accounts for the sub-second offset when `seconds < 0 && nanos > 0`;
2. gates the seconds-sign branch on the post-division `secs` (`secs < 0` / `secs === -1`) rather than the duration's actual sign;
3. gates the nano formatting on `secs < 0` rather than the duration's actual sign.

When `seconds % 60 === 0` the unadjusted `secs` is `0`, so the sign of a negative sub-second duration is lost across the minute/hour boundary.

## Fix

`toString` is reimplemented in js-joda's own idioms. js-joda stores a negative duration as a negative second count plus a non-negative nano offset (e.g. `-0.5s` is `seconds = -1, nanos = 500000000`). The fix recovers, from that representation, the signed whole-second part and the magnitude of the sub-second fraction separately:

- when the duration is negative and has a nano offset, one second of the offset belongs to the whole part (`wholeSeconds = seconds + 1`) and the remaining fraction is its complement against a full second (`NANOS_PER_SECOND - nanos`);
- hours/minutes/secs come from `wholeSeconds`;
- the seconds field gets an explicit `-0` when the whole part is zero but the duration is a negative fraction;
- the fraction is printed as a zero-padded nine-digit value with trailing zeros trimmed.

`Duration.parse` and the arithmetic are untouched; only `toString` changes. The correct outputs were determined from the documented `Duration.toString` behavior (JDK-8146278); no OpenJDK source was copied or translated.

## Tests

`data_toString` in `packages/core/test/reference/DurationTest.js` previously omitted the negative-seconds-with-non-zero-nanos rows. This PR adds them: the four cases above plus the sub-second cases where the whole-second part is zero (`ofSeconds(-1, 5e8)` -> `PT-0.5S`, `ofSeconds(-61, 5e8)` -> `PT-1M-0.5S`, `ofSeconds(-3601, 5e8)` -> `PT-1H-0.5S`), asserting the documented output.

Before the fix these rows fail (e.g. `expected 'PT-1M0.5S' to deeply equal 'PT-59.5S'`). After the fix `DurationTest` is 154/154 and the full `@js-joda/core` mocha suite passes (2585 passing, 0 failing), including all pre-existing `toString` cases and the previously-correct negative cases such as `ofSeconds(-30, 5e8)` -> `PT-29.5S` and `ofSeconds(-3600, 0)` -> `PT-1H`.
