### PR TITLE
fix: parse zone ids that share a prefix with a fixed id

### DIFF
--- a/packages/core/src/format/parser/ZoneIdPrinterParser.js
+++ b/packages/core/src/format/parser/ZoneIdPrinterParser.js
@@ -71,7 +71,67 @@ export class ZoneIdPrinterParser {
             return ~position;
         }
 
-        // handle fixed time-zone IDs
+        // A fixed ID (Z, UT, UTC, GMT, an offset) can also be the start of a
+        // longer region id such as GMT0 or Zulu, so parse both and keep the
+        // longest match (as the class doc above promises).
+        const region = this._parseRegion(text, position);
+        const fixedEndPos = this._parseFixedId(context, text, position);
+
+        const fixedLength = fixedEndPos >= 0 ? fixedEndPos - position : 0;
+        if (region != null && region.parseLength > fixedLength) {
+            context.setParsedZone(ZoneRegion.ofId(region.parsedZoneId));
+            return position + region.parseLength;
+        }
+        return fixedEndPos;
+    }
+
+    /**
+     * Finds the longest available zone region id matching text at position,
+     * without touching the parse context.
+     *
+     * @param {String} text
+     * @param {number} position
+     * @return {?{parsedZoneId: string, parseLength: number}}
+     */
+    _parseRegion(text, position) {
+        const availableZoneIds = ZoneRulesProvider.getAvailableZoneIds();
+        if (availableZoneIds.length === 0) {
+            return null;
+        }
+        if (zoneIdTree.size !== availableZoneIds.length) {
+            zoneIdTree = ZoneIdTree.createTreeMap(availableZoneIds);
+        }
+
+        const maxParseLength = text.length - position;
+        let treeMap = zoneIdTree.treeMap;
+        let parsedZoneId = null;
+        let parseLength = 0;
+        while(treeMap != null) {
+            const parsedSubZoneId = text.substr(position, Math.min(treeMap.length, maxParseLength));
+            treeMap = treeMap.get(parsedSubZoneId);
+            if (treeMap != null && treeMap.isLeaf) {
+                parsedZoneId = parsedSubZoneId;
+                parseLength = treeMap.length;
+            }
+        }
+        if (parsedZoneId == null) {
+            return null;
+        }
+        return { parsedZoneId, parseLength };
+    }
+
+    /**
+     * Parses a fixed zone id (an offset, a UT/UTC/GMT prefixed offset, SYSTEM
+     * or Z) and sets it on the context. Returns the end position, or ~position
+     * if no fixed id matches at position.
+     *
+     * @param {DateTimeParseContext} context
+     * @param {String} text
+     * @param {number} position
+     * @return {number}
+     */
+    _parseFixedId(context, text, position) {
+        const length = text.length;
         const nextChar = text.charAt(position);
         if (nextChar === '+' || nextChar === '-') {
             const newContext = context.copy();
@@ -80,8 +140,7 @@ export class ZoneIdPrinterParser {
                 return endPos;
             }
             const offset = newContext.getParsed(ChronoField.OFFSET_SECONDS);
-            const zone = ZoneOffset.ofTotalSeconds(offset);
-            context.setParsedZone(zone);
+            context.setParsedZone(ZoneOffset.ofTotalSeconds(offset));
             return endPos;
         } else if (length >= position + 2) {
             const nextNextChar = text.charAt(position + 1);
@@ -104,35 +163,10 @@ export class ZoneIdPrinterParser {
             context.setParsedZone(ZoneId.systemDefault());
             return position + 6;
         }
-
-        // ...
         if (context.charEquals(nextChar, 'Z')) {
             context.setParsedZone(ZoneOffset.UTC);
             return position + 1;
         }
-
-        const availableZoneIds = ZoneRulesProvider.getAvailableZoneIds();
-        if (zoneIdTree.size !== availableZoneIds.length) {
-            zoneIdTree = ZoneIdTree.createTreeMap(availableZoneIds);
-        }
-
-        const maxParseLength = length - position;
-        let treeMap = zoneIdTree.treeMap;
-        let parsedZoneId = null;
-        let parseLength = 0;
-        while(treeMap != null) {
-            const parsedSubZoneId = text.substr(position, Math.min(treeMap.length, maxParseLength));
-            treeMap = treeMap.get(parsedSubZoneId);
-            if (treeMap != null && treeMap.isLeaf) {
-                parsedZoneId = parsedSubZoneId;
-                parseLength = treeMap.length;
-            }
-        }
-        if (parsedZoneId != null) {
-            context.setParsedZone(ZoneRegion.ofId(parsedZoneId));
-            return position + parseLength;
-        }
-
         return ~position;
     }
 

--- a/packages/core/test/reference/format/ZoneIdPrinterParserTest.js
+++ b/packages/core/test/reference/format/ZoneIdPrinterParserTest.js
@@ -159,6 +159,55 @@ describe('org.threeten.bp.format.TestZoneIdParser', () => {
 
     });
 
+    describe('parse region ids sharing a prefix with a fixed id (#681)', function () {
+
+        let getAvailableZoneIdsFn = null;
+        let getRulesFn = null;
+
+        before(() => {
+            getAvailableZoneIdsFn = ZoneRulesProvider.getAvailableZoneIds;
+            getRulesFn = ZoneRulesProvider.getRules;
+            // GMT and UTC are real region ids too, so a following offset must
+            // still beat the bare region (GMT+03:30 must not truncate to GMT).
+            ZoneRulesProvider.getAvailableZoneIds =
+                () => ['GMT', 'UTC', 'GMT0', 'Zulu', 'America/New_York'];
+            ZoneRulesProvider.getRules = () => ZoneOffset.ofHours(0).rules();
+        });
+
+        after(() => {
+            ZoneRulesProvider.getAvailableZoneIds = getAvailableZoneIdsFn;
+            ZoneRulesProvider.getRules = getRulesFn;
+        });
+
+        function data_longestMatch() {
+            return [
+                ['GMT0', 4, ZoneId.of('GMT0')],  // region beats the GMT prefix
+                ['Zulu', 4, ZoneId.of('Zulu')],  // region beats Z
+                ['GMT+03:30', 9, null],  // offset beats the bare GMT region
+                ['UTC+01:30', 9, null],  // offset beats the bare UTC region
+                ['GMT', 3, null],        // bare region ties the fixed id, fixed wins
+                ['Z0', 1, null],         // no Z0 region, Z wins
+                ['UTC0', 3, null],       // no UTC0 region, UTC wins
+                ['GMTZ', 3, null],       // no GMTZ region, GMT wins
+            ];
+        }
+
+        it('picks the longest match', function () {
+            dataProviderTest(data_longestMatch, (text, expectedIndex, expectedZone) => {
+                const pos = new ParsePosition(0);
+                const parsed = new DateTimeFormatterBuilder().appendZoneId()
+                    .toFormatter().parseUnresolved(text, pos);
+                assertEquals(pos.getErrorIndex(), -1, `Incorrect error index parsing: ${text}`);
+                assertEquals(pos.getIndex(), expectedIndex, `Incorrect index parsing: ${text}`);
+                if (expectedZone != null) {
+                    assertEquals(parsed.query(TemporalQueries.zoneId()), expectedZone,
+                        `Incorrect zoneId parsing: ${text}`);
+                }
+            });
+        });
+
+    });
+
     it('javascript special id SYSTEM', function () {
         const text = 'SYSTEM';
         const parsed = builder.appendZoneId().toFormatter().parseUnresolved(text, pos);


### PR DESCRIPTION
Fixes #681.

js-joda prints a `ZonedDateTime` for `GMT0` or `Zulu` as `…Z[GMT0]` / `…Z[Zulu]`, then throws parsing it back. The parser matches the `GMT`/`UT`/`UTC` prefixes and a leading `Z` before it checks the region table and stops on the first hit, so `GMT0` stops at `GMT` and `Zulu` at `Z`. Both are real zone ids longer than the prefix, so now the longest match wins.

One call for you: longest-wins, not always-prefer-region. `GMT`/`UTC` are real zone ids too, so region-first would break `GMT+03:30` / `UTC+01:30`. Happy to change it.

Tests in `ZoneIdPrinterParserTest.js`; core suite green, eslint clean, nothing from OpenJDK.