### PR TITLE
docs: clarify contributions must derive from threeten-bp, not OpenJDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Note that only pull requests and issues that match the threeten backport API wil
 
 - `OpenJDK` is under GNU GPL+linking exception.
 
+- **For contributors:** because of the licensing above, contributions must be derived from the BSD-licensed ThreeTen-Backport, **not** from OpenJDK's `java.time`, which is GPL-licensed. Do not copy or translate OpenJDK source into js-joda. If you need behavior that ThreeTen-Backport does not yet implement (e.g. a bug fixed in the JDK but not in threeten-bp), write an independent implementation in js-joda's own style; you may reference the *documented behavior* or a JDK bug report as a specification, but the code itself must be your own work.
+
 - The author of `Joda-Time` and the lead architect of the JSR-310 is Stephen Colebourne.
 
 The API of this project (as far as possible with JavaScript), a lot of implementation details and documentation


### PR DESCRIPTION
## What

Adds an explicit contributor-facing rule to the README **License** section: because js-joda is BSD-licensed and sourced from the BSD-licensed ThreeTen-Backport, contributions must **not** be copied or translated from OpenJDK's `java.time` (GPLv2 + Classpath Exception).

## Why

The License section already documents the threeten-bp lineage and notes that OpenJDK is GPL, but it never states the practical rule for contributors. This came up in #805, where a correct fix was ported directly from OpenJDK because the equivalent bug is still present in threeten-bp (so there was no BSD source to port from). Making the rule explicit helps contributors avoid introducing GPL-derived code and points them at the right approach: write an independent implementation in js-joda's own style, referencing only documented behavior / JDK bug reports as a specification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)