### PR TITLE
fix(core): initialize parsed excessDays to Period.ZERO

### DIFF
--- a/packages/core/src/format/DateTimeParseContext.js
+++ b/packages/core/src/format/DateTimeParseContext.js
@@ -9,6 +9,7 @@ import { assert, requireNonNull } from '../assert';
 import { DateTimeBuilder } from './DateTimeBuilder';
 import { EnumMap } from './EnumMap';
 
+import { Period } from '../Period';
 import { IsoChronology } from '../chrono/IsoChronology';
 import { Temporal } from '../temporal/Temporal';
 import { TemporalQueries } from '../temporal/TemporalQueries';
@@ -244,6 +245,7 @@ class Parsed extends Temporal {
         this.zone = null;
         this.fieldValues = new EnumMap();
         this.leapSecond = false;
+        this.excessDays = Period.ZERO;
         this.dateTimeParseContext = dateTimeParseContext;
     }
 

--- a/packages/core/test/reference/format/InstantPrinterParserTest.js
+++ b/packages/core/test/reference/format/InstantPrinterParserTest.js
@@ -6,6 +6,7 @@ import '../../_init';
 import { IllegalArgumentException } from '../../../src/errors';
 import { Instant } from '../../../src/Instant';
 import { LocalDateTime } from '../../../src/LocalDateTime';
+import { Period } from '../../../src/Period';
 import { ZoneOffset } from '../../../src/ZoneOffset';
 
 import { DateTimeFormatterBuilder } from '../../../src/format/DateTimeFormatterBuilder';
@@ -180,7 +181,7 @@ describe('tck.java.time.format.TCKInstantPrinterParser', () => {
         const expected = Instant.ofEpochSecond(instantSecs, nano);
         const f = new DateTimeFormatterBuilder().appendInstant(-1).toFormatter();
         assertEquals(f.parse(input, Instant.FROM), expected);
-        // assertEquals(f.parse(input).query(DateTimeFormatter.parsedExcessDays()), Period.ZERO);
+        assertEquals(f.parse(input).query(DateTimeFormatter.parsedExcessDays()), Period.ZERO);
         assertEquals(f.parse(input).query(DateTimeFormatter.parsedLeapSecond()), false);
     }
 
@@ -196,7 +197,7 @@ describe('tck.java.time.format.TCKInstantPrinterParser', () => {
         if (input.charAt(input.length - 11) === '.') {
             const expected = Instant.ofEpochSecond(instantSecs, nano);
             assertEquals(f.parse(input, Instant.FROM), expected);
-            // assertEquals(f.parse(input).query(DateTimeFormatter.parsedExcessDays()), Period.ZERO);
+            assertEquals(f.parse(input).query(DateTimeFormatter.parsedExcessDays()), Period.ZERO);
             assertEquals(f.parse(input).query(DateTimeFormatter.parsedLeapSecond()), false);
         } else {
             try {
@@ -213,7 +214,7 @@ describe('tck.java.time.format.TCKInstantPrinterParser', () => {
         const f = new DateTimeFormatterBuilder().appendInstant(-1).toFormatter(ResolverStyle.STRICT);
         const parsed = f.parse('1970-02-03T24:00:00Z');
         assertEquals(parsed.query(Instant.FROM), expected);
-        // assertEquals(parsed.query(DateTimeFormatter.parsedExcessDays()), Period.ZERO);
+        assertEquals(parsed.query(DateTimeFormatter.parsedExcessDays()), Period.ZERO);
         assertEquals(parsed.query(DateTimeFormatter.parsedLeapSecond()), false);
     });
 
@@ -222,7 +223,7 @@ describe('tck.java.time.format.TCKInstantPrinterParser', () => {
         const f = new DateTimeFormatterBuilder().appendInstant(-1).toFormatter(ResolverStyle.STRICT);
         const parsed = f.parse('1970-02-03T23:59:60.123456789Z');
         assertEquals(parsed.query(Instant.FROM), expected);
-        // assertEquals(parsed.query(DateTimeFormatter.parsedExcessDays()), Period.ZERO);
+        assertEquals(parsed.query(DateTimeFormatter.parsedExcessDays()), Period.ZERO);
         assertEquals(parsed.query(DateTimeFormatter.parsedLeapSecond()), true);
     });
 


### PR DESCRIPTION
`DateTimeFormatter.parsedExcessDays()` returned `undefined` after parsing an input without excess days. Following the documented pattern of querying the parse result and inspecting the `Period` then threw instead of yielding a zero period.

`java.time` initializes the parsed result's `excessDays` to `Period.ZERO`. This change does the same, so the query returns `Period.ZERO` when nothing overflowed and still returns the real excess (for example `24:00` giving `P1D`) when present. The four reference assertions that check the zero case are re-enabled.
