### PR TITLE
fix(core): truncate Instant toward negative infinity for pre-epoch values

### DIFF
--- a/packages/core/src/Instant.js
+++ b/packages/core/src/Instant.js
@@ -520,7 +520,7 @@ export class Instant extends Temporal {
             throw new DateTimeException('Unit must divide into a standard day without remainder');
         }
         const nod = MathUtil.intMod(this._seconds, LocalTime.SECONDS_PER_DAY) * LocalTime.NANOS_PER_SECOND + this._nanos;
-        const result = MathUtil.intDiv(nod, dur) * dur;
+        const result = MathUtil.floorDiv(nod, dur) * dur;
         return this.plusNanos(result - nod);
     }
 

--- a/packages/core/test/reference/InstantTest.js
+++ b/packages/core/test/reference/InstantTest.js
@@ -1894,13 +1894,12 @@ describe('org.threeten.bp.TestInstant', () => {
     });
 
     describe('truncatedTo', () => {
-        // TODO Fix failing tests see https://github.com/ThreeTen/threetenbp/pull/54
         it('test_truncatedTo', () => {
             assertEquals(Instant.ofEpochSecond(2, 1000000).truncatedTo(ChronoUnit.SECONDS), Instant.ofEpochSecond(2));
             assertEquals(Instant.ofEpochSecond(2, -1000000).truncatedTo(ChronoUnit.SECONDS), Instant.ofEpochSecond(1));
-            // assertEquals(Instant.ofEpochSecond(0, -1000000).truncatedTo(ChronoUnit.SECONDS), Instant.ofEpochSecond(-1));
+            assertEquals(Instant.ofEpochSecond(0, -1000000).truncatedTo(ChronoUnit.SECONDS), Instant.ofEpochSecond(-1));
             assertEquals(Instant.ofEpochSecond(-1).truncatedTo(ChronoUnit.SECONDS), Instant.ofEpochSecond(-1));
-            // assertEquals(Instant.ofEpochSecond(-1, -1000000).truncatedTo(ChronoUnit.SECONDS), Instant.ofEpochSecond(-2));
+            assertEquals(Instant.ofEpochSecond(-1, -1000000).truncatedTo(ChronoUnit.SECONDS), Instant.ofEpochSecond(-2));
             assertEquals(Instant.ofEpochSecond(-2).truncatedTo(ChronoUnit.SECONDS), Instant.ofEpochSecond(-2));
         });
 


### PR DESCRIPTION
`Instant.truncatedTo` divided the nano-of-day by the unit length with integer division that rounds toward zero. For instants before 1970 the nano-of-day is negative, so truncation rounded up toward the epoch instead of down. For example `1969-12-31T23:59:30Z` truncated to minutes returned `1970-01-01T00:00:00Z` instead of `1969-12-31T23:59:00Z`.

Using `floorDiv` floors toward negative infinity, matching `java.time.Instant.truncatedTo` and the fix in ThreeTen PR 54. The two reference assertions that were disabled for this are re-enabled.
