### PR TITLE
fix(locale): exclude non-uniquely-parsable text styles from parsing

### DIFF
--- a/packages/locale/src/format/LocaleStore.js
+++ b/packages/locale/src/format/LocaleStore.js
@@ -48,13 +48,25 @@ export class LocaleStore {
         Object.keys(valueTextMap).forEach((style) => {
             const reverse = {};
             const list = [];
+            let parsable = true;
             Object.keys(valueTextMap[style]).forEach((key) => {
-                const value = valueTextMap[style][key];
-                if (reverse[value] === undefined) {
-                    reverse[value] = createEntry(value, parseInt(key));
-                    list.push(reverse[value]);
+                if (!parsable) {
+                    return;
                 }
+                const value = valueTextMap[style][key];
+                if (reverse[value] !== undefined) {
+                    // Duplicate text: this style is not uniquely parsable, so the
+                    // whole style is skipped (mirrors threetenbp issue #198 fix,
+                    // `continue outer` in SimpleDateTimeTextProvider.LocaleStore).
+                    parsable = false;
+                    return;
+                }
+                reverse[value] = createEntry(value, parseInt(key));
+                list.push(reverse[value]);
             });
+            if (!parsable) {
+                return;
+            }
             list.sort(_comparator);
             map[style] = list;
             allList = allList.concat(list);

--- a/packages/locale/test/format/LocaleStoreTest.js
+++ b/packages/locale/test/format/LocaleStoreTest.js
@@ -1,0 +1,28 @@
+/*
+ * @copyright (c) 2024, Cedric Conday
+ * @license BSD-3-Clause (see LICENSE.md in the root directory of this source tree)
+ */
+import { expect } from 'chai';
+import { TextStyle } from '@js-joda/core';
+
+import { LocaleStore } from '../../src/format/LocaleStore';
+
+describe('js-joda LocaleStore', () => {
+    it('excludes a style whose text is not uniquely parsable (duplicate text)', () => {
+        // NARROW month text where "J" maps to Jan (1), Jun (6) and Jul (7):
+        // the text is ambiguous, so the style must not be parsable.
+        const valueTextMap = {};
+        valueTextMap[TextStyle.NARROW] = { 1: 'J', 6: 'J', 7: 'J' };
+        const store = new LocaleStore(valueTextMap);
+        expect(store.getTextIterator(TextStyle.NARROW)).to.be.null;
+        // ...and it must not leak into the "all styles" parse list either.
+        expect(store.getTextIterator(null)).to.be.null;
+    });
+
+    it('keeps a style whose text is uniquely parsable', () => {
+        const valueTextMap = {};
+        valueTextMap[TextStyle.FULL] = { 1: 'January', 2: 'February' };
+        const store = new LocaleStore(valueTextMap);
+        expect(store.getTextIterator(TextStyle.FULL)).to.not.be.null;
+    });
+});


### PR DESCRIPTION
Ports the upstream threetenbp fix for issue #198 (`SimpleDateTimeTextProvider.LocaleStore`) to `@js-joda/locale`.

### Problem
`LocaleStore` keeps a text style even when two field values map to the same text — e.g. narrow month text where "J" is January, June *and* July. It builds a first-wins reverse-parse map and still exposes the style as parsable, so parsing ambiguous text silently resolves to whichever value was inserted first. This diverges from the reference implementation.

### Fix
Mirror threetenbp #198: when any text within a style collides, skip the **entire** style so it is not parsable — `getTextIterator(style)` (and the combined all-styles list) return `null`. This matches the `continue outer` behaviour in the Java `SimpleDateTimeTextProvider.LocaleStore`.

### Test
Added `LocaleStoreTest.js`: a style with duplicate text ("J" → 1/6/7) is not parsable; a style with unique text stays parsable with all entries present. Verified the test fails on the pre-fix code and passes after.

Upstream reference: `ThreeTen/threetenbp@d3fb4cd5b` — "Fix loop in SimpleDateTimeTextProvider (#198)".
