### PR TITLE
fix(core): correct ISO_WEEK_DATE and enable ISO week/quarter parsing

### DIFF
--- a/packages/core/src/format/DateTimeBuilder.js
+++ b/packages/core/src/format/DateTimeBuilder.js
@@ -14,6 +14,7 @@ import { ResolverStyle } from './ResolverStyle';
 import { IsoChronology } from '../chrono/IsoChronology';
 import { ChronoLocalDate } from '../chrono/ChronoLocalDate';
 import { ChronoField } from '../temporal/ChronoField';
+import { IsoFields } from '../temporal/IsoFields';
 import { TemporalAccessor } from '../temporal/TemporalAccessor';
 import { TemporalQueries } from '../temporal/TemporalQueries';
 
@@ -148,11 +149,10 @@ export class DateTimeBuilder extends TemporalAccessor {
         // this._mergeInstantFields();
         this._mergeDate(resolverStyle);
         this._mergeTime(resolverStyle);
-        //if (resolveFields(resolverStyle)) {
-        //    mergeInstantFields();
-        //    mergeDate(resolverStyle);
-        //    mergeTime(resolverStyle);
-        //}
+        if (this._resolveFields(resolverStyle)) {
+            this._mergeDate(resolverStyle);
+            this._mergeTime(resolverStyle);
+        }
         this._resolveTimeInferZeroes(resolverStyle);
         //this._crossCheck();
         if (this.excessDays != null && this.excessDays.isZero() === false && this.date != null && this.time != null) {
@@ -162,6 +162,30 @@ export class DateTimeBuilder extends TemporalAccessor {
         //resolveFractional();
         this._resolveInstant();
         return this;
+    }
+
+    /**
+     * Resolves the date fields that are not {@link ChronoField}s by delegating to their own
+     * `resolve()`, the step java.time performs generically. As parsed values are held in a
+     * name-keyed map, the ISO fields that define a `resolve()` (week-of-week-based-year and
+     * day-of-quarter) are handled here. Returns whether a date was produced.
+     *
+     * @param {ResolverStyle} resolverStyle
+     * @return {boolean}
+     * @private
+     */
+    _resolveFields(resolverStyle) {
+        let resolved = false;
+        for (const field of [IsoFields.WEEK_OF_WEEK_BASED_YEAR, IsoFields.DAY_OF_QUARTER]) {
+            if (this.fieldValues.containsKey(field)) {
+                const date = field.resolve(this.fieldValues, this, resolverStyle);
+                if (date != null) {
+                    this._checkDate(date);
+                    resolved = true;
+                }
+            }
+        }
+        return resolved;
     }
 
     /**

--- a/packages/core/src/format/DateTimeFormatter.js
+++ b/packages/core/src/format/DateTimeFormatter.js
@@ -21,6 +21,7 @@ import { ResolverStyle } from './ResolverStyle';
 
 import { IsoChronology } from '../chrono/IsoChronology';
 import { ChronoField } from '../temporal/ChronoField';
+import { IsoFields } from '../temporal/IsoFields';
 import { createTemporalQuery } from '../temporal/TemporalQuery';
 
 /**
@@ -696,12 +697,13 @@ export function _init() {
         .toFormatter(ResolverStyle.STRICT);
 
     DateTimeFormatter.ISO_WEEK_DATE = new DateTimeFormatterBuilder()
-        .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+        .parseCaseInsensitive()
+        .appendValue(IsoFields.WEEK_BASED_YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
         .appendLiteral('-W')
-        .appendValue(ChronoField.ALIGNED_WEEK_OF_YEAR)
+        .appendValue(IsoFields.WEEK_OF_WEEK_BASED_YEAR, 2)
         .appendLiteral('-')
-        .appendValue(ChronoField.DAY_OF_WEEK)
-        .toFormatter(ResolverStyle.STRICT);
+        .appendValue(ChronoField.DAY_OF_WEEK, 1)
+        .toFormatter(ResolverStyle.STRICT).withChronology(IsoChronology.INSTANCE);
 
     DateTimeFormatter.ISO_DATE = new DateTimeFormatterBuilder()
         .parseCaseInsensitive()

--- a/packages/core/test/format/DateTimeFormatterTest.js
+++ b/packages/core/test/format/DateTimeFormatterTest.js
@@ -80,6 +80,26 @@ describe('js-joda DateTimeFormatterTest', () => {
             checkFormat(DateTimeFormatter.ISO_WEEK_DATE, '2018-W17-6');
         });
 
+        it('should parse and format ISO_WEEK_DATE against ISO-8601 week dates', () => {
+            const f = DateTimeFormatter.ISO_WEEK_DATE;
+            // week 1 belongs to the week-based year and can start in the previous calendar year
+            const cases = [
+                ['2014-W01-1', '2013-12-30'],
+                ['2015-W01-1', '2014-12-29'],
+                ['2010-W01-5', '2010-01-08'],
+                ['2020-W01-2', '2019-12-31'],
+                ['2009-W01-1', '2008-12-29'],
+                ['2015-W53-7', '2016-01-03'],  // 53-week year
+                ['2020-W53-4', '2020-12-31'],  // 53-week year
+                ['2004-W53-6', '2005-01-01'],  // 53-week year
+                ['2018-W17-6', '2018-04-28'],
+            ];
+            for (const [week, iso] of cases) {
+                expect(LocalDate.parse(week, f).toString()).to.eql(iso);
+                expect(LocalDate.parse(iso).format(f)).to.eql(week);
+            }
+        });
+
         it('should properly use ISO_INSTANT format', () => {
             checkFormat(DateTimeFormatter.ISO_INSTANT, '2018-04-28T10:34:00Z');
         });

--- a/packages/core/test/reference/temporal/IsoFieldsTest.js
+++ b/packages/core/test/reference/temporal/IsoFieldsTest.js
@@ -13,6 +13,7 @@ import { ValueRange } from '../../../src/temporal/ValueRange';
 
 import { ChronoField } from '../../../src/temporal/ChronoField';
 import { IsoFields } from '../../../src/temporal/IsoFields';
+import { DateTimeFormatterBuilder } from '../../../src/format/DateTimeFormatterBuilder';
 
 describe('org.threeten.bp.temporal.TestIsoFields', ()=>{
 
@@ -95,7 +96,6 @@ describe('org.threeten.bp.temporal.TestIsoFields', ()=>{
 
     });
 
-    /* TODO weekday parser
     describe('parse weeks', () => {
 
         // @Test(dataProvider='week')
@@ -105,13 +105,12 @@ describe('org.threeten.bp.temporal.TestIsoFields', ()=>{
                     .appendValue(IsoFields.WEEK_BASED_YEAR).appendLiteral('-')
                     .appendValue(IsoFields.WEEK_OF_WEEK_BASED_YEAR).appendLiteral('-')
                     .appendValue(ChronoField.DAY_OF_WEEK).toFormatter();
-                const parsed = LocalDate.parse(wby + '-' + week + '-' + dow.value(), f);
+                const parsed = LocalDate.parse(`${wby}-${week}-${dow.value()}`, f);
                 assertEquals(parsed, date);
             });
         });
 
     });
-*/
 
     const yearsToLoop = isCoverageTestRunner() || isBrowserTestRunner() ? 2 : 23; // should be at least 400
     it('test_loop', function () {
@@ -240,6 +239,17 @@ describe('org.threeten.bp.temporal.TestIsoFields', ()=>{
                         .with(IsoFields.QUARTER_OF_YEAR, q)
                         .with(IsoFields.DAY_OF_QUARTER, doq),
                     date);
+            });
+        });
+
+        it('test_parse_quarters', function () {
+            dataProviderTest(data_quarter, (date, doq, q) => {
+                const f = new DateTimeFormatterBuilder()
+                    .appendValue(ChronoField.YEAR).appendLiteral('-')
+                    .appendValue(IsoFields.QUARTER_OF_YEAR).appendLiteral('-')
+                    .appendValue(IsoFields.DAY_OF_QUARTER).toFormatter();
+                const parsed = LocalDate.parse(`${date.year()}-${q}-${doq}`, f);
+                assertEquals(parsed, date);
             });
         });
 


### PR DESCRIPTION
`DateTimeFormatter.ISO_WEEK_DATE` returns the wrong date in both directions for most years, silently. It is built on `ChronoField.YEAR` + `ALIGNED_WEEK_OF_YEAR` (a week counter that resets on Jan 1) instead of the ISO week fields, so any year whose Jan 1 is not a Monday is off by a week.

```js
LocalDate.parse('2014-W01-1', DateTimeFormatter.ISO_WEEK_DATE).toString();
// '2014-01-06', should be '2013-12-30'
LocalDate.of(2013, 12, 30).format(DateTimeFormatter.ISO_WEEK_DATE);
// '2013-W52-1', should be '2014-W01-1'
```

Both `java.time` (the reference API) and Python's `date.fromisocalendar` give `2013-12-30` / `2014-W01-1`. The lone existing `ISO_WEEK_DATE` test used `2018-W17-6`, and 2018 is one of the rare years where Jan 1 is a Monday, so the aligned-week counter coincides with the ISO week and the bug stayed hidden.

The underlying cause is that `DateTimeBuilder.resolve()` never ran the per-field resolve step, so `IsoFields.WEEK_OF_WEEK_BASED_YEAR.resolve()` and `IsoFields.DAY_OF_QUARTER.resolve()` were never called during parsing. The correct ISO week fields could not be parsed at all, which is why the formatter fell back to the wrong-but-parseable `ChronoField.YEAR` + `ALIGNED_WEEK_OF_YEAR`.

This invokes those fields' `resolve()` from `DateTimeBuilder.resolve()` and defines `ISO_WEEK_DATE` with `WEEK_BASED_YEAR` + `WEEK_OF_WEEK_BASED_YEAR`, matching the java.time definition. As a side effect, quarter dates now parse too: a `YEAR` + `QUARTER_OF_YEAR` + `DAY_OF_QUARTER` formatter previously threw `DateTimeParseException` and now round-trips.

Note on scope: js-joda keeps parsed values in an `EnumMap` keyed by field name, so java.time's generic resolve loop over field objects isn't directly portable without reworking that map. Instead the two ISO fields that define a `resolve()` are handled explicitly, which covers the whole ISO week/quarter class in core. Locale `WeekFields` parsing has the same underlying limitation and could be addressed separately.

Tests: the previously disabled `TestIsoFields` week-parse test (`/* TODO weekday parser`) is restored, and week/quarter parse+format+round-trip coverage is added for non-Monday-Jan-1 years, single-digit weeks, and 53-week years. The full `@js-joda/core` suite passes (2595) as does `@js-joda/extra` (719).
